### PR TITLE
Fix reading flash by type from empty value

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Flash.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Flash.scala
@@ -348,7 +348,9 @@ object Flash {
    * Gets the first flash value of type `A` regardless of any key.
    */
   def get[A: Schema]: Flash[A] = withInput { map =>
-    map.keys.map(a => Flash.get(a)(Schema[A])).reduce(_ <> _)
+    map.keys.map(a => Flash.get(a)(Schema[A])).foldLeft[Flash[A]](Flash.fail("no flash set")) { case (lhs, rhs) =>
+      lhs <> rhs
+    }
   }
 
   private[http] def run[A](flash: Flash[A], sourceRequest: Request): Either[Throwable, A] =


### PR DESCRIPTION
Hi!
I've found an issue while trying out ZIO HTTP's flash support.
It is possible that a flash cookie is available, i.e. the flash ID can be read from the request cookie, but at the same time the `InMemory` store might not contain any value for the given flash ID. Currently this results in a defect due to a `reduce` on an empty list generating an unexpected `InternalServerError`. This situation can occur when an application is restarted.
The first commit adds a failing test.
The second commit fixes the issue.
Hope this is useful!
