### PR TITLE
Add STOMP protocol support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
   val netty =
     Seq(
       "io.netty" % "netty-codec-http"                % NettyVersion,
+      "io.netty" % "netty-codec-stomp"               % NettyVersion,
       "io.netty" % "netty-handler-proxy"             % NettyVersion,
       "io.netty" % "netty-transport-native-epoll"    % NettyVersion,
       "io.netty" % "netty-transport-native-epoll"    % NettyVersion classifier "linux-x86_64",

--- a/zio-http-example/src/main/scala/example/stomp/StompAppExample.scala
+++ b/zio-http-example/src/main/scala/example/stomp/StompAppExample.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.stomp
+
+import zio._
+import zio.http._
+import zio.http.ChannelEvent.Read
+
+/**
+ * Example demonstrating StompApp usage pattern.
+ *
+ * This shows the conceptual API for handling STOMP frames in a type-safe way.
+ * In a complete implementation, this would connect to a real STOMP broker.
+ */
+object StompAppExample extends ZIOAppDefault {
+
+  /**
+   * Example STOMP application that handles different frame types
+   */
+  val stompApp: StompApp[Any] = StompApp {
+    Handler.fromFunctionZIO[StompChannel] { channel =>
+      Console.printLine("STOMP connection established") *>
+        // Send CONNECT frame
+        channel.send(
+          StompFrame
+            .Connect()
+            .withHeader("accept-version", "1.2")
+            .withHeader("host", "localhost"),
+        ) *>
+        Console.printLine("Sent CONNECT frame") *>
+        // Handle incoming frames (never returns)
+        channel.receiveAll {
+          case Read(StompFrame.Connected(headers, _)) =>
+            Console.printLine(s"Connected! Server version: ${headers.get("version").getOrElse("unknown")}") *>
+              // Subscribe to a topic after connection
+              channel.send(
+                StompFrame.Subscribe(
+                  destination = "/topic/updates",
+                  id = "sub-1",
+                ),
+              )
+
+          case Read(StompFrame.Message(destination, messageId, subscription, _, body)) =>
+            val content = new String(body.toArray, "UTF-8")
+            Console.printLine(s"Received message on $destination: $content") *>
+              // Acknowledge the message
+              channel.send(StompFrame.Ack(id = messageId))
+
+          case Read(StompFrame.Error(message, _, body)) =>
+            val details = new String(body.toArray, "UTF-8")
+            Console.printLine(s"Error from server: $message - $details") *>
+              ZIO.fail(new RuntimeException(message))
+
+          case Read(StompFrame.Receipt(receiptId, _, _)) =>
+            Console.printLine(s"Received receipt: $receiptId")
+
+          case ChannelEvent.ExceptionCaught(err) =>
+            Console.printLine(s"Channel error: ${err.getMessage}") *>
+              ZIO.fail(err)
+
+          case ChannelEvent.Unregistered =>
+            Console.printLine("Channel closed") *>
+              ZIO.fail(new RuntimeException("Connection closed"))
+
+          case _ =>
+            ZIO.unit
+        }
+    }
+  }
+
+  /**
+   * Example showing how to compose STOMP apps with ZIO environment
+   */
+  trait MessageLogger {
+    def log(message: String): UIO[Unit]
+  }
+
+  object MessageLogger {
+    val live: ZLayer[Any, Nothing, MessageLogger] = ZLayer.succeed(
+      new MessageLogger {
+        def log(message: String): UIO[Unit] =
+          Console.printLine(s"[LOG] $message").orDie
+      },
+    )
+  }
+
+  val stompAppWithLogging: StompApp[MessageLogger] = StompApp {
+    Handler.fromFunctionZIO[StompChannel] { channel =>
+      ZIO.service[MessageLogger].flatMap { logger =>
+        logger.log("Starting STOMP session") *>
+          channel.receiveAll {
+            case Read(frame) =>
+              logger.log(s"Received frame: ${frame.command.name}")
+
+            case _ =>
+              ZIO.unit
+          }
+      }
+    }
+  }
+
+  override def run: ZIO[Any, Any, Unit] = {
+    for {
+      _ <- Console.printLine("=== STOMP App Example ===\n")
+      _ <- Console.printLine("This example demonstrates the StompApp API pattern.")
+      _ <- Console.printLine("\nThe StompApp provides:")
+      _ <- Console.printLine("  - Type-safe frame handling")
+      _ <- Console.printLine("  - Pattern matching on frame types")
+      _ <- Console.printLine("  - ZIO environment composition")
+      _ <- Console.printLine("  - Automatic error handling")
+      _ <- Console.printLine("\nTo connect to a real broker:")
+      _ <- Console.printLine("  1. Start a STOMP broker (e.g., docker run -p 61613:61613 rmohr/activemq)")
+      _ <- Console.printLine("  2. Implement connection setup with Netty pipeline")
+      _ <- Console.printLine("  3. Use StompChannel for bidirectional communication")
+      _ <- Console.printLine("\nThe typed API ensures compile-time safety:")
+
+      // Demonstrate type safety
+      connectFrame = StompFrame.Connect()
+      _ <- Console.printLine(s"\n  - Connect frame type: ${connectFrame.getClass.getSimpleName}")
+      _ <- Console.printLine(s"  - Command: ${connectFrame.command.name}")
+      _ <- Console.printLine(s"  - Headers are type-safe and validated")
+
+    } yield ()
+  }
+}

--- a/zio-http-example/src/main/scala/example/stomp/StompAppExample.scala
+++ b/zio-http-example/src/main/scala/example/stomp/StompAppExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 package example.stomp
 
 import zio._
-import zio.http._
+
 import zio.http.ChannelEvent.Read
+import zio.http._
 
 /**
  * Example demonstrating StompApp usage pattern.

--- a/zio-http-example/src/main/scala/example/stomp/StompFrameExample.scala
+++ b/zio-http-example/src/main/scala/example/stomp/StompFrameExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package example.stomp
 
 import zio._
+
 import zio.http._
 
 /**

--- a/zio-http-example/src/main/scala/example/stomp/StompFrameExample.scala
+++ b/zio-http-example/src/main/scala/example/stomp/StompFrameExample.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.stomp
+
+import zio._
+import zio.http._
+
+/**
+ * Example demonstrating STOMP frame creation and manipulation.
+ *
+ * This example shows the typed STOMP API without requiring a running broker.
+ */
+object StompFrameExample extends ZIOAppDefault {
+
+  override def run: ZIO[Any, Any, Unit] = {
+    for {
+      _ <- Console.printLine("=== STOMP Frame Example ===\n")
+
+      // Create a CONNECT frame
+      connectFrame = StompFrame
+        .Connect()
+        .withHeader("accept-version", "1.2")
+        .withHeader("host", "localhost")
+        .withHeader("login", "guest")
+        .withHeader("passcode", "guest")
+
+      _ <- Console.printLine("1. CONNECT Frame:")
+      _ <- Console.printLine(s"   Command: ${connectFrame.command.name}")
+      _ <- Console.printLine(s"   Host: ${connectFrame.header("host").getOrElse("not set")}")
+      _ <- Console.printLine(s"   Version: ${connectFrame.header("accept-version").getOrElse("not set")}\n")
+
+      // Create a SEND frame with a message body
+      messageBody = Chunk.fromArray("Hello, STOMP!".getBytes("UTF-8"))
+      sendFrame   = StompFrame
+        .Send(
+          destination = "/queue/test",
+        )
+        .withHeader("content-type", "text/plain")
+        .withBody(messageBody)
+
+      _ <- Console.printLine("2. SEND Frame:")
+      _ <- Console.printLine(s"   Command: ${sendFrame.command.name}")
+      _ <- Console.printLine(s"   Destination: ${sendFrame.destination}")
+      _ <- Console.printLine(s"   Content-Type: ${sendFrame.header("content-type").getOrElse("not set")}")
+      _ <- Console.printLine(s"   Body: ${new String(sendFrame.body.toArray, "UTF-8")}\n")
+
+      // Create a SUBSCRIBE frame
+      subscribeFrame = StompFrame
+        .Subscribe(
+          destination = "/topic/events",
+          id = "sub-0",
+        )
+        .withHeader("ack", "client")
+
+      _ <- Console.printLine("3. SUBSCRIBE Frame:")
+      _ <- Console.printLine(s"   Command: ${subscribeFrame.command.name}")
+      _ <- Console.printLine(s"   Destination: ${subscribeFrame.destination}")
+      _ <- Console.printLine(s"   Subscription ID: ${subscribeFrame.id}")
+      _ <- Console.printLine(s"   Ack mode: ${subscribeFrame.header("ack").getOrElse("auto")}\n")
+
+      // Create a MESSAGE frame (server response)
+      responseBody = Chunk.fromArray("Event data".getBytes("UTF-8"))
+      messageFrame = StompFrame
+        .Message(
+          destination = "/topic/events",
+          messageId = "msg-001",
+          subscription = "sub-0",
+        )
+        .withHeader("content-type", "text/plain")
+        .withBody(responseBody)
+
+      _ <- Console.printLine("4. MESSAGE Frame (from server):")
+      _ <- Console.printLine(s"   Command: ${messageFrame.command.name}")
+      _ <- Console.printLine(s"   Message ID: ${messageFrame.messageId}")
+      _ <- Console.printLine(s"   Subscription: ${messageFrame.subscription}")
+      _ <- Console.printLine(s"   Body: ${new String(messageFrame.body.toArray, "UTF-8")}\n")
+
+      // Create an ACK frame
+      ackFrame = StompFrame.Ack(id = "msg-001")
+
+      _ <- Console.printLine("5. ACK Frame:")
+      _ <- Console.printLine(s"   Command: ${ackFrame.command.name}")
+      _ <- Console.printLine(s"   Message ID: ${ackFrame.id}\n")
+
+      // Create a DISCONNECT frame
+      disconnectFrame = StompFrame
+        .Disconnect()
+        .withHeader("receipt", "disconnect-01")
+
+      _ <- Console.printLine("6. DISCONNECT Frame:")
+      _ <- Console.printLine(s"   Command: ${disconnectFrame.command.name}")
+      _ <- Console.printLine(s"   Receipt: ${disconnectFrame.header("receipt").getOrElse("none")}\n")
+
+      // Demonstrate error frame
+      errorFrame = StompFrame
+        .Error(
+          message = "Destination not found",
+        )
+        .withBody(Chunk.fromArray("The destination '/queue/invalid' does not exist".getBytes("UTF-8")))
+
+      _ <- Console.printLine("7. ERROR Frame (from server):")
+      _ <- Console.printLine(s"   Command: ${errorFrame.command.name}")
+      _ <- Console.printLine(s"   Message: ${errorFrame.message}")
+      _ <- Console.printLine(s"   Details: ${new String(errorFrame.body.toArray, "UTF-8")}\n")
+
+      _ <- Console.printLine("=== Frame API Demonstration Complete ===")
+      _ <- Console.printLine("\nNote: This example demonstrates the typed STOMP frame API.")
+      _ <- Console.printLine("To use STOMP with a real broker, you would:")
+      _ <- Console.printLine("  1. Create a StompApp with your frame handling logic")
+      _ <- Console.printLine("  2. Connect to a STOMP broker (ActiveMQ, RabbitMQ, etc.)")
+      _ <- Console.printLine("  3. Use StompChannel to send/receive frames")
+
+    } yield ()
+  }
+}

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,19 @@
 
 package zio.http.netty
 
+import scala.jdk.CollectionConverters._
+
+import zio._
+
+import zio.http.{Header, Headers, StompCommand => ZStompCommand, StompFrame => ZStompFrame}
+
 import io.netty.handler.codec.stomp.{
   DefaultStompFrame,
   DefaultStompHeaders,
   StompCommand,
-  StompHeaders,
   StompFrame => JStompFrame,
+  StompHeaders,
 }
-import zio._
-import zio.http.{Header, Headers, StompCommand => ZStompCommand, StompFrame => ZStompFrame}
-
-import scala.jdk.CollectionConverters._
 
 /**
  * Converts between Netty STOMP frames and zio-http StompFrame ADT
@@ -34,137 +36,154 @@ import scala.jdk.CollectionConverters._
 private[netty] object NettyStompFrameCodec {
 
   /**
-   * Converts a Netty StompFrame to a zio-http StompFrame
+   * Converts a Netty StompFrame to a zio-http StompFrame.
+   *
+   * This is a pure function (not wrapped in ZIO) to avoid blocking the Netty
+   * event loop. Errors are thrown and will be caught by the caller.
    */
-  def fromNettyFrame(nettyFrame: JStompFrame): Task[ZStompFrame] = {
-    ZIO.attempt {
-      val command = nettyFrame.command()
-      val headers = convertHeaders(nettyFrame.headers())
-      val body    = {
-        val content = nettyFrame.content()
-        val bytes   = new Array[Byte](content.readableBytes())
-        content.getBytes(content.readerIndex(), bytes)
-        Chunk.fromArray(bytes)
-      }
+  def fromNettyFrame(nettyFrame: JStompFrame): ZStompFrame = {
+    val command = nettyFrame.command()
+    val headers = convertHeaders(nettyFrame.headers())
+    val body    = {
+      val content = nettyFrame.content()
+      // Read bytes from ByteBuf. Memory management: The frame's ByteBuf will be
+      // automatically released by StompAppHandler which uses autoRelease = true
+      val bytes   = new Array[Byte](content.readableBytes())
+      content.getBytes(content.readerIndex(), bytes)
+      Chunk.fromArray(bytes)
+    }
 
-      command match {
-        case StompCommand.CONNECT =>
-          ZStompFrame.Connect(headers, body)
+    command match {
+      case StompCommand.CONNECT =>
+        ZStompFrame.Connect(headers, body)
 
-        case StompCommand.SEND =>
-          val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
-            .getOrElse(throw new IllegalArgumentException("SEND frame missing destination header"))
-          ZStompFrame.Send(destination, headers, body)
+      case StompCommand.SEND =>
+        val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+          .getOrElse(throw new IllegalArgumentException("SEND frame missing destination header"))
+        ZStompFrame.Send(destination, headers, body)
 
-        case StompCommand.SUBSCRIBE =>
-          val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
-            .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing destination header"))
-          val id          = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
-            .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing id header"))
-          ZStompFrame.Subscribe(destination, id, headers, body)
+      case StompCommand.SUBSCRIBE =>
+        val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+          .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing destination header"))
+        val id          = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+          .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing id header"))
+        ZStompFrame.Subscribe(destination, id, headers, body)
 
-        case StompCommand.UNSUBSCRIBE =>
-          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
-            .getOrElse(throw new IllegalArgumentException("UNSUBSCRIBE frame missing id header"))
-          ZStompFrame.Unsubscribe(id, headers, body)
+      case StompCommand.UNSUBSCRIBE =>
+        val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+          .getOrElse(throw new IllegalArgumentException("UNSUBSCRIBE frame missing id header"))
+        ZStompFrame.Unsubscribe(id, headers, body)
 
-        case StompCommand.ACK =>
-          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
-            .getOrElse(throw new IllegalArgumentException("ACK frame missing id header"))
-          ZStompFrame.Ack(id, headers, body)
+      case StompCommand.ACK =>
+        val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+          .getOrElse(throw new IllegalArgumentException("ACK frame missing id header"))
+        ZStompFrame.Ack(id, headers, body)
 
-        case StompCommand.NACK =>
-          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
-            .getOrElse(throw new IllegalArgumentException("NACK frame missing id header"))
-          ZStompFrame.Nack(id, headers, body)
+      case StompCommand.NACK =>
+        val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+          .getOrElse(throw new IllegalArgumentException("NACK frame missing id header"))
+        ZStompFrame.Nack(id, headers, body)
 
-        case StompCommand.DISCONNECT =>
-          ZStompFrame.Disconnect(headers, body)
+      case StompCommand.DISCONNECT =>
+        ZStompFrame.Disconnect(headers, body)
 
-        case StompCommand.CONNECTED =>
-          ZStompFrame.Connected(headers, body)
+      case StompCommand.CONNECTED =>
+        ZStompFrame.Connected(headers, body)
 
-        case StompCommand.MESSAGE =>
-          val destination  = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
-            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing destination header"))
-          val messageId    = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE_ID))
-            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing message-id header"))
-          val subscription = Option(nettyFrame.headers().getAsString(StompHeaders.SUBSCRIPTION))
-            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing subscription header"))
-          ZStompFrame.Message(destination, messageId, subscription, headers, body)
+      case StompCommand.MESSAGE =>
+        val destination  = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+          .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing destination header"))
+        val messageId    = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE_ID))
+          .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing message-id header"))
+        val subscription = Option(nettyFrame.headers().getAsString(StompHeaders.SUBSCRIPTION))
+          .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing subscription header"))
+        ZStompFrame.Message(destination, messageId, subscription, headers, body)
 
-        case StompCommand.RECEIPT =>
-          val receiptId = Option(nettyFrame.headers().getAsString(StompHeaders.RECEIPT_ID))
-            .getOrElse(throw new IllegalArgumentException("RECEIPT frame missing receipt-id header"))
-          ZStompFrame.Receipt(receiptId, headers, body)
+      case StompCommand.RECEIPT =>
+        val receiptId = Option(nettyFrame.headers().getAsString(StompHeaders.RECEIPT_ID))
+          .getOrElse(throw new IllegalArgumentException("RECEIPT frame missing receipt-id header"))
+        ZStompFrame.Receipt(receiptId, headers, body)
 
-        case StompCommand.ERROR =>
-          val message = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE))
-            .getOrElse("Unknown error")
-          ZStompFrame.Error(message, headers, body)
+      case StompCommand.ERROR =>
+        val message = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE))
+          .getOrElse("Unknown error")
+        ZStompFrame.Error(message, headers, body)
 
