### PR TITLE
#2541 Fix bug where the OpenAPI generator fails to generate multiple methods for the same path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ZIO HTTP is a scala library for building http apps. It is powered by ZIO and [Ne
 Setup via `build.sbt`:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC3"
+libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC4"
 ```
 
 **NOTES ON VERSIONING:**

--- a/zio-http/src/test/resources/endpoint/openapi/multiple-methods-on-same-path.json
+++ b/zio-http/src/test/resources/endpoint/openapi/multiple-methods-on-same-path.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Multiple Methods on Same Path",
+    "version": "1.0"
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "null"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
This is an attempt to fix #2541.   
Please make any suggestions regarding unidiomatic or ugly code, or anything I may have overlooked.