### PR TITLE
Added support for specifying multiple media types for a single codec

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/ContentCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/ContentCodecs.scala
@@ -30,8 +30,14 @@ private[codec] trait ContentCodecs {
   def content[A](name: String, mediaType: MediaType)(implicit codec: HttpContentCodec[A]): ContentCodec[A] =
     HttpCodec.Content(codec.only(mediaType), Some(name))
 
+  def content[A](name: String, mediaTypes: List[MediaType])(implicit codec: HttpContentCodec[A]): ContentCodec[A] =
+    HttpCodec.Content(codec.many(mediaTypes), Some(name))
+
   def content[A](mediaType: MediaType)(implicit codec: HttpContentCodec[A]): ContentCodec[A] =
     HttpCodec.Content(codec.only(mediaType), None)
+
+  def content[A](mediaTypes: List[MediaType])(implicit codec: HttpContentCodec[A]): ContentCodec[A] =
+    HttpCodec.Content(codec.many(mediaTypes), None)
 
   def contentStream[A](name: String)(implicit codec: HttpContentCodec[A]): ContentCodec[ZStream[Any, Nothing, A]] =
     HttpCodec.ContentStream(codec, Some(name))

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
@@ -81,6 +81,17 @@ sealed trait HttpContentCodec[A] { self =>
       HttpContentCodec.Filtered(self, mediaType)
     }
 
+  def many(mediaTypes: List[MediaType]): HttpContentCodec[A] = {
+    val filteredCodecs: List[HttpContentCodec[A]] = mediaTypes.map { mediaType =>
+      if (lookup(mediaType).isEmpty)
+        throw new IllegalArgumentException(s"MediaType $mediaType is not supported by $self")
+      else
+        HttpContentCodec.Filtered(self, mediaType)
+    }
+
+    filteredCodecs.reduceLeft(_ ++ _)
+  }
+
   def only(mediaType: Option[MediaType]): HttpContentCodec[A] =
     mediaType match {
       case Some(value) => only(value)


### PR DESCRIPTION
/claim #3284


```scala
// Before – this doesn't work correctly:
val mediaTypeJsonOrTextEndpoint = Endpoint(RoutePattern.POST / "api" / "mediaTypeJsonOrText")
  .outCodec(HttpCodec.content[Greeting](MediaType.text.plain))
  .outCodec(HttpCodec.content[Greeting](MediaType.application.json))
```

This approach fails because both codecs are defined for the same type (`Greeting`). The fallback mechanism isn't smart enough to distinguish based on media type and will always select the first codec, even if the client expects a different content type.

### My Solution Is:

```scala
// Added support for multiple media types:
val mediaTypeJsonOrTextEndpoint = Endpoint(RoutePattern.POST / "api" / "mediaTypeJsonOrText")
  .outCodec(HttpCodec.content[Greeting](List(MediaType.text.plain, MediaType.application.json)))
```

To resolve this, I added support for specifying **multiple media types** for a **single codec**. Now the codec can respond with either plain text or JSON, depending on the `Accept` header, without relying on fallback behavior.


