### PR TITLE
Enable Live Reload Docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -305,6 +305,7 @@ lazy val docs = project
   .in(file("zio-http-docs"))
   .settings(stdSettings("zio-http-docs"))
   .settings(
+    fork := false,
     moduleName                                 := "zio-http-docs",
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",


### PR DESCRIPTION
This change enables the `sbt docs/previewWebsite` to work properly on live reload mode.