### PR TITLE
Root route formatting

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -468,6 +468,10 @@ object RoutePatternSpec extends ZIOHttpSpec {
 
         assertTrue(routePattern.format((1, "abc")) == Right(Path("/users/1/posts/abc")))
       },
+      test("formatting root") {
+        val routePattern = Method.GET / Root
+        assertTrue(routePattern.format(()) == Right(Path("/")))
+      },
     )
 
   def structureEquals = suite("structure equals")(

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -145,6 +145,16 @@ object URLSpec extends ZIOHttpSpec {
           val expected = Right("/users?a=1&b=2")
           assertTrue(actual == expected)
         },
+        test("relative root") {
+          val actual   = URL(Path.root, URL.Location.Relative)
+          val expected = "/"
+          assertTrue(actual.encode == expected)
+        },
+        test("relative empty") {
+          val actual   = URL(Path.empty, URL.Location.Relative)
+          val expected = ""
+          assertTrue(actual.encode == expected)
+        },
       ),
       suite("path")(
         test("updates the path without needed to know the host") {

--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -109,7 +109,8 @@ final case class RoutePattern[A](method: Method, pathCodec: PathCodec[A]) { self
    * Formats a value of type `A` into a path. This is useful for embedding paths
    * into HTML that is rendered by the server.
    */
-  def format(value: A): Either[String, Path] = pathCodec.format(value)
+  def format(value: A): Either[String, Path] =
+    pathCodec.format(value).map(_.addLeadingSlash)
 
   /**
    * Determines if this pattern matches the specified method and path. Rather


### PR DESCRIPTION
Hi all,
Here is an attempt to fix issue #3760, which I opened earlier.
The idea is that since `RoutePattern` always starts with a `/`, it is safe to add a leading slash to the path computed by `PathCodec.format`.
Hope this is useful!
Kind regards,
Manfred