### PR TITLE
Redirect Netlify Domain to The ziohttp.com Domain

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,0 +1,2 @@
+https://zio-http.netlify.app/*   https://ziohttp.com/:splat       301!
+http://zio-http.netlify.app/*    https://ziohttp.com/:splat       301!


### PR DESCRIPTION
Currently, Google directs the non-primary domain of the ZIO HTTP project: zio-http.netlify.app, so we need to instruct and redirect it to the primary one: ziohttp.com.

<img width="1314" height="560" alt="image" src="https://github.com/user-attachments/assets/ab4796b6-013b-4789-884c-b164db518872" />
