### PR TITLE
added content-length header for nonempty content

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
@@ -69,6 +69,12 @@ trait HttpMessageCodec {
       case Some(text) => JUnpooled.copiedBuffer(text, HTTP_CHARSET)
       case None       => JUnpooled.EMPTY_BUFFER
     }
+    val writerIndex = content.writerIndex()
+    val headers =
+      if (writerIndex == 0)
+        Header.disassemble(req.headers)
+      else
+        Header.disassemble(Header(JHttpHeaderNames.CONTENT_LENGTH, writerIndex.toString()) :: req.headers)
     val headers = Header.disassemble(req.headers)
     val jReq    = new JDefaultFullHttpRequest(jVersion, method, uri, content)
     jReq.headers().set(headers)

--- a/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
@@ -69,13 +69,11 @@ trait HttpMessageCodec {
       case Some(text) => JUnpooled.copiedBuffer(text, HTTP_CHARSET)
       case None       => JUnpooled.EMPTY_BUFFER
     }
-    val writerIndex = content.writerIndex()
-    val headers =
-      if (writerIndex == 0)
-        Header.disassemble(req.headers)
-      else
-        Header.disassemble(Header(JHttpHeaderNames.CONTENT_LENGTH, writerIndex.toString()) :: req.headers)
     val headers = Header.disassemble(req.headers)
+    val writerIndex = content.writerIndex()
+    if(writerIndex!=0){
+      headers.set(JHttpHeaderNames.CONTENT_LENGTH, writerIndex.toString())
+    }
     val jReq    = new JDefaultFullHttpRequest(jVersion, method, uri, content)
     jReq.headers().set(headers)
 

