### PR TITLE
feat: Add relative and absolute URL generation to Endpoint

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Invocation.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Invocation.scala
@@ -17,6 +17,7 @@
 package zio.http.endpoint
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.http.{Request, URL}
 
 /**
  * An invocation represents a single invocation of an endpoint through provision
@@ -28,4 +29,17 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 final case class Invocation[P, I, E, O, A <: AuthType](
   endpoint: Endpoint[P, I, E, O, A],
   input: I,
-)
+) {
+  /**
+  * Creates a relative URL for this invocation.
+  */
+  def toURL: Either[String, URL] =
+    endpoint.toURL(input)
+
+  /**
+   * Creates an absolute URL for this invocation, deriving the scheme and
+   * authority from the provided Request.
+   */
+  def toAbsoluteURL(request: Request): Either[String, URL] =
+    endpoint.toAbsoluteURL(input)(request)
+}


### PR DESCRIPTION
/claim #3643, This PR adds the ability to generate both relative and absolute URLs from `Endpoint` and `Invocation` instances.
- Added `toURL` and `toAbsoluteURL` methods to the `Endpoint` class. These methods use the endpoint's input `HttpCodec` to generate a request and extract the URL, ensuring that path and query parameters are correctly formatted.
- Added corresponding `toURL` and `toAbsoluteURL` convenience methods to the `Invocation` class.
- Added a new test suite to `EndpointSpec.scala` to verify the functionality of the new URL generation methods.

All new and existing tests are passing.
<img width="723" height="198" alt="Tests Passed" src="https://github.com/user-attachments/assets/ba59db81-bb66-459c-a4fd-a6274ec0d717" />
