### PR TITLE
Removing extraneous generic parameter from Server

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -6,7 +6,7 @@ import zhttp.http._
 import zhttp.service.server.{ServerChannelFactory, ServerChannelInitializer, ServerRequestHandler}
 import zio._
 
-final class Server[R](serverBootstrap: JServerBootstrap, init: JChannelInitializer[JChannel]) { self =>
+final class Server(serverBootstrap: JServerBootstrap, init: JChannelInitializer[JChannel]) { self =>
 
   /**
    * Starts the server on the provided port
@@ -16,7 +16,7 @@ final class Server[R](serverBootstrap: JServerBootstrap, init: JChannelInitializ
 }
 
 object Server {
-  def make[R, E: SilentResponse](http: HttpApp[R, E]): ZIO[R with EventLoopGroup, Throwable, Server[R]] =
+  def make[R, E: SilentResponse](http: HttpApp[R, E]): ZIO[R with EventLoopGroup, Throwable, Server] =
     for {
       zExec          <- UnsafeChannelExecutor.make[R]
       channelFactory <- ServerChannelFactory.Live.auto


### PR DESCRIPTION
[Server](https://github.com/dream11/zio-http/blob/main/zio-http/src/main/scala/zhttp/service/Server.scala#L9) is parameterized with a generic `R`. There is no use of generic `R` within the `Server`. 

As per our [conversation](https://discord.com/channels/629491597070827530/819703129267372113/821949004317065228) on discord, raising this PR to clean up. 