--- a/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpMessageCodec.scala
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter
 import scala.util.Try
 
 trait HttpMessageCodec {
-  private val jTrailingHeaders    = new JDefaultHttpHeaders(false)
+  private val jTrailingHeaders = new JDefaultHttpHeaders(false)
   private val SERVER_NAME: String = "ZIO-Http"
 
   /**
@@ -18,17 +18,17 @@ trait HttpMessageCodec {
    */
   def decodeJRequest(jReq: JFullHttpRequest): Either[Throwable, Request] = for {
     url <- URL.fromString(jReq.uri())
-    method   = Method.fromJHttpMethod(jReq.method())
-    headers  = Header.make(jReq.headers())
+    method = Method.fromJHttpMethod(jReq.method())
+    headers = Header.make(jReq.headers())
     endpoint = method -> url
-    data     = Request.Data(headers, HttpContent.Complete(jReq.content().toString(HTTP_CHARSET)))
+    data = Request.Data(headers, HttpContent.Complete(jReq.content().toString(HTTP_CHARSET)))
   } yield Request(endpoint, data)
 
   /**
    * Tries to decode netty request into ZIO Http Request
    */
   def decodeJResponse(jRes: JFullHttpResponse): Either[Throwable, UHttpResponse] = Try {
-    val status  = Status.fromJHttpResponseStatus(jRes.status())
+    val status = Status.fromJHttpResponseStatus(jRes.status())
     val headers = Header.parse(jRes.headers())
     val content = HttpContent.Complete(jRes.content().toString(HTTP_CHARSET))
 
@@ -39,11 +39,11 @@ trait HttpMessageCodec {
    * Encode the [[zhttp.http.UHttpResponse]] to [io.netty.handler.codec.http.FullHttpResponse]
    */
   def encodeResponse[R](jVersion: JHttpVersion, res: Response.HttpResponse[R]): JFullHttpResponse = {
-    val jHttpHeaders   =
+    val jHttpHeaders =
       res.headers.foldLeft[JHttpHeaders](new JDefaultHttpHeaders()) { (jh, hh) =>
         jh.set(hh.name, hh.value)
       }
-    val jStatus        = res.status.toJHttpStatus
+    val jStatus = res.status.toJHttpStatus
     val jContentBytBuf = res.content match {
       case HttpContent.Complete(data) =>
         jHttpHeaders.set(JHttpHeaderNames.CONTENT_LENGTH, data.length())
@@ -63,18 +63,18 @@ trait HttpMessageCodec {
    * Converts Request to JFullHttpRequest
    */
   def encodeRequest(jVersion: JHttpVersion, req: Request): JFullHttpRequest = {
-    val method  = req.method.asJHttpMethod
-    val uri     = req.url.asString
+    val method = req.method.asJHttpMethod
+    val uri = req.url.asString
     val content = req.getBodyAsString match {
       case Some(text) => JUnpooled.copiedBuffer(text, HTTP_CHARSET)
-      case None       => JUnpooled.EMPTY_BUFFER
+      case None => JUnpooled.EMPTY_BUFFER
     }
     val headers = Header.disassemble(req.headers)
     val writerIndex = content.writerIndex()
-    if(writerIndex!=0){
+    if (writerIndex != 0) {
       headers.set(JHttpHeaderNames.CONTENT_LENGTH, writerIndex.toString())
     }
-    val jReq    = new JDefaultFullHttpRequest(jVersion, method, uri, content)
+    val jReq = new JDefaultFullHttpRequest(jVersion, method, uri, content)
     jReq.headers().set(headers)
 
     jReq

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -1,9 +1,8 @@
 package zhttp.service
 
-import zhttp.http.{Http, Response}
+import zhttp.http._
 import zhttp.service.server.ServerChannelFactory
 import zio.{Ref, UIO, ZIO, ZRef}
-import zhttp.http._
 import zio.test.Assertion.{isNone, isPositive, isSome}
 import zio.test.TestAspect.ignore
 import zio.test.assertM

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -64,9 +64,9 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
           testM("post request with nonempty content and set content-length") {
             val path    = "postWithNonemptyContentAndSetContentLength"
             val content = "content"
-            val headers = List(Header(contentLengthName, "dummy"))
+            val headers = List(Header.custom(contentLengthName, "dummy"))
             val actual  = request(Root / path, Method.POST, content, headers) *> getLengthForPath(state, path)
-            assertM(actual)(isSome(isPositive))
+            assertM(actual)(isSome(isPositive[Int]))
           },
         ),
       )

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -1,12 +1,11 @@
 package zhttp.service
 
-import zhttp.http.{Http, Response}
+import zhttp.http.{Http, Response, _}
 import zhttp.service.server.ServerChannelFactory
-import zio.{Has, Ref, UIO, ZIO, ZManaged, ZRef}
-import zhttp.http._
 import zio.test.Assertion.{isNone, isPositive, isSome}
 import zio.test.TestAspect.ignore
 import zio.test.assertM
+import zio.{Ref, UIO, ZIO, ZRef}
 
 import scala.util.Try
 

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -1,0 +1,76 @@
+package zhttp.service
+
+import zhttp.http.{Http, Response}
+import zhttp.service.server.ServerChannelFactory
+import zio.{Has, Ref, UIO, ZIO, ZManaged, ZRef}
+import zhttp.http._
+import zio.test.Assertion.{isNone, isPositive, isSome}
+import zio.test.TestAspect.ignore
+import zio.test.assertM
+
+import scala.util.Try
+
+object ClientContentLengthSpec extends HttpRunnableSpec {
+
+  type ServerState = Map[String, Int]
+
+  val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
+
+  val contentLengthName = "content-length"
+
+  def getContentLength(headers: List[Header]): Option[Int] =
+    headers
+      .find(_.name.toString.toLowerCase == "content-length")
+      .flatMap(d => tryParseInt(d.value.toString))
+
+  def tryParseInt(s: String): Option[Int] = Try(s.toInt).toOption
+
+  def updateState(state: ServerState, headers: List[Header], path: String): ServerState =
+    getContentLength(headers) match {
+      case Some(length) if !state.contains(path) => state.updated(path, length)
+      case _                                     => state
+    }
+
+  def getApp(state: Ref[ServerState]) = serve {
+    Http.collectM { case Request((_, URL(Root / path, _, _)), Request.Data(headers, _)) =>
+      state.update(updateState(_, headers, path)) *> ZIO.succeed(Response.ok)
+    }
+  }
+
+  def getLengthForPath(state: Ref[ServerState], path: String): UIO[Option[Int]] = {
+    state.get.map(_.get(path))
+  }
+
+  val serverAppState =
+    for {
+      state <- ZRef.make(Map[String, Int]()).toManaged_
+      _     <- getApp(state)
+    } yield state
+
+  override def spec = suiteM("Client Content-Length auto assign")(
+    serverAppState
+      .map((state: Ref[ServerState]) =>
+        List(
+          testM("get request without content") {
+            val path   = "getWithoutContent"
+            val actual = status(Root / path) *> getLengthForPath(state, path)
+            assertM(actual)(isNone)
+          } @@ ignore,
+          testM("post request with nonempty content") {
+            val path    = "postWithNonemptyContent"
+            val content = "content"
+            val actual  = request(Root / path, Method.POST, content) *> getLengthForPath(state, path)
+            assertM(actual)(isSome(isPositive))
+          },
+          testM("post request with nonempty content and set content-length") {
+            val path    = "postWithNonemptyContentAndSetContentLength"
+            val content = "content"
+            val headers = List(Header(contentLengthName, "dummy"))
+            val actual  = request(Root / path, Method.POST, content, headers) *> getLengthForPath(state, path)
+            assertM(actual)(isSome(isPositive))
+          },
+        ),
+      )
+      .useNow,
+  ).provideCustomLayer(env)
+}

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -2,10 +2,10 @@ package zhttp.service
 
 import zhttp.http._
 import zhttp.service.server.ServerChannelFactory
-import zio.{Ref, UIO, ZIO, ZRef}
 import zio.test.Assertion.{isNone, isPositive, isSome}
 import zio.test.TestAspect.ignore
 import zio.test.assertM
+import zio.{Ref, UIO, ZIO, ZRef}
 
 import scala.util.Try
 

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -59,7 +59,7 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
             val path    = "postWithNonemptyContent"
             val content = "content"
             val actual  = request(Root / path, Method.POST, content) *> getLengthForPath(state, path)
-            assertM(actual)(isSome(isPositive))
+            assertM(actual)(isSome(isPositive[Int]))
           },
           testM("post request with nonempty content and set content-length") {
             val path    = "postWithNonemptyContentAndSetContentLength"

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -9,7 +9,7 @@ import zio.{Ref, UIO, ZIO, ZRef}
 
 import scala.util.Try
 
-object ClientContentLengthSpec extends HttpRunnableSpec {
+object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
 
   type ServerState = Map[String, Int]
 

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -1,11 +1,12 @@
 package zhttp.service
 
-import zhttp.http.{Http, Response, _}
+import zhttp.http.{Http, Response}
 import zhttp.service.server.ServerChannelFactory
+import zio.{Ref, UIO, ZIO, ZRef}
+import zhttp.http._
 import zio.test.Assertion.{isNone, isPositive, isSome}
 import zio.test.TestAspect.ignore
 import zio.test.assertM
-import zio.{Ref, UIO, ZIO, ZRef}
 
 import scala.util.Try
 

--- a/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
@@ -3,7 +3,7 @@ package zhttp.service
 import zio.test.Assertion.anything
 import zio.test.assertM
 
-object ClientSpec extends HttpRunnableSpec {
+object ClientSpec extends HttpRunnableSpec(8082) {
   val env           = ChannelFactory.auto ++ EventLoopGroup.auto()
   override def spec = suite("Client")(
     testM("respond Ok") {

--- a/zio-http/src/test/scala/zhttp/service/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/HttpRunnableSpec.scala
@@ -6,9 +6,7 @@ import zhttp.http._
 import zio.test.DefaultRunnableSpec
 import zio.{Has, ZIO, ZManaged}
 
-trait HttpRunnableSpec extends DefaultRunnableSpec {
-
-  val port = 8081
+abstract class HttpRunnableSpec(port: Int) extends DefaultRunnableSpec {
 
   def serve[R <: Has[_], E: SilentResponse](
     app: Http[R, E],

--- a/zio-http/src/test/scala/zhttp/service/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/HttpRunnableSpec.scala
@@ -1,19 +1,33 @@
 package zhttp.service
 
+import zhttp.http.HttpContent.Complete
 import zhttp.http.URL.Location
 import zhttp.http._
 import zio.test.DefaultRunnableSpec
 import zio.{Has, ZIO, ZManaged}
 
 trait HttpRunnableSpec extends DefaultRunnableSpec {
+
+  val port = 8081
+
   def serve[R <: Has[_], E: SilentResponse](
     app: Http[R, E],
   ): ZManaged[R with EventLoopGroup with ServerChannelFactory, Nothing, Unit] =
-    Server.make(Server.app(app) ++ Server.port(8081)).orDie
+    Server.make(Server.app(app) ++ Server.port(port)).orDie
 
   def status(path: Path): ZIO[EventLoopGroup with ChannelFactory, Throwable, Status] =
     requestPath(path).map(_.status)
 
   def requestPath(path: Path): ZIO[EventLoopGroup with ChannelFactory, Throwable, UHttpResponse] =
-    Client.request(Method.GET -> URL(path, Location.Absolute(Scheme.HTTP, "localhost", 8081)))
+    Client.request(Method.GET -> URL(path, Location.Absolute(Scheme.HTTP, "localhost", port)))
+
+  def request(
+    path: Path,
+    method: Method,
+    content: String,
+    headers: List[Header] = Nil,
+  ): ZIO[EventLoopGroup with ChannelFactory, Throwable, UHttpResponse] = {
+    val data = Request.Data(headers, Complete[String](content))
+    Client.request(Request(method -> URL(path, Location.Absolute(Scheme.HTTP, "localhost", port)), data))
+  }
 }

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -6,7 +6,7 @@ import zio.ZIO
 import zio.test.Assertion.equalTo
 import zio.test.assertM
 
-object ServerSpec extends HttpRunnableSpec {
+object ServerSpec extends HttpRunnableSpec(8081) {
   val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
 
   val app = serve {


### PR DESCRIPTION
For [issue](https://github.com/dream11/zio-http/issues/86) is only one question: Should we handle situation when `req.headers` already contains content-length header?