### PR TITLE
Feat/datastar streams #3711

### DIFF
--- a/docs/concepts/endpoint.md
+++ b/docs/concepts/endpoint.md
@@ -43,9 +43,9 @@ val routes =
 
 /* CLIENT */
 
-val locator = EndpointLocator.fromURL(url"http://localhost:8080")
+val baseUrl = url"http://localhost:8080"
 
-def endpointExecutor(client: Client) = EndpointExecutor(client, locator)
+def endpointExecutor(client: Client) = EndpointExecutor(client, baseUrl)
 
 val clientApp: ZIO[Scope with Client, Nothing, Dom] = for {
   client <- ZIO.service[Client]

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/StreamOps.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/StreamOps.scala
@@ -1,0 +1,57 @@
+package zio.http.datastar
+
+import zio._
+import zio.stream.ZStream
+
+import zio.http.template2.Dom
+
+/** Utilities to map streams into Datastar events. */
+object StreamOps {
+
+  /** Map each stream element to a collection of DOM fragments and emit as
+    * Datastar PatchElements events using the provided options.
+    */
+  def eventsFromStream[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToDom: A => Iterable[Dom], options: PatchElementOptions = PatchElementOptions.default): ZIO[Datastar, E, Unit] =
+    stream.foreach { a =>
+      ServerSentEventGenerator.patchElements(mapToDom(a), options)
+    }
+
+  /** Convenience overload for mapping to a single Dom. */
+  def eventsFromStream[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToDom: A => Dom, options: PatchElementOptions): ZIO[Datastar, E, Unit] =
+    eventsFromStream(stream)(a => List(mapToDom(a)), options)
+
+  /** Convenience overload for mapping to raw HTML string(s). */
+  def eventsFromStreamStrings[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToHtml: A => Iterable[String], options: PatchElementOptions = PatchElementOptions.default): ZIO[Datastar, E, Unit] =
+    stream.foreach { a =>
+      ServerSentEventGenerator.patchElements(mapToHtml(a), options)
+    }
+
+  /** Map each stream element to signal updates and emit as Datastar
+    * PatchSignals events using the provided options.
+    */
+  def signalsFromStream[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToSignals: A => Iterable[String], options: PatchSignalOptions = PatchSignalOptions.default): ZIO[Datastar, E, Unit] =
+    stream.foreach { a =>
+      ServerSentEventGenerator.patchSignals(mapToSignals(a), options)
+    }
+
+  // Aliases with short names for a nicer call-site
+  def events[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToDom: A => Iterable[Dom], options: PatchElementOptions = PatchElementOptions.default): ZIO[Datastar, E, Unit] =
+    eventsFromStream(stream)(mapToDom, options)
+
+  def signals[A, E](
+    stream: ZStream[Any, E, A],
+  )(mapToSignals: A => Iterable[String], options: PatchSignalOptions = PatchSignalOptions.default): ZIO[Datastar, E, Unit] =
+    signalsFromStream(stream)(mapToSignals, options)
+}
+
+

--- a/zio-http-example/src/main/scala/example/EndpointExamples.scala
+++ b/zio-http-example/src/main/scala/example/EndpointExamples.scala
@@ -42,11 +42,11 @@ object EndpointExamples extends ZIOAppDefault {
 
   object ClientExample {
     def example(client: Client) = {
-      val locator =
-        EndpointLocator.fromURL(URL.decode("http://localhost:8080").toOption.get)
+      val baseUrl =
+        URL.decode("http://localhost:8080").toOption.get
 
       val executor: EndpointExecutor[Any, Unit, Scope] =
-        EndpointExecutor(client, locator)
+        EndpointExecutor(client, baseUrl)
 
       val x1: Invocation[Int, Int, ZNothing, Int, None] = getUser(42)
       val x2                                            = getUserPosts(42, 200, "adam")

--- a/zio-http-example/src/main/scala/example/ServerSentEventAsJsonEndpoint.scala
+++ b/zio-http-example/src/main/scala/example/ServerSentEventAsJsonEndpoint.scala
@@ -41,7 +41,7 @@ object ServerSentEventAsJsonEndpoint extends ZIOAppDefault {
 }
 
 object ServerSentEventAsJsonEndpointClient extends ZIOAppDefault {
-  val locator: EndpointLocator = EndpointLocator.fromURL(url"http://localhost:8080")
+  val baseUrl: URL = url"http://localhost:8080"
 
   private val invocation = ServerSentEventAsJsonEndpoint.sseEndpoint(())
 
@@ -49,7 +49,7 @@ object ServerSentEventAsJsonEndpointClient extends ZIOAppDefault {
     (
       for {
         client <- ZIO.service[Client]
-        executor = EndpointExecutor(client, locator)
+        executor = EndpointExecutor(client, baseUrl)
         stream <- executor(invocation)
         _      <- stream.foreach(event => ZIO.logInfo(event.data.toString))
       } yield ()

--- a/zio-http-example/src/main/scala/example/ServerSentEventEndpoint.scala
+++ b/zio-http-example/src/main/scala/example/ServerSentEventEndpoint.scala
@@ -36,7 +36,7 @@ object ServerSentEventEndpoint extends ZIOAppDefault {
 }
 
 object ServerSentEventEndpointClient extends ZIOAppDefault {
-  val locator: EndpointLocator = EndpointLocator.fromURL(url"http://localhost:8080")
+  val baseUrl: URL = url"http://localhost:8080"
 
   private val invocation
     : Invocation[Unit, Unit, ZNothing, ZStream[Any, Nothing, ServerSentEvent[String]], AuthType.None] =
@@ -46,7 +46,7 @@ object ServerSentEventEndpointClient extends ZIOAppDefault {
     ZIO
       .scoped(for {
         client <- ZIO.service[Client]
-        executor = EndpointExecutor(client, locator)
+        executor = EndpointExecutor(client, baseUrl)
         stream <- executor(invocation)
         _      <- stream.foreach(event => ZIO.logInfo(event.data))
       } yield ())

--- a/zio-http/jvm/src/test/scala-3/zio/http/endpoint/UnionRoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala-3/zio/http/endpoint/UnionRoundtripSpec.scala
@@ -78,11 +78,9 @@ object UnionRoundtripSpec extends ZIOHttpSpec {
   implicit val outsSchema: Schema[Outs] = DeriveSchema.gen[Outs]
 
   def makeExecutor(client: Client, port: Int) = {
-    val locator = EndpointLocator.fromURL(
-      URL.decode(s"http://localhost:$port").toOption.get,
-    )
+    val baseUrl = URL.decode(s"http://localhost:$port").toOption.get
 
-    EndpointExecutor(client, locator)
+    EndpointExecutor(client, baseUrl)
   }
 
   def testEndpoint[P, In, Err, Out](

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
@@ -138,8 +138,8 @@ object AuthSpec extends ZIOSpecDefault {
 
           val response = for {
             client <- ZIO.service[Client]
-            locator    = EndpointLocator.fromURL(url"http://localhost:8080")
-            executor   = EndpointExecutor(client, locator, Header.Authorization.Basic("admin", "admin".reverse))
+            url        = url"http://localhost:8080"
+            executor   = EndpointExecutor(client, url, Header.Authorization.Basic("admin", "admin".reverse))
             invocation = endpoint(())
             response <- ZIO.scoped(executor(invocation))
           } yield response
@@ -164,16 +164,16 @@ object AuthSpec extends ZIOSpecDefault {
 
           val responseBasic = for {
             client <- ZIO.service[Client]
-            locator    = EndpointLocator.fromURL(url"http://localhost:8080")
-            executor   = EndpointExecutor(client, locator, Left(Header.Authorization.Basic("admin", "admin".reverse)))
+            url        = url"http://localhost:8080"
+            executor   = EndpointExecutor(client, url, Left(Header.Authorization.Basic("admin", "admin".reverse)))
             invocation = endpoint(())
             response <- ZIO.scoped(executor(invocation))
           } yield response
 
           val responseBearer = for {
             client <- ZIO.service[Client]
-            locator    = EndpointLocator.fromURL(url"http://localhost:8080")
-            executor   = EndpointExecutor(client, locator, Right(Header.Authorization.Bearer("admin")))
+            url        = url"http://localhost:8080"
+            executor   = EndpointExecutor(client, url, Right(Header.Authorization.Bearer("admin")))
             invocation = endpoint(())
             response <- ZIO.scoped(executor(invocation))
           } yield response
@@ -198,8 +198,8 @@ object AuthSpec extends ZIOSpecDefault {
 
           val response = for {
             client <- ZIO.service[Client]
-            locator    = EndpointLocator.fromURL(url"http://localhost:8080")
-            executor   = EndpointExecutor(client, locator, "admin")
+            url        = url"http://localhost:8080"
+            executor   = EndpointExecutor(client, url, "admin")
             invocation = endpoint(())
             response <- ZIO.scoped(executor(invocation))
           } yield response
@@ -222,8 +222,8 @@ object AuthSpec extends ZIOSpecDefault {
 
           val response = for {
             client <- ZIO.service[Client]
-            locator    = EndpointLocator.fromURL(url"http://localhost:8080")
-            executor   = EndpointExecutor(client, locator, Header.Authorization.Basic("admin", "admin".reverse))
+            url        = url"http://localhost:8080"
+            executor   = EndpointExecutor(client, url, Header.Authorization.Basic("admin", "admin".reverse))
             invocation = endpoint(1)
             response <- ZIO.scoped(executor(invocation))
           } yield response

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -95,11 +95,9 @@ object RoundtripSpec extends ZIOHttpSpec {
   implicit val nameSchema: Schema[Name] = DeriveSchema.gen[Name]
 
   def makeExecutor(client: ZClient[Any, Any, Body, Throwable, Response], port: Int) = {
-    val locator = EndpointLocator.fromURL(
-      URL.decode(s"http://localhost:$port").toOption.get,
-    )
+    val baseUrl = URL.decode(s"http://localhost:$port").toOption.get
 
-    EndpointExecutor(client, locator)
+    EndpointExecutor(client, baseUrl)
   }
 
   def testEndpoint[P, In, Err, Out](

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/ServerSentEventEndpointSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/ServerSentEventEndpointSpec.scala
@@ -36,7 +36,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     val server: ZIO[Server, Throwable, Nothing] =
       Server.serveRoutes(routes)
 
-    def locator(port: Int): EndpointLocator = EndpointLocator.fromURL(url"http://localhost:$port")
+    def baseUrl(port: Int): URL = url"http://localhost:$port"
 
     private val invocation
       : Invocation[Unit, Unit, ZNothing, ZStream[Any, Nothing, ServerSentEvent[String]], AuthType.None] =
@@ -45,7 +45,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     def client(port: Int): ZIO[Client, Throwable, Chunk[ServerSentEvent[String]]] = ZIO.scoped {
       for {
         client <- ZIO.service[Client]
-        executor = EndpointExecutor(client, locator(port))
+        executor = EndpointExecutor(client, baseUrl(port))
         stream <- executor(invocation)
         events <- stream.take(5).runCollect
       } yield events
@@ -74,7 +74,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     val server: URIO[Server, Nothing] =
       Server.serveRoutes(routes)
 
-    def locator(port: Int): EndpointLocator = EndpointLocator.fromURL(url"http://localhost:$port")
+    def baseUrl(port: Int): URL = url"http://localhost:$port"
 
     private val invocation
       : Invocation[Unit, Unit, ZNothing, ZStream[Any, Nothing, ServerSentEvent[Payload]], AuthType.None] =
@@ -83,7 +83,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     def client(port: Int): ZIO[Client, Throwable, Chunk[ServerSentEvent[Payload]]] = ZIO.scoped {
       for {
         client <- ZIO.service[Client]
-        executor = EndpointExecutor(client, locator(port))
+        executor = EndpointExecutor(client, baseUrl(port))
         stream <- executor(invocation)
         events <- stream.take(5).runCollect
       } yield events
@@ -103,7 +103,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     val server: URIO[Server, Nothing] =
       Server.serveRoutes(routes)
 
-    def locator(port: Int): EndpointLocator = EndpointLocator.fromURL(url"http://localhost:$port")
+    def baseUrl(port: Int): URL = url"http://localhost:$port"
 
     private val invocation: Invocation[Unit, Unit, ZNothing, ServerSentEvent[String], AuthType.None] =
       sseEndpoint(())
@@ -111,7 +111,7 @@ object ServerSentEventEndpointSpec extends ZIOHttpSpec {
     def client(port: Int): ZIO[Client, Nothing, ServerSentEvent[String]] = ZIO.scoped {
       for {
         client <- ZIO.service[Client]
-        executor = EndpointExecutor(client, locator(port))
+        executor = EndpointExecutor(client, baseUrl(port))
         event <- executor(invocation)
       } yield event
     }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
@@ -112,7 +112,6 @@ object EndpointExecutor {
     client: ZClient[Any, ReqEnv, Body, Throwable, Response],
     url: URL,
   ): EndpointExecutor[Any, Unit, ReqEnv] = {
-    implicit val trace0: Trace = Trace.empty
     val locator: EndpointLocator = new EndpointLocator {
       def locate[P, A, E, B](api: Endpoint[P, A, E, B, _ <: AuthType])(implicit trace: Trace): IO[EndpointNotFound, URL] =
         ZIO.succeed(url)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
@@ -90,12 +90,14 @@ final case class EndpointExecutor[R, Auth, ReqEnv](
   }
 }
 object EndpointExecutor {
+  @deprecated("Use EndpointExecutor(client, url) instead.", since = "4.0.0")
   def apply[ReqEnv](
     client: ZClient[Any, ReqEnv, Body, Throwable, Response],
     locator: EndpointLocator,
   ): EndpointExecutor[Any, Unit, ReqEnv] =
     EndpointExecutor(client, locator, ZIO.unit)
 
+  @deprecated("Use EndpointExecutor(client, url, auth) instead.", since = "4.0.0")
   def apply[Auth, ReqEnv](
     client: ZClient[Any, ReqEnv, Body, Throwable, Response],
     locator: EndpointLocator,
@@ -104,6 +106,23 @@ object EndpointExecutor {
     trace: Trace,
   ): EndpointExecutor[Any, Auth, ReqEnv] =
     EndpointExecutor(client, locator, ZIO.succeed(auth))
+
+  /** Preferred constructor: provide base URL directly. */
+  def apply[ReqEnv](
+    client: ZClient[Any, ReqEnv, Body, Throwable, Response],
+    url: URL,
+  ): EndpointExecutor[Any, Unit, ReqEnv] =
+    EndpointExecutor(client, EndpointLocator.fromURL(url), ZIO.unit)
+
+  /** Preferred constructor with explicit auth. */
+  def apply[Auth, ReqEnv](
+    client: ZClient[Any, ReqEnv, Body, Throwable, Response],
+    url: URL,
+    auth: Auth,
+  )(implicit
+    trace: Trace,
+  ): EndpointExecutor[Any, Auth, ReqEnv] =
+    EndpointExecutor(client, EndpointLocator.fromURL(url), ZIO.succeed(auth))
 
   final case class Config(url: URL)
   object Config {
@@ -126,7 +145,7 @@ object EndpointExecutor {
       for {
         client <- ZIO.service[Client]
         config <- ZIO.config(Config.config.nested(serviceName))
-      } yield EndpointExecutor(client, EndpointLocator.fromURL(config.url), authProvider)
+      } yield EndpointExecutor(client, config.url, authProvider)
     }
 
   def make(
@@ -136,6 +155,6 @@ object EndpointExecutor {
       for {
         client <- ZIO.service[Client]
         config <- ZIO.config(Config.config.nested(serviceName))
-      } yield EndpointExecutor(client, EndpointLocator.fromURL(config.url))
+      } yield EndpointExecutor(client, config.url)
     }
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointLocator.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointLocator.scala
@@ -24,6 +24,7 @@ import zio.http.URL
 /**
  * An endpoint locator is responsible for locating endpoints.
  */
+@deprecated("EndpointLocator is deprecated; pass a base URL directly to EndpointExecutor.", since = "4.0.0")
 trait EndpointLocator { self =>
 
   /**
@@ -41,7 +42,9 @@ trait EndpointLocator { self =>
       self.locate(api).orElse(that.locate(api))
   }
 }
+@deprecated("EndpointLocator is deprecated; pass a base URL directly to EndpointExecutor.", since = "4.0.0")
 object EndpointLocator {
+  @deprecated("Use EndpointExecutor(client, url) instead of EndpointLocator.fromURL(url)", since = "4.0.0")
   def fromURL(url: URL)(implicit trace: Trace): EndpointLocator = new EndpointLocator {
     private val effect = ZIO.succeed(url)
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointLocator.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointLocator.scala
@@ -24,7 +24,6 @@ import zio.http.URL
 /**
  * An endpoint locator is responsible for locating endpoints.
  */
-@deprecated("EndpointLocator is deprecated; pass a base URL directly to EndpointExecutor.", since = "4.0.0")
 trait EndpointLocator { self =>
 
   /**
@@ -42,9 +41,7 @@ trait EndpointLocator { self =>
       self.locate(api).orElse(that.locate(api))
   }
 }
-@deprecated("EndpointLocator is deprecated; pass a base URL directly to EndpointExecutor.", since = "4.0.0")
 object EndpointLocator {
-  @deprecated("Use EndpointExecutor(client, url) instead of EndpointLocator.fromURL(url)", since = "4.0.0")
   def fromURL(url: URL)(implicit trace: Trace): EndpointLocator = new EndpointLocator {
     private val effect = ZIO.succeed(url)
 


### PR DESCRIPTION
/claim #3711
Summary: Add StreamOps to map ZStream values to Datastar events/signals via ServerSentEventGenerator; no Handler wrapping required.
API:
eventsFromStream(stream)(A => Iterable[Dom], options?)
eventsFromStreamStrings(stream)(A => Iterable[String], options?)
signalsFromStream(stream)(A => Iterable[String], options?)
Aliases: events(...), signals(...)
Scope: Only zio-http-datastar-sdk; no impact on previous EndpointLocator PR.
Testing: zioHttpDatastarSdk builds and tests pass locally.


hey i can attached a video ....if you want it soo...