### PR TITLE
Add `fileName` to OpenAPI.Info

### DIFF
--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -1058,6 +1058,7 @@ object CodeGenSpec extends ZIOSpecDefault {
               termsOfService = None,
               contact = None,
               license = None,
+              fileName = None,
               version = "1.0.0",
             ),
             paths = ListMap(
@@ -1125,6 +1126,7 @@ object CodeGenSpec extends ZIOSpecDefault {
               termsOfService = None,
               contact = None,
               license = None,
+              fileName = None,
               version = "1.0.0",
             ),
             paths = ListMap(

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
@@ -195,6 +195,7 @@ object OpenAPI {
       termsOfService = None,
       contact = None,
       license = None,
+      fileName = None,
       version = "",
     ),
     servers = List.empty,
@@ -331,6 +332,8 @@ object OpenAPI {
    *   The contact information for the exposed API.
    * @param license
    *   The license information for the exposed API.
+   * @param fileName
+   *   The file name of the OpenAPI document.
    * @param version
    *   The version of the OpenAPI document (which is distinct from the OpenAPI
    *   Specification version or the API implementation version).
@@ -341,6 +344,7 @@ object OpenAPI {
     termsOfService: Option[URI],
     contact: Option[Contact],
     license: Option[License],
+    fileName: Option[String],
     version: String,
   )
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -1021,6 +1021,7 @@ object OpenAPIGen {
         termsOfService = None,
         contact = None,
         license = None,
+        fileName = None,
         version = "",
       ),
       servers = Nil,

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/SwaggerUI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/SwaggerUI.scala
@@ -56,8 +56,9 @@ object SwaggerUI {
     import zio.http.template._
     val basePath   = Method.GET / path
     val jsonRoutes = (api +: apis).map { api =>
-      basePath / s"${URLEncoder.encode(api.info.title, Charsets.Utf8.name())}.json" -> handler { (_: Request) =>
-        Response.json(api.toJson)
+      basePath / s"${URLEncoder.encode(api.info.fileName.getOrElse(api.info.title), Charsets.Utf8.name())}.json" -> handler {
+        (_: Request) =>
+          Response.json(api.toJson)
       }
     }
     val jsonPaths  = jsonRoutes.map(_.routePattern.pathCodec.render)


### PR DESCRIPTION
Adding a separate `fileName` field to `OpenAPI.Info` to specify the JSON file name; if it is not provided, the `OpenAPI.Info.title` can be used instead.