### PR TITLE
Added ZClient.requiringConfig, which has consistent types across platforms

### DIFF
--- a/zio-http/js/src/main/scala/zio/http/ZClientPlatformSpecific.scala
+++ b/zio-http/js/src/main/scala/zio/http/ZClientPlatformSpecific.scala
@@ -7,6 +7,9 @@ import zio.http.internal.FetchDriver
 
 trait ZClientPlatformSpecific {
 
+  def requiringConfig: ZLayer[ZClient.Config, Throwable, Client] =
+    live
+
   def customized: ZLayer[Config with ZClient.Driver[Any, Scope, Throwable], Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.scoped {
@@ -35,7 +38,7 @@ trait ZClientPlatformSpecific {
 
   def default: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
-    ZLayer.succeed(Config.default) >>> live
+    ZLayer.succeed(Config.default) >>> requiringConfig
   }
 
 }

--- a/zio-http/jvm/src/main/scala/zio/http/ZClientPlatformSpecific.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/ZClientPlatformSpecific.scala
@@ -8,6 +8,11 @@ import zio.http.netty.client.NettyClientDriver
 
 trait ZClientPlatformSpecific {
 
+  def requiringConfig: ZLayer[ZClient.Config, Throwable, Client] = {
+    implicit val trace: Trace = Trace.empty
+    (ZLayer.succeed(NettyConfig.defaultWithFastShutdown) ++ DnsResolver.default) >>> live
+  }
+
   def customized: ZLayer[Config with ClientDriver with DnsResolver, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.scoped {
@@ -41,8 +46,7 @@ trait ZClientPlatformSpecific {
 
   def default: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
-    (ZLayer.succeed(Config.default) ++ ZLayer.succeed(NettyConfig.defaultWithFastShutdown) ++
-      DnsResolver.default) >>> live
+    ZLayer.succeed(Config.default) >>> requiringConfig
   }
 
 }


### PR DESCRIPTION
The way `ZClientPlatformSpecific` defines its layers, with layers of the same names but different types on different platforms, is a bit unfortunate for a consuming library which is also cross platform, and does not want to deal with platform-specific things within zio-http.

The only layer which has a consistent signature is `default`.

There is no consistent layer across platforms which has the signature `ZLayer[ZClient.Config, Throwable, Client]`. This MR adds such a layer builder.