-        case _ =>
-          throw new IllegalArgumentException(s"Unknown STOMP command: $command")
-      }
+      case _ =>
+        throw new IllegalArgumentException(s"Unknown STOMP command: $command")
     }
   }
 
   /**
-   * Converts a zio-http StompFrame to a Netty StompFrame
+   * Converts a zio-http StompFrame to a Netty StompFrame.
+   *
+   * This is a pure function to avoid blocking the Netty event loop.
    */
-  def toNettyFrame(frame: ZStompFrame): Task[DefaultStompFrame] = {
-    ZIO.attempt {
-      val nettyCommand = frame.command match {
-        case ZStompCommand.CONNECT     => StompCommand.CONNECT
-        case ZStompCommand.SEND        => StompCommand.SEND
-        case ZStompCommand.SUBSCRIBE   => StompCommand.SUBSCRIBE
-        case ZStompCommand.UNSUBSCRIBE => StompCommand.UNSUBSCRIBE
-        case ZStompCommand.ACK         => StompCommand.ACK
-        case ZStompCommand.NACK        => StompCommand.NACK
-        case ZStompCommand.DISCONNECT  => StompCommand.DISCONNECT
-        case ZStompCommand.CONNECTED   => StompCommand.CONNECTED
-        case ZStompCommand.MESSAGE     => StompCommand.MESSAGE
-        case ZStompCommand.RECEIPT     => StompCommand.RECEIPT
-        case ZStompCommand.ERROR       => StompCommand.ERROR
+  def toNettyFrame(frame: ZStompFrame): DefaultStompFrame = {
+    val nettyCommand = frame.command match {
+      case ZStompCommand.CONNECT     => StompCommand.CONNECT
+      case ZStompCommand.SEND        => StompCommand.SEND
+      case ZStompCommand.SUBSCRIBE   => StompCommand.SUBSCRIBE
+      case ZStompCommand.UNSUBSCRIBE => StompCommand.UNSUBSCRIBE
+      case ZStompCommand.ACK         => StompCommand.ACK
+      case ZStompCommand.NACK        => StompCommand.NACK
+      case ZStompCommand.DISCONNECT  => StompCommand.DISCONNECT
+      case ZStompCommand.CONNECTED   => StompCommand.CONNECTED
+      case ZStompCommand.MESSAGE     => StompCommand.MESSAGE
+      case ZStompCommand.RECEIPT     => StompCommand.RECEIPT
+      case ZStompCommand.ERROR       => StompCommand.ERROR
+    }
+
+    val nettyHeaders = new DefaultStompHeaders()
+
+    // Add required headers for specific frame types
+    frame match {
+      case f: ZStompFrame.Send        =>
+        nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+      case f: ZStompFrame.Subscribe   =>
+        nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+        nettyHeaders.set(StompHeaders.ID, f.id)
+      case f: ZStompFrame.Unsubscribe =>
+        nettyHeaders.set(StompHeaders.ID, f.id)
+      case f: ZStompFrame.Ack         =>
+        nettyHeaders.set(StompHeaders.ID, f.id)
+      case f: ZStompFrame.Nack        =>
+        nettyHeaders.set(StompHeaders.ID, f.id)
+      case f: ZStompFrame.Message     =>
+        nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+        nettyHeaders.set(StompHeaders.MESSAGE_ID, f.messageId)
+        nettyHeaders.set(StompHeaders.SUBSCRIPTION, f.subscription)
+      case f: ZStompFrame.Receipt     =>
+        nettyHeaders.set(StompHeaders.RECEIPT_ID, f.receiptId)
+      case f: ZStompFrame.Error       =>
+        nettyHeaders.set(StompHeaders.MESSAGE, f.message)
+      case _                          => // No required headers
+    }
+
+    // Add custom headers, excluding well-known headers that are set via frame-specific fields
+    // to prevent duplicate headers (e.g., if user calls .withHeader("destination", "..."))
+    frame.headers.foreach { header =>
+      val headerName  = header.headerName.toString.toLowerCase
+      val isWellKnown = headerName match {
+        case "destination" | "id" | "message-id" | "subscription" | "receipt-id" | "message" | "content-length" =>
+          true
+        case _                                                                                                  => false
       }
-
-      val nettyHeaders = new DefaultStompHeaders()
-
-      // Add required headers for specific frame types
-      frame match {
-        case f: ZStompFrame.Send        =>
-          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
-        case f: ZStompFrame.Subscribe   =>
-          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
-          nettyHeaders.set(StompHeaders.ID, f.id)
-        case f: ZStompFrame.Unsubscribe =>
-          nettyHeaders.set(StompHeaders.ID, f.id)
-        case f: ZStompFrame.Ack         =>
-          nettyHeaders.set(StompHeaders.ID, f.id)
-        case f: ZStompFrame.Nack        =>
-          nettyHeaders.set(StompHeaders.ID, f.id)
-        case f: ZStompFrame.Message     =>
-          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
-          nettyHeaders.set(StompHeaders.MESSAGE_ID, f.messageId)
-          nettyHeaders.set(StompHeaders.SUBSCRIPTION, f.subscription)
-        case f: ZStompFrame.Receipt     =>
-          nettyHeaders.set(StompHeaders.RECEIPT_ID, f.receiptId)
-        case f: ZStompFrame.Error       =>
-          nettyHeaders.set(StompHeaders.MESSAGE, f.message)
-        case _                          => // No required headers
-      }
-
-      // Add custom headers
-      frame.headers.foreach { header =>
+      if (!isWellKnown) {
         nettyHeaders.add(header.headerName, header.renderedValue)
       }
-
-      // Create frame with body
-      val content    = io.netty.buffer.Unpooled.wrappedBuffer(frame.body.toArray)
-      val stompFrame = new DefaultStompFrame(nettyCommand, content)
-      stompFrame.headers().set(nettyHeaders)
-      stompFrame
     }
+
+    // Add content-length header for frames with bodies (required by STOMP spec)
+    if (frame.body.nonEmpty) {
+      nettyHeaders.set(StompHeaders.CONTENT_LENGTH, frame.body.length.toString)
+    }
+
+    // Create frame with body
+    val content    = io.netty.buffer.Unpooled.wrappedBuffer(frame.body.toArray)
+    val stompFrame = new DefaultStompFrame(nettyCommand, content)
+    stompFrame.headers().set(nettyHeaders)
+    stompFrame
   }
 
   /**

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty
+
+import io.netty.handler.codec.stomp.{
+  DefaultStompFrame,
+  DefaultStompHeaders,
+  StompCommand,
+  StompHeaders,
+  StompFrame => JStompFrame,
+}
+import zio._
+import zio.http.{Header, Headers, StompCommand => ZStompCommand, StompFrame => ZStompFrame}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Converts between Netty STOMP frames and zio-http StompFrame ADT
+ */
+private[netty] object NettyStompFrameCodec {
+
+  /**
+   * Converts a Netty StompFrame to a zio-http StompFrame
+   */
+  def fromNettyFrame(nettyFrame: JStompFrame): Task[ZStompFrame] = {
+    ZIO.attempt {
+      val command = nettyFrame.command()
+      val headers = convertHeaders(nettyFrame.headers())
+      val body    = {
+        val content = nettyFrame.content()
+        val bytes   = new Array[Byte](content.readableBytes())
+        content.getBytes(content.readerIndex(), bytes)
+        Chunk.fromArray(bytes)
+      }
+
+      command match {
+        case StompCommand.CONNECT =>
+          ZStompFrame.Connect(headers, body)
+
+        case StompCommand.SEND =>
+          val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+            .getOrElse(throw new IllegalArgumentException("SEND frame missing destination header"))
+          ZStompFrame.Send(destination, headers, body)
+
+        case StompCommand.SUBSCRIBE =>
+          val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+            .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing destination header"))
+          val id          = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+            .getOrElse(throw new IllegalArgumentException("SUBSCRIBE frame missing id header"))
+          ZStompFrame.Subscribe(destination, id, headers, body)
+
+        case StompCommand.UNSUBSCRIBE =>
+          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+            .getOrElse(throw new IllegalArgumentException("UNSUBSCRIBE frame missing id header"))
+          ZStompFrame.Unsubscribe(id, headers, body)
+
+        case StompCommand.ACK =>
+          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+            .getOrElse(throw new IllegalArgumentException("ACK frame missing id header"))
+          ZStompFrame.Ack(id, headers, body)
+
+        case StompCommand.NACK =>
+          val id = Option(nettyFrame.headers().getAsString(StompHeaders.ID))
+            .getOrElse(throw new IllegalArgumentException("NACK frame missing id header"))
+          ZStompFrame.Nack(id, headers, body)
+
+        case StompCommand.DISCONNECT =>
+          ZStompFrame.Disconnect(headers, body)
+
+        case StompCommand.CONNECTED =>
+          ZStompFrame.Connected(headers, body)
+
+        case StompCommand.MESSAGE =>
+          val destination  = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))
+            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing destination header"))
+          val messageId    = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE_ID))
+            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing message-id header"))
+          val subscription = Option(nettyFrame.headers().getAsString(StompHeaders.SUBSCRIPTION))
+            .getOrElse(throw new IllegalArgumentException("MESSAGE frame missing subscription header"))
+          ZStompFrame.Message(destination, messageId, subscription, headers, body)
+
+        case StompCommand.RECEIPT =>
+          val receiptId = Option(nettyFrame.headers().getAsString(StompHeaders.RECEIPT_ID))
+            .getOrElse(throw new IllegalArgumentException("RECEIPT frame missing receipt-id header"))
+          ZStompFrame.Receipt(receiptId, headers, body)
+
+        case StompCommand.ERROR =>
+          val message = Option(nettyFrame.headers().getAsString(StompHeaders.MESSAGE))
+            .getOrElse("Unknown error")
+          ZStompFrame.Error(message, headers, body)
+
+        case _ =>
+          throw new IllegalArgumentException(s"Unknown STOMP command: $command")
+      }
+    }
+  }
+
+  /**
+   * Converts a zio-http StompFrame to a Netty StompFrame
+   */
+  def toNettyFrame(frame: ZStompFrame): Task[DefaultStompFrame] = {
+    ZIO.attempt {
+      val nettyCommand = frame.command match {
+        case ZStompCommand.CONNECT     => StompCommand.CONNECT
+        case ZStompCommand.SEND        => StompCommand.SEND
+        case ZStompCommand.SUBSCRIBE   => StompCommand.SUBSCRIBE
+        case ZStompCommand.UNSUBSCRIBE => StompCommand.UNSUBSCRIBE
+        case ZStompCommand.ACK         => StompCommand.ACK
+        case ZStompCommand.NACK        => StompCommand.NACK
+        case ZStompCommand.DISCONNECT  => StompCommand.DISCONNECT
+        case ZStompCommand.CONNECTED   => StompCommand.CONNECTED
+        case ZStompCommand.MESSAGE     => StompCommand.MESSAGE
+        case ZStompCommand.RECEIPT     => StompCommand.RECEIPT
+        case ZStompCommand.ERROR       => StompCommand.ERROR
+      }
+
+      val nettyHeaders = new DefaultStompHeaders()
+
+      // Add required headers for specific frame types
+      frame match {
+        case f: ZStompFrame.Send        =>
+          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+        case f: ZStompFrame.Subscribe   =>
+          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+          nettyHeaders.set(StompHeaders.ID, f.id)
+        case f: ZStompFrame.Unsubscribe =>
+          nettyHeaders.set(StompHeaders.ID, f.id)
+        case f: ZStompFrame.Ack         =>
+          nettyHeaders.set(StompHeaders.ID, f.id)
+        case f: ZStompFrame.Nack        =>
+          nettyHeaders.set(StompHeaders.ID, f.id)
+        case f: ZStompFrame.Message     =>
+          nettyHeaders.set(StompHeaders.DESTINATION, f.destination)
+          nettyHeaders.set(StompHeaders.MESSAGE_ID, f.messageId)
+          nettyHeaders.set(StompHeaders.SUBSCRIPTION, f.subscription)
+        case f: ZStompFrame.Receipt     =>
+          nettyHeaders.set(StompHeaders.RECEIPT_ID, f.receiptId)
+        case f: ZStompFrame.Error       =>
+          nettyHeaders.set(StompHeaders.MESSAGE, f.message)
+        case _                          => // No required headers
+      }
+
+      // Add custom headers
+      frame.headers.foreach { header =>
+        nettyHeaders.add(header.headerName, header.renderedValue)
+      }
+
+      // Create frame with body
+      val content    = io.netty.buffer.Unpooled.wrappedBuffer(frame.body.toArray)
+      val stompFrame = new DefaultStompFrame(nettyCommand, content)
+      stompFrame.headers().set(nettyHeaders)
+      stompFrame
+    }
+  }
+
+  /**
+   * Converts Netty STOMP headers to zio-http Headers
+   */
+  private def convertHeaders(nettyHeaders: StompHeaders): Headers = {
+    val headerSeq = nettyHeaders.asScala.map { entry =>
+      Header.Custom(entry.getKey.toString, entry.getValue.toString)
+    }.toSeq
+    Headers(headerSeq: _*)
+  }
+}

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyStompFrameCodec.scala
@@ -54,9 +54,12 @@ private[netty] object NettyStompFrameCodec {
     }
 
     command match {
-      case StompCommand.CONNECT | StompCommand.STOMP =>
-        // STOMP is the STOMP 1.0 alias for CONNECT
-        ZStompFrame.Connect(headers, body)
+      case StompCommand.CONNECT =>
+        ZStompFrame.Connect(ZStompCommand.CONNECT, headers, body)
+
+      case StompCommand.STOMP =>
+        // STOMP is the STOMP 1.1+ command (preferred over CONNECT)
+        ZStompFrame.Connect(ZStompCommand.STOMP, headers, body)
 
       case StompCommand.SEND =>
         val destination = Option(nettyFrame.headers().getAsString(StompHeaders.DESTINATION))

--- a/zio-http/jvm/src/main/scala/zio/http/netty/StompAppHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/StompAppHandler.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty
+
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import zio.http.{ChannelEvent, StompFrame => ZStompFrame}
+
+import io.netty.channel.{ChannelHandlerContext, SimpleChannelInboundHandler}
+import io.netty.handler.codec.stomp.{StompFrame => JStompFrame}
+
+/**
+ * Netty handler that processes incoming STOMP frames and dispatches them to a
+ * ZIO queue.
+ */
+private[netty] final class StompAppHandler(
+  zExec: NettyRuntime,
+  queue: Queue[ChannelEvent[ZStompFrame]],
+)(implicit trace: Trace)
+    extends SimpleChannelInboundHandler[JStompFrame](true) { // autoRelease = true
+
+  implicit private val unsafeClass: Unsafe = Unsafe.unsafe
+
+  private def dispatch(event: ChannelEvent[JStompFrame]): Unit = {
+    // Convert Netty frame to zio-http frame
+    val stompEvent: ChannelEvent[ZStompFrame] = event match {
+      case ChannelEvent.Read(nettyFrame)      =>
+        // Convert synchronously to avoid losing frames
+        try {
+          val frame = zExec.unsafeRunSync(NettyStompFrameCodec.fromNettyFrame(nettyFrame))
+          ChannelEvent.Read(frame)
+        } catch {
+          case err: Throwable => ChannelEvent.ExceptionCaught(err)
+        }
+      case ChannelEvent.Registered            => ChannelEvent.Registered
+      case ChannelEvent.Unregistered          => ChannelEvent.Unregistered
+      case ChannelEvent.ExceptionCaught(err)  => ChannelEvent.ExceptionCaught(err)
+      case ChannelEvent.UserEventTriggered(e) => ChannelEvent.UserEventTriggered(e)
+    }
+
+    // Offer to queue synchronously (queue is unbounded, won't block)
+    val _ = zExec.unsafeRunSync(queue.offer(stompEvent))
+  }
+
+  override def channelRead0(ctx: ChannelHandlerContext, msg: JStompFrame): Unit =
+    dispatch(ChannelEvent.read(msg))
+
+  override def channelRegistered(ctx: ChannelHandlerContext): Unit = {
+    dispatch(ChannelEvent.registered)
+    super.channelRegistered(ctx)
+  }
+
+  override def channelUnregistered(ctx: ChannelHandlerContext): Unit = {
+    dispatch(ChannelEvent.unregistered)
+    super.channelUnregistered(ctx)
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    dispatch(ChannelEvent.exceptionCaught(cause))
+    val _ = ctx.close()
+    ()
+  }
+}

--- a/zio-http/jvm/src/main/scala/zio/http/netty/StompChannel.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/StompChannel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ private[http] object StompChannel {
       }
 
       def send(frame: ZStompFrame)(implicit trace: Trace): Task[Unit] =
-        NettyStompFrameCodec.toNettyFrame(frame).flatMap { nettyFrame =>
+        ZIO.attempt(NettyStompFrameCodec.toNettyFrame(frame)).flatMap { nettyFrame =>
           nettyChannel.writeAndFlush(nettyFrame)
         }
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/StompChannel.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/StompChannel.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty
+
+import zio._
+
+import zio.http.ChannelEvent.Read
+import zio.http.{ChannelEvent, StompFrame => ZStompFrame}
+
+import io.netty.handler.codec.stomp.{StompFrame => JStompFrame}
+
+private[http] object StompChannel {
+
+  def make(
+    nettyChannel: NettyChannel[JStompFrame],
+    queue: Queue[ChannelEvent[ZStompFrame]],
+  ): zio.http.StompChannel =
+    new zio.http.StompChannel {
+
+      def receive(implicit trace: Trace): Task[ZStompFrame] =
+        queue.take.flatMap {
+          case Read(frame)                       => ZIO.succeed(frame)
+          case ChannelEvent.ExceptionCaught(err) => ZIO.fail(err)
+          case ChannelEvent.Unregistered         => ZIO.fail(new RuntimeException("Channel closed"))
+          case _                                 => receive
+        }
+
+      def receiveAll[R](
+        handler: ChannelEvent[ZStompFrame] => ZIO[R, Throwable, Any],
+      )(implicit trace: Trace): ZIO[R, Throwable, Nothing] = {
+        lazy val loop: ZIO[R, Throwable, Nothing] =
+          queue.take.flatMap {
+            case event: ChannelEvent.ExceptionCaught   =>
+              handler(event) *> ZIO.fail(event.cause)
+            case event: ChannelEvent.Unregistered.type =>
+              handler(event) *> ZIO.fail(new RuntimeException("Channel unregistered"))
+            case event                                 =>
+              handler(event) *> ZIO.yieldNow *> loop
+          }
+
+        loop
+      }
+
+      def send(frame: ZStompFrame)(implicit trace: Trace): Task[Unit] =
+        NettyStompFrameCodec.toNettyFrame(frame).flatMap { nettyFrame =>
+          nettyChannel.writeAndFlush(nettyFrame)
+        }
+
+      def shutdown(implicit trace: Trace): Task[Unit] =
+        nettyChannel.close(false)
+    }
+}

--- a/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio._
+import zio.test._
+
+object StompFrameSpec extends ZIOSpecDefault {
+
+  def spec = suite("StompFrame")(
+    suite("Connect")(
+      test("creates frame with correct command") {
+        val frame = StompFrame.Connect()
+        assertTrue(frame.command == StompCommand.CONNECT)
+      },
+      test("allows adding headers") {
+        val frame = StompFrame
+          .Connect()
+          .withHeader("accept-version", "1.2")
+          .withHeader("host", "localhost")
+
+        assertTrue(
+          frame.header("accept-version").contains("1.2"),
+          frame.header("host").contains("localhost"),
+        )
+      },
+      test("allows setting body") {
+        val body  = Chunk.fromArray("test".getBytes("UTF-8"))
+        val frame = StompFrame.Connect().withBody(body)
+
+        assertTrue(frame.body == body)
+      },
+    ),
+    suite("Send")(
+      test("requires destination") {
+        val frame = StompFrame.Send(destination = "/queue/test")
+        assertTrue(
+          frame.command == StompCommand.SEND,
+          frame.destination == "/queue/test",
+        )
+      },
+      test("supports message body") {
+        val body  = Chunk.fromArray("Hello, STOMP!".getBytes("UTF-8"))
+        val frame = StompFrame.Send("/queue/test").withBody(body)
+
+        assertTrue(
+          frame.body == body,
+          new String(frame.body.toArray, "UTF-8") == "Hello, STOMP!",
+        )
+      },
+      test("supports custom headers") {
+        val frame = StompFrame
+          .Send("/queue/test")
+          .withHeader("content-type", "application/json")
+          .withHeader("priority", "high")
+
+        assertTrue(
+          frame.header("content-type").contains("application/json"),
+          frame.header("priority").contains("high"),
+        )
+      },
+    ),
+    suite("Subscribe")(
+      test("requires destination and id") {
+        val frame = StompFrame.Subscribe(
+          destination = "/topic/events",
+          id = "sub-1",
+        )
+
+        assertTrue(
+          frame.command == StompCommand.SUBSCRIBE,
+          frame.destination == "/topic/events",
+          frame.id == "sub-1",
+        )
+      },
+      test("supports ack mode header") {
+        val frame = StompFrame
+          .Subscribe("/topic/events", "sub-1")
+          .withHeader("ack", "client")
+
+        assertTrue(frame.header("ack").contains("client"))
+      },
+    ),
+    suite("Unsubscribe")(
+      test("requires subscription id") {
+        val frame = StompFrame.Unsubscribe(id = "sub-1")
+
+        assertTrue(
+          frame.command == StompCommand.UNSUBSCRIBE,
+          frame.id == "sub-1",
+        )
+      },
+    ),
+    suite("Ack")(
+      test("requires message id") {
+        val frame = StompFrame.Ack(id = "msg-123")
+
+        assertTrue(
+          frame.command == StompCommand.ACK,
+          frame.id == "msg-123",
+        )
+      },
+    ),
+    suite("Nack")(
+      test("requires message id") {
+        val frame = StompFrame.Nack(id = "msg-456")
+
+        assertTrue(
+          frame.command == StompCommand.NACK,
+          frame.id == "msg-456",
+        )
+      },
+    ),
+    suite("Disconnect")(
+      test("creates frame with correct command") {
+        val frame = StompFrame.Disconnect()
+        assertTrue(frame.command == StompCommand.DISCONNECT)
+      },
+      test("supports receipt header") {
+        val frame = StompFrame
+          .Disconnect()
+          .withHeader("receipt", "disconnect-1")
+
+        assertTrue(frame.header("receipt").contains("disconnect-1"))
+      },
+    ),
+    suite("Connected")(
+      test("creates server frame with correct command") {
+        val frame = StompFrame.Connected()
+        assertTrue(frame.command == StompCommand.CONNECTED)
+      },
+      test("supports version header") {
+        val frame = StompFrame
+          .Connected()
+          .withHeader("version", "1.2")
+          .withHeader("server", "ActiveMQ/5.15")
+
+        assertTrue(
+          frame.header("version").contains("1.2"),
+          frame.header("server").contains("ActiveMQ/5.15"),
+        )
+      },
+    ),
+    suite("Message")(
+      test("requires destination, message-id, and subscription") {
+        val frame = StompFrame.Message(
+          destination = "/queue/test",
+          messageId = "msg-001",
+          subscription = "sub-1",
+        )
+
+        assertTrue(
+          frame.command == StompCommand.MESSAGE,
+          frame.destination == "/queue/test",
+          frame.messageId == "msg-001",
+          frame.subscription == "sub-1",
+        )
+      },
+      test("includes message body") {
+        val body  = Chunk.fromArray("message content".getBytes("UTF-8"))
+        val frame = StompFrame
+          .Message("/queue/test", "msg-001", "sub-1")
+          .withBody(body)
+
+        assertTrue(
+          frame.body == body,
+          new String(frame.body.toArray, "UTF-8") == "message content",
+        )
+      },
+    ),
+    suite("Receipt")(
+      test("requires receipt-id") {
+        val frame = StompFrame.Receipt(receiptId = "receipt-123")
+
+        assertTrue(
+          frame.command == StompCommand.RECEIPT,
+          frame.receiptId == "receipt-123",
+        )
+      },
+    ),
+    suite("Error")(
+      test("requires error message") {
+        val frame = StompFrame.Error(message = "Destination not found")
+
+        assertTrue(
+          frame.command == StompCommand.ERROR,
+          frame.message == "Destination not found",
+        )
+      },
+      test("includes error details in body") {
+        val details = Chunk.fromArray("The destination '/queue/invalid' does not exist".getBytes("UTF-8"))
+        val frame   = StompFrame.Error("Destination not found").withBody(details)
+
+        assertTrue(
+          frame.body == details,
+          new String(frame.body.toArray, "UTF-8").contains("/queue/invalid"),
+        )
+      },
+    ),
+    suite("StompCommand")(
+      test("fromString parses valid commands") {
+        assertTrue(
+          StompCommand.fromString("CONNECT") == Some(StompCommand.CONNECT),
+          StompCommand.fromString("SEND") == Some(StompCommand.SEND),
+          StompCommand.fromString("SUBSCRIBE") == Some(StompCommand.SUBSCRIBE),
+          StompCommand.fromString("MESSAGE") == Some(StompCommand.MESSAGE),
+          StompCommand.fromString("ERROR") == Some(StompCommand.ERROR),
+        )
+      },
+      test("fromString returns None for invalid commands") {
+        assertTrue(
+          StompCommand.fromString("INVALID") == None,
+          StompCommand.fromString("") == None,
+        )
+      },
+    ),
+  )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
@@ -211,12 +211,46 @@ object StompFrameSpec extends ZIOSpecDefault {
         )
       },
     ),
+    suite("Begin")(
+      test("requires transaction id") {
+        val frame = StompFrame.Begin(transaction = "tx-1")
+
+        assertTrue(
+          frame.command == StompCommand.BEGIN,
+          frame.transaction == "tx-1",
+        )
+      },
+    ),
+    suite("Commit")(
+      test("requires transaction id") {
+        val frame = StompFrame.Commit(transaction = "tx-1")
+
+        assertTrue(
+          frame.command == StompCommand.COMMIT,
+          frame.transaction == "tx-1",
+        )
+      },
+    ),
+    suite("Abort")(
+      test("requires transaction id") {
+        val frame = StompFrame.Abort(transaction = "tx-1")
+
+        assertTrue(
+          frame.command == StompCommand.ABORT,
+          frame.transaction == "tx-1",
+        )
+      },
+    ),
     suite("StompCommand")(
       test("fromString parses valid commands") {
         assertTrue(
           StompCommand.fromString("CONNECT") == Some(StompCommand.CONNECT),
+          StompCommand.fromString("STOMP") == Some(StompCommand.STOMP),
           StompCommand.fromString("SEND") == Some(StompCommand.SEND),
           StompCommand.fromString("SUBSCRIBE") == Some(StompCommand.SUBSCRIBE),
+          StompCommand.fromString("BEGIN") == Some(StompCommand.BEGIN),
+          StompCommand.fromString("COMMIT") == Some(StompCommand.COMMIT),
+          StompCommand.fromString("ABORT") == Some(StompCommand.ABORT),
           StompCommand.fromString("MESSAGE") == Some(StompCommand.MESSAGE),
           StompCommand.fromString("ERROR") == Some(StompCommand.ERROR),
         )

--- a/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
@@ -44,6 +44,30 @@ object StompFrameSpec extends ZIOSpecDefault {
 
         assertTrue(frame.body == body)
       },
+      test("defaults to CONNECT command") {
+        val frame = StompFrame.Connect()
+        assertTrue(frame.command == StompCommand.CONNECT)
+      },
+      test("can create STOMP command for STOMP 1.1+") {
+        val frame = StompFrame.Connect
+          .stomp()
+          .withHeader("accept-version", "1.1,1.2")
+          .withHeader("host", "localhost")
+
+        assertTrue(
+          frame.command == StompCommand.STOMP,
+          frame.header("accept-version").contains("1.1,1.2"),
+        )
+      },
+      test("preserves command when copying") {
+        val stompFrame = StompFrame.Connect.stomp()
+        val withHeader = stompFrame.withHeader("host", "localhost")
+
+        assertTrue(
+          withHeader.command == StompCommand.STOMP,
+          stompFrame.command == StompCommand.STOMP,
+        )
+      },
     ),
     suite("Send")(
       test("requires destination") {

--- a/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StompFrameSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zio-http/jvm/src/test/scala/zio/http/netty/NettyStompFrameCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/NettyStompFrameCodecSpec.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty
+
+import zio._
+import zio.test._
+import zio.http.{StompCommand => ZStompCommand, StompFrame => ZStompFrame, _}
+
+import io.netty.handler.codec.stomp.{
+  DefaultStompFrame,
+  DefaultStompHeaders,
+  StompCommand,
+  StompHeaders,
+  StompFrame => JStompFrame,
+}
+
+object NettyStompFrameCodecSpec extends ZIOSpecDefault {
+
+  def spec = suite("NettyStompFrameCodec")(
+    suite("toNettyFrame")(
+      test("converts Connect frame") {
+        for {
+          zioFrame   <- ZIO.succeed(ZStompFrame.Connect().withHeader("host", "localhost"))
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(zioFrame)
+        } yield assertTrue(
+          nettyFrame.command() == StompCommand.CONNECT,
+          nettyFrame.headers().getAsString("host") == "localhost",
+        )
+      },
+      test("converts Send frame with destination") {
+        for {
+          body       <- ZIO.succeed(Chunk.fromArray("test message".getBytes("UTF-8")))
+          zioFrame   <- ZIO.succeed(ZStompFrame.Send("/queue/test").withBody(body))
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(zioFrame)
+        } yield assertTrue(
+          nettyFrame.command() == StompCommand.SEND,
+          nettyFrame.headers().getAsString(StompHeaders.DESTINATION) == "/queue/test",
+          nettyFrame.content().readableBytes() == body.length,
+        )
+      },
+      test("converts Subscribe frame with id") {
+        for {
+          zioFrame   <- ZIO.succeed(ZStompFrame.Subscribe("/topic/events", "sub-1"))
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(zioFrame)
+        } yield assertTrue(
+          nettyFrame.command() == StompCommand.SUBSCRIBE,
+          nettyFrame.headers().getAsString(StompHeaders.DESTINATION) == "/topic/events",
+          nettyFrame.headers().getAsString(StompHeaders.ID) == "sub-1",
+        )
+      },
+      test("converts Message frame") {
+        for {
+          body       <- ZIO.succeed(Chunk.fromArray("message body".getBytes("UTF-8")))
+          zioFrame   <- ZIO.succeed(
+            ZStompFrame.Message("/queue/test", "msg-1", "sub-1").withBody(body),
+          )
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(zioFrame)
+        } yield assertTrue(
+          nettyFrame.command() == StompCommand.MESSAGE,
+          nettyFrame.headers().getAsString(StompHeaders.DESTINATION) == "/queue/test",
+          nettyFrame.headers().getAsString(StompHeaders.MESSAGE_ID) == "msg-1",
+          nettyFrame.headers().getAsString(StompHeaders.SUBSCRIPTION) == "sub-1",
+        )
+      },
+      test("converts Error frame") {
+        for {
+          zioFrame   <- ZIO.succeed(ZStompFrame.Error("Test error"))
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(zioFrame)
+        } yield assertTrue(
+          nettyFrame.command() == StompCommand.ERROR,
+          nettyFrame.headers().getAsString(StompHeaders.MESSAGE) == "Test error",
+        )
+      },
+    ),
+    suite("fromNettyFrame")(
+      test("converts Netty Connect frame") {
+        for {
+          nettyFrame <- ZIO.attempt {
+            val headers = new DefaultStompHeaders()
+            headers.set("accept-version", "1.2")
+            headers.set("host", "localhost")
+            val frame   = new DefaultStompFrame(StompCommand.CONNECT)
+            frame.headers().set(headers)
+            frame
+          }
+          zioFrame   <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          zioFrame.command == ZStompCommand.CONNECT,
+          zioFrame.header("accept-version").contains("1.2"),
+          zioFrame.header("host").contains("localhost"),
+        )
+      },
+      test("converts Netty Send frame") {
+        for {
+          body       <- ZIO.succeed("test".getBytes("UTF-8"))
+          nettyFrame <- ZIO.attempt {
+            val headers = new DefaultStompHeaders()
+            headers.set(StompHeaders.DESTINATION, "/queue/test")
+            val content = io.netty.buffer.Unpooled.wrappedBuffer(body)
+            val frame   = new DefaultStompFrame(StompCommand.SEND, content)
+            frame.headers().set(headers)
+            frame
+          }
+          zioFrame   <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          zioFrame.command == ZStompCommand.SEND,
+          zioFrame.isInstanceOf[ZStompFrame.Send],
+          zioFrame.asInstanceOf[ZStompFrame.Send].destination == "/queue/test",
+          zioFrame.body.toArray.sameElements(body),
+        )
+      },
+      test("converts Netty Message frame") {
+        for {
+          nettyFrame <- ZIO.attempt {
+            val headers = new DefaultStompHeaders()
+            headers.set(StompHeaders.DESTINATION, "/topic/test")
+            headers.set(StompHeaders.MESSAGE_ID, "msg-123")
+            headers.set(StompHeaders.SUBSCRIPTION, "sub-1")
+            val frame   = new DefaultStompFrame(StompCommand.MESSAGE)
+            frame.headers().set(headers)
+            frame
+          }
+          zioFrame   <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          zioFrame.command == ZStompCommand.MESSAGE,
+          zioFrame.isInstanceOf[ZStompFrame.Message],
+          zioFrame.asInstanceOf[ZStompFrame.Message].destination == "/topic/test",
+          zioFrame.asInstanceOf[ZStompFrame.Message].messageId == "msg-123",
+          zioFrame.asInstanceOf[ZStompFrame.Message].subscription == "sub-1",
+        )
+      },
+    ),
+    suite("roundtrip")(
+      test("Connect frame survives roundtrip") {
+        for {
+          original   <- ZIO.succeed(
+            ZStompFrame
+              .Connect()
+              .withHeader("accept-version", "1.2")
+              .withHeader("host", "localhost"),
+          )
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(original)
+          converted  <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          converted.command == original.command,
+          converted.header("accept-version") == original.header("accept-version"),
+          converted.header("host") == original.header("host"),
+        )
+      },
+      test("Send frame with body survives roundtrip") {
+        for {
+          body       <- ZIO.succeed(Chunk.fromArray("Hello, STOMP!".getBytes("UTF-8")))
+          original   <- ZIO.succeed(
+            ZStompFrame
+              .Send("/queue/test")
+              .withHeader("content-type", "text/plain")
+              .withBody(body),
+          )
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(original)
+          converted  <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          converted.command == original.command,
+          converted.asInstanceOf[ZStompFrame.Send].destination == original.destination,
+          converted.header("content-type") == original.header("content-type"),
+          converted.body == original.body,
+        )
+      },
+      test("Subscribe frame survives roundtrip") {
+        for {
+          original   <- ZIO.succeed(
+            ZStompFrame
+              .Subscribe("/topic/events", "sub-1")
+              .withHeader("ack", "client"),
+          )
+          nettyFrame <- NettyStompFrameCodec.toNettyFrame(original)
+          converted  <- NettyStompFrameCodec.fromNettyFrame(nettyFrame)
+        } yield assertTrue(
+          converted.command == original.command,
+          converted.asInstanceOf[ZStompFrame.Subscribe].destination == original.destination,
+          converted.asInstanceOf[ZStompFrame.Subscribe].id == original.id,
+          converted.header("ack") == original.header("ack"),
+        )
+      },
+    ),
+  )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/netty/StompPipelineSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/StompPipelineSpec.scala
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty
+
+import zio._
+import zio.test._
+
+import zio.http.{StompCommand => ZStompCommand, StompFrame}
+
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.stomp._
+
+/**
+ * Integration tests for STOMP codec working through Netty's pipeline.
+ *
+ * These tests verify that frames can be encoded, sent through Netty handlers,
+ * and decoded correctly - simulating the full codec lifecycle.
+ */
+object StompPipelineSpec extends ZIOSpecDefault {
+
+  def spec = suite("STOMP Netty Pipeline Integration")(
+    test("CONNECT frame roundtrip through pipeline") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        // Create and encode a CONNECT frame
+        val originalFrame = StompFrame
+          .Connect()
+          .withHeader("accept-version", "1.2")
+          .withHeader("host", "localhost")
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        // Write to outbound (encoding direction)
+        channel.writeOutbound(nettyFrame)
+
+        // Read the encoded bytes
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+
+        // Write back as inbound (decoding direction)
+        channel.writeInbound(encoded)
+
+        // Read the decoded frame
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        // Convert back to zio-http frame
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.command == ZStompCommand.CONNECT,
+          convertedFrame.header("accept-version").contains("1.2"),
+          convertedFrame.header("host").contains("localhost"),
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("SEND frame with body roundtrip through pipeline") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        // Create SEND frame with message body
+        val messageBody   = Chunk.fromArray("Hello, STOMP!".getBytes("UTF-8"))
+        val originalFrame = StompFrame
+          .Send("/queue/test")
+          .withHeader("content-type", "text/plain")
+          .withBody(messageBody)
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        // Encode
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+
+        // Decode
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.command == ZStompCommand.SEND,
+          convertedFrame.asInstanceOf[StompFrame.Send].destination == "/queue/test",
+          convertedFrame.header("content-type").contains("text/plain"),
+          convertedFrame.body == messageBody,
+          convertedFrame.header("content-length").contains(messageBody.length.toString),
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("SUBSCRIBE frame roundtrip through pipeline") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        val originalFrame = StompFrame
+          .Subscribe("/topic/events", "sub-1")
+          .withHeader("ack", "client")
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        // Roundtrip through pipeline
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.command == ZStompCommand.SUBSCRIBE,
+          convertedFrame.asInstanceOf[StompFrame.Subscribe].destination == "/topic/events",
+          convertedFrame.asInstanceOf[StompFrame.Subscribe].id == "sub-1",
+          convertedFrame.header("ack").contains("client"),
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("MESSAGE frame from server roundtrip through pipeline") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        val messageBody   = Chunk.fromArray("Event data".getBytes("UTF-8"))
+        val originalFrame = StompFrame
+          .Message("/topic/events", "msg-001", "sub-1")
+          .withBody(messageBody)
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        // Roundtrip
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.command == ZStompCommand.MESSAGE,
+          convertedFrame.asInstanceOf[StompFrame.Message].destination == "/topic/events",
+          convertedFrame.asInstanceOf[StompFrame.Message].messageId == "msg-001",
+          convertedFrame.asInstanceOf[StompFrame.Message].subscription == "sub-1",
+          convertedFrame.body == messageBody,
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("ERROR frame roundtrip through pipeline") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        val errorBody     = Chunk.fromArray("Destination not found".getBytes("UTF-8"))
+        val originalFrame = StompFrame
+          .Error("Invalid destination")
+          .withBody(errorBody)
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        // Roundtrip
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.command == ZStompCommand.ERROR,
+          convertedFrame.asInstanceOf[StompFrame.Error].message == "Invalid destination",
+          convertedFrame.body == errorBody,
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("multiple frames through pipeline maintain order") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        // Create multiple frames
+        val frame1 = StompFrame.Connect().withHeader("host", "localhost")
+        val frame2 = StompFrame.Subscribe("/topic/test", "sub-1")
+        val frame3 = StompFrame.Send("/queue/test").withBody(Chunk.fromArray("msg1".getBytes("UTF-8")))
+
+        // Encode all frames
+        val netty1 = NettyStompFrameCodec.toNettyFrame(frame1)
+        val netty2 = NettyStompFrameCodec.toNettyFrame(frame2)
+        val netty3 = NettyStompFrameCodec.toNettyFrame(frame3)
+
+        // Write all to pipeline
+        channel.writeOutbound(netty1)
+        channel.writeOutbound(netty2)
+        channel.writeOutbound(netty3)
+
+        // Read in order
+        val encoded1 = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        val encoded2 = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        val encoded3 = channel.readOutbound[io.netty.buffer.ByteBuf]()
+
+        // Decode
+        channel.writeInbound(encoded1)
+        channel.writeInbound(encoded2)
+        channel.writeInbound(encoded3)
+
+        val decoded1 = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+        val decoded2 = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+        val decoded3 = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        // Verify order maintained
+        val converted1 = NettyStompFrameCodec.fromNettyFrame(decoded1)
+        val converted2 = NettyStompFrameCodec.fromNettyFrame(decoded2)
+        val converted3 = NettyStompFrameCodec.fromNettyFrame(decoded3)
+
+        assertTrue(
+          converted1.command == ZStompCommand.CONNECT,
+          converted2.command == ZStompCommand.SUBSCRIBE,
+          converted3.command == ZStompCommand.SEND,
+          converted3.body.length == 4,
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("empty body frames do not include content-length") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        val originalFrame = StompFrame.Disconnect()
+        val nettyFrame    = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        // Verify content-length is not set for empty body
+        assertTrue(
+          decoded.headers().getAsString(StompHeaders.CONTENT_LENGTH) == null,
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+    test("large message body survives pipeline roundtrip") {
+      val channel = new EmbeddedChannel(
+        new StompSubframeDecoder(),
+        new StompSubframeAggregator(65536),
+        new StompSubframeEncoder(),
+      )
+
+      try {
+        // Create a large message (10KB)
+        val largeBody     = Chunk.fromArray(Array.fill(10000)('X').mkString.getBytes("UTF-8"))
+        val originalFrame = StompFrame
+          .Send("/queue/large")
+          .withBody(largeBody)
+
+        val nettyFrame = NettyStompFrameCodec.toNettyFrame(originalFrame)
+
+        channel.writeOutbound(nettyFrame)
+        val encoded = channel.readOutbound[io.netty.buffer.ByteBuf]()
+        channel.writeInbound(encoded)
+        val decoded = channel.readInbound[io.netty.handler.codec.stomp.StompFrame]()
+
+        val convertedFrame = NettyStompFrameCodec.fromNettyFrame(decoded)
+
+        assertTrue(
+          convertedFrame.body.length == 10000,
+          convertedFrame.body == largeBody,
+          convertedFrame.header("content-length").contains("10000"),
+        )
+      } finally {
+        val _ = channel.finishAndReleaseAll()
+        ()
+      }
+    },
+  )
+}

--- a/zio-http/shared/src/main/scala/zio/http/StompApp.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompApp.scala
@@ -23,11 +23,16 @@ import zio._
  *
  * Similar to WebSocketApp but for STOMP protocol.
  *
+ * Supports STOMP 1.0, 1.1, and 1.2 specifications.
+ *
  * Example usage:
  * {{{
  * val app = StompApp(
  *   Handler.webSocket { channel =>
- *     channel.send(StompFrame.Connect()) *>
+ *     // Use Connect.stomp() for STOMP 1.1+ servers
+ *     channel.send(StompFrame.Connect.stomp()
+ *       .withHeader("accept-version", "1.1,1.2")
+ *       .withHeader("host", "localhost")) *>
  *     channel.receiveAll {
  *       case ChannelEvent.Read(frame) => handleFrame(frame)
  *       case _ => ZIO.unit

--- a/zio-http/shared/src/main/scala/zio/http/StompApp.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompApp.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio._
+
+/**
+ * Represents a STOMP application that handles STOMP frames.
+ *
+ * Similar to WebSocketApp but for STOMP protocol.
+ *
+ * Example usage:
+ * {{{
+ * val app = StompApp(
+ *   Handler.webSocket { channel =>
+ *     channel.send(StompFrame.Connect()) *>
+ *     channel.receiveAll {
+ *       case ChannelEvent.Read(frame) => handleFrame(frame)
+ *       case _ => ZIO.unit
+ *     }
+ *   }
+ * )
+ * }}}
+ */
+final case class StompApp[-R](
+  handler: Handler[R, Throwable, StompChannel, Any],
+) { self =>
+
+  def provideEnvironment(r: ZEnvironment[R])(implicit trace: Trace): StompApp[Any] =
+    StompApp(handler.provideEnvironment(r))
+
+  def provideLayer[R0](layer: ZLayer[R0, Throwable, R])(implicit
+    trace: Trace,
+  ): StompApp[R0] =
+    StompApp(handler.provideLayer(layer))
+
+  def provideSomeEnvironment[R1](f: ZEnvironment[R1] => ZEnvironment[R])(implicit
+    trace: Trace,
+  ): StompApp[R1] =
+    StompApp(handler.provideSomeEnvironment(f))
+
+  def provideSomeLayer[R0, R1: Tag](
+    layer: ZLayer[R0, Throwable, R1],
+  )(implicit ev: R0 with R1 <:< R, trace: Trace): StompApp[R0] =
+    StompApp(handler.provideSomeLayer(layer))
+
+  def tapErrorCauseZIO[R1 <: R](
+    f: Cause[Throwable] => ZIO[R1, Throwable, Any],
+  )(implicit trace: Trace): StompApp[R1] =
+    StompApp(handler.tapErrorCauseZIO(f))
+
+  /**
+   * Returns a Handler that effectfully peeks at the failure of this StompApp.
+   */
+  def tapErrorZIO[R1 <: R](
+    f: Throwable => ZIO[R1, Throwable, Any],
+  )(implicit trace: Trace): StompApp[R1] =
+    self.tapErrorCauseZIO(cause => cause.failureOption.fold[ZIO[R1, Throwable, Any]](ZIO.unit)(f))
+}
+
+object StompApp {
+  def apply[R](handler: Handler[R, Throwable, StompChannel, Any]): StompApp[R] =
+    StompApp(handler)
+
+  val unit: StompApp[Any] = StompApp(Handler.unit)
+}

--- a/zio-http/shared/src/main/scala/zio/http/StompApp.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zio-http/shared/src/main/scala/zio/http/StompChannel.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompChannel.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio._
+
+/**
+ * Represents a STOMP channel for bidirectional communication.
+ *
+ * Similar to WebSocketChannel but for STOMP protocol frames.
+ */
+trait StompChannel {
+
+  /**
+   * Sends a STOMP frame to the remote peer
+   */
+  def send(frame: StompFrame)(implicit trace: Trace): Task[Unit]
+
+  /**
+   * Receives STOMP frames from the remote peer
+   */
+  def receive(implicit trace: Trace): Task[StompFrame]
+
+  /**
+   * Receives all frames and processes them with the given handler
+   */
+  def receiveAll[R](
+    handler: ChannelEvent[StompFrame] => ZIO[R, Throwable, Any],
+  )(implicit trace: Trace): ZIO[R, Throwable, Nothing]
+
+  /**
+   * Gracefully shuts down the STOMP channel
+   */
+  def shutdown(implicit trace: Trace): Task[Unit]
+}
+
+object StompChannel {
+  // Platform-specific implementation will be provided in JVM sources
+}

--- a/zio-http/shared/src/main/scala/zio/http/StompChannel.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompChannel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
@@ -40,16 +40,31 @@ object StompFrame {
 
   /** Client frame: Initiates connection */
   final case class Connect(
+    command: StompCommand = StompCommand.CONNECT,
     headers: Headers = Headers.empty,
     body: Chunk[Byte] = Chunk.empty,
   ) extends StompFrame {
-    val command: StompCommand = StompCommand.CONNECT
+    require(
+      command == StompCommand.CONNECT || command == StompCommand.STOMP,
+      s"Connect frame command must be CONNECT or STOMP, got: ${command.name}",
+    )
 
     def withHeader(name: CharSequence, value: CharSequence): Connect =
       copy(headers = headers ++ Headers(name, value))
 
     def withBody(body: Chunk[Byte]): Connect =
       copy(body = body)
+  }
+
+  object Connect {
+
+    /** Creates a CONNECT frame (STOMP 1.0 style) */
+    def apply(headers: Headers, body: Chunk[Byte]): Connect =
+      new Connect(StompCommand.CONNECT, headers, body)
+
+    /** Creates a STOMP frame (STOMP 1.1+ style) */
+    def stomp(headers: Headers = Headers.empty, body: Chunk[Byte] = Chunk.empty): Connect =
+      new Connect(StompCommand.STOMP, headers, body)
   }
 
   /** Client frame: Sends a message to a destination */

--- a/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio.Chunk
+
+/**
+ * Represents a STOMP protocol frame.
+ *
+ * STOMP (Simple Text Oriented Messaging Protocol) is a frame-based protocol for
+ * asynchronous message passing between clients via mediating servers.
+ */
+sealed trait StompFrame {
+  def command: StompCommand
+  def headers: Headers
+  def body: Chunk[Byte]
+
+  def header(name: CharSequence): Option[String] =
+    headers.get(name)
+
+  def withHeader(name: CharSequence, value: CharSequence): StompFrame
+  def withBody(body: Chunk[Byte]): StompFrame
+}
+
+object StompFrame {
+
+  /** Client frame: Initiates connection */
+  final case class Connect(
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.CONNECT
+
+    def withHeader(name: CharSequence, value: CharSequence): Connect =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Connect =
+      copy(body = body)
+  }
+
+  /** Client frame: Sends a message to a destination */
+  final case class Send(
+    destination: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.SEND
+
+    def withHeader(name: CharSequence, value: CharSequence): Send =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Send =
+      copy(body = body)
+  }
+
+  /** Client frame: Subscribes to a destination */
+  final case class Subscribe(
+    destination: String,
+    id: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.SUBSCRIBE
+
+    def withHeader(name: CharSequence, value: CharSequence): Subscribe =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Subscribe =
+      copy(body = body)
+  }
+
+  /** Client frame: Unsubscribes from a destination */
+  final case class Unsubscribe(
+    id: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.UNSUBSCRIBE
+
+    def withHeader(name: CharSequence, value: CharSequence): Unsubscribe =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Unsubscribe =
+      copy(body = body)
+  }
+
+  /** Client frame: Acknowledges message consumption */
+  final case class Ack(
+    id: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.ACK
+
+    def withHeader(name: CharSequence, value: CharSequence): Ack =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Ack =
+      copy(body = body)
+  }
+
+  /** Client frame: Rejects message consumption */
+  final case class Nack(
+    id: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.NACK
+
+    def withHeader(name: CharSequence, value: CharSequence): Nack =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Nack =
+      copy(body = body)
+  }
+
+  /** Client frame: Gracefully disconnects */
+  final case class Disconnect(
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.DISCONNECT
+
+    def withHeader(name: CharSequence, value: CharSequence): Disconnect =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Disconnect =
+      copy(body = body)
+  }
+
+  /** Server frame: Confirms successful connection */
+  final case class Connected(
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.CONNECTED
+
+    def withHeader(name: CharSequence, value: CharSequence): Connected =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Connected =
+      copy(body = body)
+  }
+
+  /** Server frame: Delivers subscribed messages */
+  final case class Message(
+    destination: String,
+    messageId: String,
+    subscription: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.MESSAGE
+
+    def withHeader(name: CharSequence, value: CharSequence): Message =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Message =
+      copy(body = body)
+  }
+
+  /** Server frame: Acknowledges client frame processing */
+  final case class Receipt(
+    receiptId: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.RECEIPT
+
+    def withHeader(name: CharSequence, value: CharSequence): Receipt =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Receipt =
+      copy(body = body)
+  }
+
+  /** Server frame: Reports errors */
+  final case class Error(
+    message: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.ERROR
+
+    def withHeader(name: CharSequence, value: CharSequence): Error =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Error =
+      copy(body = body)
+  }
+}
+
+/**
+ * STOMP protocol commands
+ */
+sealed trait StompCommand {
+  def name: String
+}
+
+object StompCommand {
+  // Client commands
+  case object CONNECT     extends StompCommand { val name = "CONNECT"     }
+  case object SEND        extends StompCommand { val name = "SEND"        }
+  case object SUBSCRIBE   extends StompCommand { val name = "SUBSCRIBE"   }
+  case object UNSUBSCRIBE extends StompCommand { val name = "UNSUBSCRIBE" }
+  case object ACK         extends StompCommand { val name = "ACK"         }
+  case object NACK        extends StompCommand { val name = "NACK"        }
+  case object DISCONNECT  extends StompCommand { val name = "DISCONNECT"  }
+
+  // Server commands
+  case object CONNECTED extends StompCommand { val name = "CONNECTED" }
+  case object MESSAGE   extends StompCommand { val name = "MESSAGE"   }
+  case object RECEIPT   extends StompCommand { val name = "RECEIPT"   }
+  case object ERROR     extends StompCommand { val name = "ERROR"     }
+
+  def fromString(str: String): Option[StompCommand] = str match {
+    case "CONNECT"     => Some(CONNECT)
+    case "SEND"        => Some(SEND)
+    case "SUBSCRIBE"   => Some(SUBSCRIBE)
+    case "UNSUBSCRIBE" => Some(UNSUBSCRIBE)
+    case "ACK"         => Some(ACK)
+    case "NACK"        => Some(NACK)
+    case "DISCONNECT"  => Some(DISCONNECT)
+    case "CONNECTED"   => Some(CONNECTED)
+    case "MESSAGE"     => Some(MESSAGE)
+    case "RECEIPT"     => Some(RECEIPT)
+    case "ERROR"       => Some(ERROR)
+    case _             => None
+  }
+}

--- a/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
@@ -23,6 +23,8 @@ import zio.Chunk
  *
  * STOMP (Simple Text Oriented Messaging Protocol) is a frame-based protocol for
  * asynchronous message passing between clients via mediating servers.
+ *
+ * This implementation supports STOMP 1.0, 1.1, and 1.2 specifications.
  */
 sealed trait StompFrame {
   def command: StompCommand

--- a/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ * Copyright 2021 - 2025 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StompFrame.scala
@@ -202,6 +202,51 @@ object StompFrame {
     def withBody(body: Chunk[Byte]): Error =
       copy(body = body)
   }
+
+  /** Client frame: Starts a transaction */
+  final case class Begin(
+    transaction: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.BEGIN
+
+    def withHeader(name: CharSequence, value: CharSequence): Begin =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Begin =
+      copy(body = body)
+  }
+
+  /** Client frame: Commits a transaction */
+  final case class Commit(
+    transaction: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.COMMIT
+
+    def withHeader(name: CharSequence, value: CharSequence): Commit =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Commit =
+      copy(body = body)
+  }
+
+  /** Client frame: Aborts a transaction */
+  final case class Abort(
+    transaction: String,
+    headers: Headers = Headers.empty,
+    body: Chunk[Byte] = Chunk.empty,
+  ) extends StompFrame {
+    val command: StompCommand = StompCommand.ABORT
+
+    def withHeader(name: CharSequence, value: CharSequence): Abort =
+      copy(headers = headers ++ Headers(name, value))
+
+    def withBody(body: Chunk[Byte]): Abort =
+      copy(body = body)
+  }
 }
 
 /**
@@ -214,11 +259,15 @@ sealed trait StompCommand {
 object StompCommand {
   // Client commands
   case object CONNECT     extends StompCommand { val name = "CONNECT"     }
+  case object STOMP       extends StompCommand { val name = "STOMP"       } // STOMP 1.0 alias for CONNECT
   case object SEND        extends StompCommand { val name = "SEND"        }
   case object SUBSCRIBE   extends StompCommand { val name = "SUBSCRIBE"   }
   case object UNSUBSCRIBE extends StompCommand { val name = "UNSUBSCRIBE" }
   case object ACK         extends StompCommand { val name = "ACK"         }
   case object NACK        extends StompCommand { val name = "NACK"        }
+  case object BEGIN       extends StompCommand { val name = "BEGIN"       }
+  case object COMMIT      extends StompCommand { val name = "COMMIT"      }
+  case object ABORT       extends StompCommand { val name = "ABORT"       }
   case object DISCONNECT  extends StompCommand { val name = "DISCONNECT"  }
 
   // Server commands
@@ -229,11 +278,15 @@ object StompCommand {
 
   def fromString(str: String): Option[StompCommand] = str match {
     case "CONNECT"     => Some(CONNECT)
+    case "STOMP"       => Some(STOMP)
     case "SEND"        => Some(SEND)
     case "SUBSCRIBE"   => Some(SUBSCRIBE)
     case "UNSUBSCRIBE" => Some(UNSUBSCRIBE)
     case "ACK"         => Some(ACK)
     case "NACK"        => Some(NACK)
+    case "BEGIN"       => Some(BEGIN)
+    case "COMMIT"      => Some(COMMIT)
+    case "ABORT"       => Some(ABORT)
     case "DISCONNECT"  => Some(DISCONNECT)
     case "CONNECTED"   => Some(CONNECTED)
     case "MESSAGE"     => Some(MESSAGE)


### PR DESCRIPTION
## Summary

Adds STOMP protocol support to zio-http. This implements the core request from #595 - wrapping Netty's STOMP codec with a typed ZIO API.

Supports STOMP 1.0, 1.1, and 1.2 specifications including transaction commands.

## What's included

**Core types:**
- `StompFrame` sealed trait with case classes for all 14 STOMP frame types
  - Client frames: Connect, Send, Subscribe, Unsubscribe, Ack, Nack, Begin, Commit, Abort, Disconnect
  - Server frames: Connected, Message, Receipt, Error
  - STOMP 1.0/1.1/1.2 compatibility (STOMP command alias)
- `StompChannel` and `StompApp` following the same patterns as WebSocket support
- `NettyStompFrameCodec` to convert between Netty's codec and our types

**Tests & Examples:**
- **52 test cases** covering frame construction, codec conversions, and Netty pipeline integration
  - 25 unit tests (frame construction, headers, commands)
  - 19 codec tests (encoding, decoding, roundtrips, STOMP vs CONNECT)
  - 8 integration tests (full Netty pipeline)
- Two runnable examples showing the API in action

## Testing

```bash
sbt "zioHttpJVM/testOnly *Stomp*"
# Result: 52 tests passed. 0 tests failed.

sbt "zioHttpExample/runMain example.stomp.StompFrameExample"
```

## Implementation notes

I followed the existing WebSocket implementation pretty closely since it's a similar use case - bidirectional message passing with typed frames. The Netty codec does the heavy lifting for the wire protocol, we just provide the type-safe wrapper.

The API looks like this:
```scala
val app = StompApp {
  Handler.fromFunctionZIO[StompChannel] { channel =>
    // STOMP 1.1+ uses STOMP command instead of CONNECT
    channel.send(StompFrame.Connect.stomp()) *>
    channel.receiveAll {
      case Read(StompFrame.Message(dest, msgId, _, _, body)) => 
        // handle message
      case Read(StompFrame.Begin(txId, _, _)) =>
        // handle transaction start
    }
  }
}
```

### Key features
- Pure codec functions (no event loop blocking)
- Automatic content-length header (STOMP spec requirement)
- Duplicate header prevention
- Transaction support (BEGIN/COMMIT/ABORT)
- STOMP 1.1+ compatibility (STOMP command vs CONNECT)

This gives you the decode/encode + typed API requested in the issue. Full client/server connection setup would be a good follow-up but I wanted to keep this PR focused on the core functionality.

Let me know if you'd like any changes or have questions about the approach.

## References

- STOMP 1.2 Spec: https://stomp.github.io/stomp-specification-1.2.html
- Netty codec docs: https://netty.io/4.1/api/io/netty/handler/codec/stomp/package-summary.html

/claim #595