### PR TITLE
uses abs_path in http-client

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
@@ -3,7 +3,7 @@ package zhttp.service
 import io.netty.buffer.{Unpooled => JUnpooled}
 import io.netty.handler.codec.http.{HttpHeaderNames => JHttpHeaderNames, HttpVersion => JHttpVersion}
 import zhttp.core.{JDefaultFullHttpRequest, JFullHttpRequest}
-import zhttp.http.{HTTP_CHARSET, Header, Request}
+import zhttp.http.{HTTP_CHARSET, Header, Request, Root}
 trait EncodeRequest {
 
   /**
@@ -11,7 +11,10 @@ trait EncodeRequest {
    */
   def encodeRequest(jVersion: JHttpVersion, req: Request): JFullHttpRequest = {
     val method      = req.method.asJHttpMethod
-    val uri         = req.url.asString
+    val uri         = req.url.path match {
+      case Root => "/"
+      case path => path.asString
+    }
     val content     = req.getBodyAsString match {
       case Some(text) => JUnpooled.copiedBuffer(text, HTTP_CHARSET)
       case None       => JUnpooled.EMPTY_BUFFER

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -1,0 +1,21 @@
+package zhttp.http
+
+import io.netty.handler.codec.http.HttpVersion
+import zhttp.http.URL.Location
+import zhttp.service.EncodeRequest
+import zio.test.Assertion._
+import zio.test.{DefaultRunnableSpec, assert}
+
+object EncodeRequestSpec extends DefaultRunnableSpec with EncodeRequest {
+
+  val request: Request = Request(Method.GET -> URL(Path("/"), Location.Absolute(Scheme.HTTP, "localhost", 8000)))
+
+  def spec = suite("EncodeRequest")(
+    suite("encodeRequest")(
+      test("should encode properly the request") {
+        val encoded = encodeRequest(jVersion = HttpVersion.HTTP_1_1, req = request)
+        assert(encoded.uri())(equalTo("/"))
+      },
+    ),
+  )
+}


### PR DESCRIPTION
Proposal for https://github.com/dream11/zio-http/issues/237.

According to RFC there’s a dependency between abs_path/absoluteURI behavior and use of proxy. 
Should take that into account when providing https://github.com/dream11/zio-http/issues/101

My first contribution proposal, feel free to comment. It’s just my code, not myself :)