### PR TITLE
feat(datastar): Endpoint → Datastar action strings

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarAction.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarAction.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.datastar
+
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint.openapi.OpenAPIGen
+import zio.http.endpoint.openapi.OpenAPIGen.{AtomizedMetaCodecs, MetaCodec}
+import zio.http.endpoint.{AuthType, Endpoint}
+
+/**
+ * Converts ZIO HTTP Endpoints to Datastar action expressions for use in
+ * `data-on-*` attributes. Generates strings like `@get('/users/\$id')` from
+ * typed endpoints. Path parameters become `$param` placeholders; GET requests
+ * include query parameter placeholders. Headers and request bodies are not
+ * rendered (Datastar handles these automatically).
+ */
+object DatastarAction {
+
+  sealed trait Action extends Product with Serializable {
+    def method: Method
+    def url: String
+    def render: String = {
+      val verb = method match {
+        case Method.GET    => "get"
+        case Method.POST   => "post"
+        case Method.PUT    => "put"
+        case Method.PATCH  => "patch"
+        case Method.DELETE => "delete"
+        case other         => other.render.toLowerCase
+      }
+      s"@${verb}('${url}')"
+    }
+  }
+
+  final case class SimpleAction(method: Method, url: String) extends Action
+
+  def fromEndpoint[PathInput, Input, Err, Output, Auth <: AuthType](
+    ep: Endpoint[PathInput, Input, Err, Output, Auth],
+  ): Action = {
+    val atomizedInput = AtomizedMetaCodecs.flatten(ep.input)
+    val method        = extractMethod(ep, atomizedInput)
+    val pathStr       = renderPath(ep.route.pathCodec)
+    val fullUrl       =
+      if (method == Method.GET) appendQuery(atomizedInput, pathStr)
+      else pathStr
+
+    SimpleAction(method, fullUrl)
+  }
+
+  def asString[PathInput, Input, Err, Output, Auth <: AuthType](
+    ep: Endpoint[PathInput, Input, Err, Output, Auth],
+  ): String = fromEndpoint(ep).render
+
+  private[datastar] def extractMethod[PathInput, Input, Err, Output, Auth <: AuthType](
+    ep: Endpoint[PathInput, Input, Err, Output, Auth],
+    atomizedInput: AtomizedMetaCodecs,
+  ): Method = {
+    val m = ep.route.method
+    if (m != Method.ANY) m else OpenAPIGen.method(atomizedInput.method)
+  }
+
+  private[datastar] def renderPath[A](pathCodec: PathCodec[A]): String =
+    pathCodec.render("$", "")
+
+  private[datastar] def appendQuery(atomizedInput: AtomizedMetaCodecs, basePath: String): String = {
+    val queryParams = extractQueryParamNames(atomizedInput)
+    if (queryParams.isEmpty) basePath
+    else {
+      val queryString = queryParams.sorted.map(name => s"$name=$$${name}").mkString("&")
+      s"$basePath?$queryString"
+    }
+  }
+
+  private def extractQueryParamNames(atomizedInput: AtomizedMetaCodecs): Seq[String] =
+    atomizedInput.query.flatMap {
+      case MetaCodec(HttpCodec.Query(codec, _), _) =>
+        codec.recordFields.map { case (field, _) => field.name }
+      case _                                       => Seq.empty
+    }
+}

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarActionSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarActionSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.datastar
+
+import zio.test._
+
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint._
+
+object DatastarActionSpec extends ZIOSpecDefault {
+
+  case class User(name: String, email: String)
+  object User {
+    implicit val schema: Schema[User] = DeriveSchema.gen[User]
+  }
+
+  override def spec = suite("DatastarActionSpec")(
+    test("GET with no params") {
+      val endpoint = Endpoint(RoutePattern.GET / "ping")
+      assertTrue(DatastarAction.asString(endpoint) == "@get('/ping')")
+    },
+    test("GET with path param and query params") {
+      val endpoint = Endpoint(RoutePattern.GET / "users" / PathCodec.string("id"))
+        .query(HttpCodec.query[String]("status"))
+        .query(HttpCodec.query[Int]("limit"))
+      assertTrue(
+        DatastarAction.asString(endpoint) == "@get('/users/$id?limit=$limit&status=$status')",
+      )
+    },
+    test("POST with path param ignores body") {
+      val endpoint = Endpoint(RoutePattern.POST / "users" / PathCodec.int("id"))
+        .in[User]
+      assertTrue(DatastarAction.asString(endpoint) == "@post('/users/$id')")
+    },
+    test("DELETE with path param") {
+      val endpoint = Endpoint(RoutePattern.DELETE / "users" / PathCodec.int("id"))
+      assertTrue(DatastarAction.asString(endpoint) == "@delete('/users/$id')")
+    },
+    test("Action trait methods") {
+      val action = DatastarAction.SimpleAction(Method.PUT, "/items/$itemId")
+      assertTrue(
+        action.method == Method.PUT,
+        action.url == "/items/$itemId",
+        action.render == "@put('/items/$itemId')",
+      )
+    },
+  )
+}

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -253,7 +253,7 @@ object Body {
     charSequence: CharSequence,
     charset: Charset = Charsets.Http,
   ): Body =
-    if (charset == Charsets.Http && charSequence.isEmpty) EmptyBody
+    if (charset == Charsets.Http && charSequence.length() == 0) EmptyBody
     else StringBody(charSequence.toString, charset)
 
   /**


### PR DESCRIPTION
## Endpoint to Datastar action converter

Converts ZIO HTTP `Endpoint` to Datastar action expressions (`@get('/users/$id')`).

- Method mapping (GET/POST/PUT/PATCH/DELETE), with `Method.ANY` fallback via `OpenAPIGen.method`
- Path params → `$param` placeholders
- GET query params → alphabetically sorted placeholders
- Minimal API: `DatastarAction.asString(endpoint)`, `DatastarAction.fromEndpoint(endpoint)`

**Also fixes:** `Body.fromCharSequence` Scala 3.3.6+ compilation (`charSequence.isEmpty` → `charSequence.length() == 0`)

**Files:**
- `zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarAction.scala` (new)
- `zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarActionSpec.scala` (new)
- `zio-http/shared/src/main/scala/zio/http/Body.scala` (1-line fix)

/claim #3697