### PR TITLE
JSON Schema gen

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -8,7 +8,7 @@ import zio.schema.codec.BinaryCodec
 import zio.http.MediaType
 import zio.http.codec._
 import zio.http.endpoint.Endpoint
-import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaStyle}
+import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaSpec, SchemaStyle}
 import zio.http.endpoint.openapi.OpenAPIGen.{AtomizedMetaCodecs, MetaCodec}
 import zio.http.endpoint.openapi.{JsonSchema, OpenAPIGen}
 
@@ -53,7 +53,7 @@ object HttpGen {
       inAtoms.content.collect {
         case MetaCodec(HttpCodec.Content(codec, _, _), _) if codec.choices.contains(MediaType.application.json) =>
           val schema     = codec.choices(MediaType.application.json).schema
-          val jsonSchema = JsonSchema.fromZSchema(schema, SchemaRef.openApi(SchemaStyle.Inline))
+          val jsonSchema = JsonSchema.fromZSchema(schema, SchemaRef(SchemaSpec.OpenAPI, SchemaStyle.Inline))
           jsonSchema
       }.headOption
   }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -8,6 +8,7 @@ import zio.schema.codec.BinaryCodec
 import zio.http.MediaType
 import zio.http.codec._
 import zio.http.endpoint.Endpoint
+import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaStyle}
 import zio.http.endpoint.openapi.OpenAPIGen.{AtomizedMetaCodecs, MetaCodec}
 import zio.http.endpoint.openapi.{JsonSchema, OpenAPIGen}
 
@@ -52,7 +53,7 @@ object HttpGen {
       inAtoms.content.collect {
         case MetaCodec(HttpCodec.Content(codec, _, _), _) if codec.choices.contains(MediaType.application.json) =>
           val schema     = codec.choices(MediaType.application.json).schema
-          val jsonSchema = JsonSchema.fromZSchema(schema)
+          val jsonSchema = JsonSchema.fromZSchema(schema, SchemaRef.openApi(SchemaStyle.Inline))
           jsonSchema
       }.headOption
   }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -434,8 +434,7 @@ object JsonSchema {
     def toSerializableSchema: SerializableJsonSchema = {
       root.toSerializableSchema.copy(
         schema = Some("https://json-schema.org/draft/2020-12/schema"),
-        defs = Some(children.map { case (key, schema) => key -> schema.toSerializableSchema },
-      ),
+        defs = Some(children.map { case (key, schema) => key -> schema.toSerializableSchema }),
       )
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -420,6 +420,16 @@ object JsonSchema {
       case SegmentCodec.Combined(_, _, _) => throw new IllegalArgumentException("Combined segment is not supported.")
     }
 
+  /**
+   * Represents a complete JSON Schema document, consisting of:
+   *
+   * @param root
+   *   The top-level [[JsonSchema]] for the document.
+   * @param children
+   *   A map of definition names to their corresponding [[JsonSchema]]
+   *   instances. These will be emitted in the `"$defs"` section of the
+   *   serialized schema.
+   */
   case class JsonSchemaRoot(root: JsonSchema, children: Map[java.lang.String, JsonSchema]) {
     def toSerializableSchema: SerializableJsonSchema = {
       root.toSerializableSchema.copy(
@@ -438,7 +448,20 @@ object JsonSchema {
         )(JsonSchemaRoot.schema)
         .encodeJson(this, indent)
 
-    def toJson: java.lang.String       = encodeJson(None).toString
+    /**
+     * Serializes the schema into compact JSON (no pretty-printing).
+     *
+     * @return
+     *   A JSON string containing the serialized schema.
+     */
+    def toJson: java.lang.String = encodeJson(None).toString
+
+    /**
+     * Serializes the schema into human-readable, pretty-printed JSON.
+     *
+     * @return
+     *   A formatted JSON string representing the schema.
+     */
     def toJsonPretty: java.lang.String = encodeJson(Some(0)).toString
   }
 
@@ -454,6 +477,14 @@ object JsonSchema {
       )
   }
 
+  /**
+   * Builds a JSON Schema document from the given ZIO `Schema`
+   *
+   * @param schema
+   *   The schema to convert into a JSON Schema document.
+   * @return
+   *   A [[JsonSchemaRoot]] representing a valid JSON Schema document.
+   */
   def jsonSchema(schema: Schema[_]): JsonSchemaRoot = {
     val path = "#/$defs/"
     val s    = fromZSchemaMulti(schema, SchemaRef(path, SchemaStyle.Compact))

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -50,7 +50,7 @@ private[openapi] case class SerializableJsonSchema(
   exclusiveMaximum: Option[Either[Boolean, Either[Double, Long]]] = None,
   uniqueItems: Option[Boolean] = None,
   minItems: Option[Int] = None,
-  @fieldName("$defs") defs: Map[String, SerializableJsonSchema] = Map.empty
+  @fieldName("$defs") defs: Map[String, SerializableJsonSchema] = Map.empty,
 ) {
   def asNullableType(nullable: Boolean): SerializableJsonSchema = {
     import SerializableJsonSchema.typeNull
@@ -424,7 +424,8 @@ object JsonSchema {
     def toSerializableSchema: SerializableJsonSchema = {
       root.toSerializableSchema.copy(
         schema = Some("https://json-schema.org/draft/2020-12/schema"),
-        defs = children.map { case (key, schema) => key -> schema.toSerializableSchema })
+        defs = children.map { case (key, schema) => key -> schema.toSerializableSchema },
+      )
     }
 
     def encodeJson(indent: Option[Int] = None): CharSequence =
@@ -437,7 +438,7 @@ object JsonSchema {
         )(JsonSchemaRoot.schema)
         .encodeJson(this, indent)
 
-    def toJson: java.lang.String = encodeJson(None).toString
+    def toJson: java.lang.String       = encodeJson(None).toString
     def toJsonPretty: java.lang.String = encodeJson(Some(0)).toString
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -50,7 +50,7 @@ private[openapi] case class SerializableJsonSchema(
   exclusiveMaximum: Option[Either[Boolean, Either[Double, Long]]] = None,
   uniqueItems: Option[Boolean] = None,
   minItems: Option[Int] = None,
-  @fieldName("$defs") defs: Map[String, SerializableJsonSchema] = Map.empty,
+  @fieldName("$defs") defs: Option[Map[String, SerializableJsonSchema]] = None,
 ) {
   def asNullableType(nullable: Boolean): SerializableJsonSchema = {
     import SerializableJsonSchema.typeNull
@@ -434,7 +434,8 @@ object JsonSchema {
     def toSerializableSchema: SerializableJsonSchema = {
       root.toSerializableSchema.copy(
         schema = Some("https://json-schema.org/draft/2020-12/schema"),
-        defs = children.map { case (key, schema) => key -> schema.toSerializableSchema },
+        defs = Some(children.map { case (key, schema) => key -> schema.toSerializableSchema },
+      ),
       )
     }
 
@@ -473,7 +474,7 @@ object JsonSchema {
     private[openapi] def fromSerializableSchema(schema: SerializableJsonSchema): JsonSchemaRoot =
       JsonSchemaRoot(
         JsonSchema.fromSerializableSchema(schema),
-        schema.defs.map { case (key, schema) => key -> JsonSchema.fromSerializableSchema(schema) },
+        schema.defs.getOrElse(Map.empty).map { case (key, schema) => key -> JsonSchema.fromSerializableSchema(schema) },
       )
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -492,7 +492,7 @@ object JsonSchema {
     )
   }
 
-  @deprecated("use fromZSchemaMultiple", "4.0")
+  @deprecated("use fromZSchemaMultiple", "3.8")
   def fromZSchemaMulti(
     schema: Schema[_],
     refType: SchemaStyle = SchemaStyle.Inline,
@@ -922,7 +922,7 @@ object JsonSchema {
     case object Compact extends SchemaStyle
   }
 
-  sealed trait SchemaSpec extends Product with Serializable { def path: java.lang.String }
+  sealed trait SchemaSpec extends Product with Serializable { private[openapi] def path: java.lang.String }
   object SchemaSpec {
 
     /**
@@ -936,7 +936,7 @@ object JsonSchema {
     case object JsonSchema extends SchemaSpec { override def path: java.lang.String = "#/$defs/" }
   }
 
-  case class SchemaRef(spec: SchemaSpec, style: SchemaStyle) {
+  final case class SchemaRef(spec: SchemaSpec, style: SchemaStyle) {
     def inline: SchemaRef    = copy(style = SchemaStyle.Inline)
     def reference: SchemaRef = copy(style = SchemaStyle.Reference)
     def compact: SchemaRef   = copy(style = SchemaStyle.Compact)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -427,8 +427,7 @@ object JsonSchema {
    *   The top-level [[JsonSchema]] for the document.
    * @param children
    *   A map of definition names to their corresponding [[JsonSchema]]
-   *   instances. These will be emitted in the `"$defs"` section of the
-   *   serialized schema.
+   *   instances.
    */
   case class JsonSchemaRoot(root: JsonSchema, children: Map[java.lang.String, JsonSchema]) {
     def toSerializableSchema: SerializableJsonSchema = {

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -1,14 +1,18 @@
 package zio.http.endpoint.openapi
 
 import java.util.UUID
+
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.collection.{immutable, mutable}
+
 import zio._
 import zio.json.ast.Json
+
 import zio.schema.Schema.{Record, Transform}
 import zio.schema.codec.JsonCodec
 import zio.schema.{Schema, TypeId}
+
 import zio.http._
 import zio.http.codec.HttpCodec.Metadata
 import zio.http.codec.HttpCodecType.Content

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -641,7 +641,8 @@ object OpenAPIGen {
     referenceStyle: SchemaStyle = SchemaStyle.Compact,
     genExamples: Boolean,
   ): OpenAPI = {
-    val referenceType = SchemaRef("#/components/schemas/", referenceStyle)
+    val schemaPath = "#/components/schemas/"
+    val referenceType = SchemaRef(schemaPath, referenceStyle)
     val inAtoms       = AtomizedMetaCodecs.flatten(endpoint.input)
     val outs: Map[OpenAPI.StatusOrDefault, Map[MediaType, (JsonSchema, AtomizedMetaCodecs)]] =
       schemaByStatusAndMediaType(
@@ -905,7 +906,7 @@ object OpenAPIGen {
               nominal(jsonSchemaFromCodec(codec).get, referenceStyle).isDefined =>
           val schemas = JsonSchema.fromZSchemaMulti(jsonSchemaFromCodec(codec).get, referenceType)
           schemas.children.map { case (key, schema) =>
-            OpenAPI.Key.fromString(key.replace("#/components/schemas/", "")).get -> OpenAPI.ReferenceOr.Or(schema)
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
           } + (OpenAPI.Key.fromString(nominal(jsonSchemaFromCodec(codec).get, referenceStyle).get).get ->
             OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(jsonSchemaFromCodec(codec).get))))
 
@@ -918,7 +919,7 @@ object OpenAPIGen {
           val schema  = jsonSchemaFromCodec(setCodec).get.asInstanceOf[Schema.Set[_]].elementSchema
           val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
           schemas.children.map { case (key, schema) =>
-            OpenAPI.Key.fromString(key.replace("#/components/schemas/", "")).get -> OpenAPI.ReferenceOr.Or(schema)
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
           } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
             OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
 
@@ -932,7 +933,7 @@ object OpenAPIGen {
           val schema  = jsonSchemaFromCodec(seqCodec).get.asInstanceOf[Schema.Sequence[_, _, _]].elementSchema
           val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
           schemas.children.map { case (key, schema) =>
-            OpenAPI.Key.fromString(key.replace("#/components/schemas/", "")).get -> OpenAPI.ReferenceOr.Or(schema)
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
           } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
             OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
 
@@ -946,7 +947,7 @@ object OpenAPIGen {
           val schema  = jsonSchemaFromCodec(mapCodec).get.asInstanceOf[Schema.Map[_, _]].valueSchema
           val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
           schemas.children.map { case (key, schema) =>
-            OpenAPI.Key.fromString(key.replace("#/components/schemas/", "")).get -> OpenAPI.ReferenceOr.Or(schema)
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
           } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
             OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
 
@@ -957,7 +958,7 @@ object OpenAPIGen {
             ).isDefined =>
           val schemas = JsonSchema.fromZSchemaMulti(jsonSchemaFromCodec(codec).get, referenceType)
           schemas.children.map { case (key, schema) =>
-            OpenAPI.Key.fromString(key.replace("#/components/schemas/", "")).get -> OpenAPI.ReferenceOr.Or(schema)
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
           } + (OpenAPI.Key.fromString(nominal(jsonSchemaFromCodec(codec).get, referenceStyle).get).get ->
             OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(jsonSchemaFromCodec(codec).get))))
       }.flatten.toMap
@@ -1167,8 +1168,8 @@ object OpenAPIGen {
   }
   private def schemaReferencePath(nominal: TypeId.Nominal, referenceType: SchemaRef): String = {
     referenceType.style match {
-      case SchemaStyle.Compact => s"${referenceType.prefix}${nominal.typeName}"
-      case _                   => s"${referenceType.prefix}${nominal.fullyQualified.replace(".", "_")}}"
+      case SchemaStyle.Compact => s"${referenceType.path}${nominal.typeName}"
+      case _                   => s"${referenceType.path}${nominal.fullyQualified.replace(".", "_")}}"
     }
   }
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -902,26 +902,69 @@ object OpenAPIGen {
       codec.lookup(MediaType.application.json).map(_._2.schema)
 
     def componentSchemas: Map[OpenAPI.Key, OpenAPI.ReferenceOr[JsonSchema]] =
-      (endpoint.input.alternatives ++ endpoint.error.alternatives ++ endpoint.output.alternatives).flatMap {
-        case (codec, _) => AtomizedMetaCodecs.flatten(codec).content
-      }.flatMap {
-        case MetaCodec(HttpCodec.Content(codec, _, _), _) =>
-          jsonSchemaFromCodec(codec)
-            .filter(nominal(_, referenceStyle).isDefined)
-            .map {
-              case s: Schema.Set[_]            => s.elementSchema
-              case s: Schema.Sequence[_, _, _] => s.elementSchema
-              case s: Schema.Map[_, _]         => s.valueSchema
-              case s                           => s
-            }
-            .map { schema =>
-              val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
-              schemas.children.map { case (key, schema) =>
-                OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
-              } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
-                OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
-            }
-        case _                                            => None
+      (endpoint.input.alternatives.map(_._1).map(AtomizedMetaCodecs.flatten(_)).flatMap(_.content)
+        ++ endpoint.error.alternatives.map(_._1).map(AtomizedMetaCodecs.flatten(_)).flatMap(_.content)
+        ++ endpoint.output.alternatives.map(_._1).map(AtomizedMetaCodecs.flatten(_)).flatMap(_.content)).collect {
+        case MetaCodec(HttpCodec.Content(codec, _, _), _)
+            if jsonSchemaFromCodec(codec).isDefined &&
+              nominal(jsonSchemaFromCodec(codec).get, referenceStyle).isDefined =>
+          val schemas = JsonSchema.fromZSchemaMulti(jsonSchemaFromCodec(codec).get, referenceType)
+          schemas.children.map { case (key, schema) =>
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
+          } + (OpenAPI.Key.fromString(nominal(jsonSchemaFromCodec(codec).get, referenceStyle).get).get ->
+            OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(jsonSchemaFromCodec(codec).get))))
+
+        case MetaCodec(HttpCodec.Content(setCodec, _, _), _)
+            if jsonSchemaFromCodec(setCodec).isDefined && jsonSchemaFromCodec(setCodec).get.isInstanceOf[Schema.Set[_]]
+              && nominal(
+                jsonSchemaFromCodec(setCodec).get.asInstanceOf[Schema.Set[_]].elementSchema,
+                referenceStyle,
+              ).isDefined =>
+          val schema  = jsonSchemaFromCodec(setCodec).get.asInstanceOf[Schema.Set[_]].elementSchema
+          val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
+          schemas.children.map { case (key, schema) =>
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
+          } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
+            OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
+
+        case MetaCodec(HttpCodec.Content(seqCodec, _, _), _)
+            if jsonSchemaFromCodec(seqCodec).isDefined && jsonSchemaFromCodec(seqCodec).get
+              .isInstanceOf[Schema.Sequence[_, _, _]]
+              && nominal(
+                jsonSchemaFromCodec(seqCodec).get.asInstanceOf[Schema.Sequence[_, _, _]].elementSchema,
+                referenceStyle,
+              ).isDefined =>
+          val schema  = jsonSchemaFromCodec(seqCodec).get.asInstanceOf[Schema.Sequence[_, _, _]].elementSchema
+          val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
+          schemas.children.map { case (key, schema) =>
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
+          } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
+            OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
+
+        case MetaCodec(HttpCodec.Content(mapCodec, _, _), _)
+            if jsonSchemaFromCodec(mapCodec).isDefined && jsonSchemaFromCodec(mapCodec).get
+              .isInstanceOf[Schema.Map[_, _]]
+              && nominal(
+                jsonSchemaFromCodec(mapCodec).get.asInstanceOf[Schema.Map[_, _]].valueSchema,
+                referenceStyle,
+              ).isDefined =>
+          val schema  = jsonSchemaFromCodec(mapCodec).get.asInstanceOf[Schema.Map[_, _]].valueSchema
+          val schemas = JsonSchema.fromZSchemaMulti(schema, referenceType)
+          schemas.children.map { case (key, schema) =>
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
+          } + (OpenAPI.Key.fromString(nominal(schema, referenceStyle).get).get ->
+            OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(schema))))
+
+        case MetaCodec(HttpCodec.ContentStream(codec, _, _), _)
+            if jsonSchemaFromCodec(codec).isDefined && nominal(
+              jsonSchemaFromCodec(codec).get,
+              referenceStyle,
+            ).isDefined =>
+          val schemas = JsonSchema.fromZSchemaMulti(jsonSchemaFromCodec(codec).get, referenceType)
+          schemas.children.map { case (key, schema) =>
+            OpenAPI.Key.fromString(key.replace(schemaPath, "")).get -> OpenAPI.ReferenceOr.Or(schema)
+          } + (OpenAPI.Key.fromString(nominal(jsonSchemaFromCodec(codec).get, referenceStyle).get).get ->
+            OpenAPI.ReferenceOr.Or(schemas.root.discriminator(genDiscriminator(jsonSchemaFromCodec(codec).get))))
       }.flatten.toMap
 
     def httpSecuritySchemes(

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -10,7 +10,7 @@ import zio.test._
 import zio.schema.annotation.discriminatorName
 import zio.schema.{DeriveSchema, Schema}
 
-import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaStyle}
+import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaSpec, SchemaStyle}
 import zio.http.endpoint.openapi.OpenAPI.ReferenceOr
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme._
 
@@ -76,7 +76,8 @@ object OpenAPISpec extends ZIOSpecDefault {
     },
     test("JsonSchema.fromZSchemaMulti correctly handles Map schema with List as Value") {
       val schema           = Schema.map[String, List[String]]
-      val sch: JsonSchemas = JsonSchema.fromZSchemaMultiple(schema, SchemaRef.openApi(SchemaStyle.Reference))
+      val sch: JsonSchemas =
+        JsonSchema.fromZSchemaMultiple(schema, SchemaRef(SchemaSpec.OpenAPI, SchemaStyle.Reference))
 
       val isSchemaProperlyGenerated = if (sch.root.isCollection) sch.root match {
         case JsonSchema.Object(_, additionalProperties, _) =>
@@ -92,7 +93,7 @@ object OpenAPISpec extends ZIOSpecDefault {
     },
     test("JsonSchema.fromZSchema correctly handles Map with non-simple string keys") {
       val schema   = Schema.map[UUID, String]
-      val js       = JsonSchema.fromZSchema(schema, SchemaRef.openApi(SchemaStyle.Inline))
+      val js       = JsonSchema.fromZSchema(schema, SchemaRef(SchemaSpec.OpenAPI, SchemaStyle.Inline))
       val oapi     = OpenAPI.empty.copy(
         components =
           Some(OpenAPI.Components(schemas = ListMap(OpenAPI.Key.fromString("IdToName").get -> ReferenceOr.Or(js)))),

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -76,7 +76,7 @@ object OpenAPISpec extends ZIOSpecDefault {
     },
     test("JsonSchema.fromZSchemaMulti correctly handles Map schema with List as Value") {
       val schema           = Schema.map[String, List[String]]
-      val sch: JsonSchemas = JsonSchema.fromZSchemaMulti(schema, SchemaRef("", SchemaStyle.Reference))
+      val sch: JsonSchemas = JsonSchema.fromZSchemaMultiple(schema, SchemaRef.openApi(SchemaStyle.Reference))
 
       val isSchemaProperlyGenerated = if (sch.root.isCollection) sch.root match {
         case JsonSchema.Object(_, additionalProperties, _) =>
@@ -92,7 +92,7 @@ object OpenAPISpec extends ZIOSpecDefault {
     },
     test("JsonSchema.fromZSchema correctly handles Map with non-simple string keys") {
       val schema   = Schema.map[UUID, String]
-      val js       = JsonSchema.fromZSchema(schema)
+      val js       = JsonSchema.fromZSchema(schema, SchemaRef.openApi(SchemaStyle.Inline))
       val oapi     = OpenAPI.empty.copy(
         components =
           Some(OpenAPI.Components(schemas = ListMap(OpenAPI.Key.fromString("IdToName").get -> ReferenceOr.Or(js)))),
@@ -205,8 +205,6 @@ object OpenAPISpec extends ZIOSpecDefault {
                        |  },
                        |  "$schema" : "https://json-schema.org/draft/2020-12/schema"
                        |}""".stripMargin
-
-      println(json)
 
       assertTrue(toJsonAst(json) == toJsonAst(expected))
     },

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -131,7 +131,6 @@ object OpenAPISpec extends ZIOSpecDefault {
       val jsonSchema = JsonSchema.jsonSchema(schemaTestSchema)
       val json       = jsonSchema.toJsonPretty
       val expected   = """{
-                       |  "$schema" : "https://json-schema.org/draft/2020-12/schema",
                        |  "type" : "object",
                        |  "properties" : {
                        |    "number" : {
@@ -203,7 +202,8 @@ object OpenAPISpec extends ZIOSpecDefault {
                        |        }
                        |      }
                        |    }
-                       |  }
+                       |  },
+                       |  "$schema" : "https://json-schema.org/draft/2020-12/schema"
                        |}""".stripMargin
 
       println(json)

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -130,81 +130,80 @@ object OpenAPISpec extends ZIOSpecDefault {
     test("JsonSchema.jsonSchema correctly generate valid Json Schema with $defs and associated $ref") {
       val jsonSchema = JsonSchema.jsonSchema(schemaTestSchema)
       val json       = jsonSchema.toJsonPretty
-      val expected   = """{
-                       |  "type" : "object",
-                       |  "properties" : {
-                       |    "number" : {
-                       |      "type" : "integer",
-                       |      "format" : "int32"
-                       |    },
-                       |    "string" : {
-                       |      "type" : "string"
-                       |    },
-                       |    "child" : {
-                       |      "anyOf" : [
-                       |        {
-                       |          "type" : "null"
-                       |        },
-                       |        {
-                       |          "$ref" : "#/$defs/SealedTrait"
-                       |        }
-                       |      ]
-                       |    }
-                       |  },
-                       |  "required" : [
-                       |    "number",
-                       |    "string"
-                       |  ],
-                       |  "$defs" : {
-                       |    "One" : {
-                       |      "type" : "object",
-                       |      "properties" : {
-                       |        "set" : {
-                       |          "type" : "array",
-                       |          "items" : {
-                       |            "type" : "string"
-                       |          },
-                       |          "uniqueItems" : true
-                       |        }
-                       |      },
-                       |      "required" : [
-                       |        "set"
-                       |      ]
-                       |    },
-                       |    "Two" : {
-                       |      "type" : "object",
-                       |      "properties" : {
-                       |        "list" : {
-                       |          "type" : "array",
-                       |          "items" : {
-                       |            "type" : "string"
-                       |          }
-                       |        }
-                       |      },
-                       |      "required" : [
-                       |        "list"
-                       |      ]
-                       |    },
-                       |    "SealedTrait" : {
-                       |      "oneOf" : [
-                       |        {
-                       |          "$ref" : "#/$defs/One"
-                       |        },
-                       |        {
-                       |          "$ref" : "#/$defs/Two"
-                       |        }
-                       |      ],
-                       |      "discriminator" : {
-                       |        "propertyName" : "type",
-                       |        "mapping" : {
-                       |          "One" : "#/$defs/One",
-                       |          "Two" : "#/$defs/Two"
-                       |        }
-                       |      }
-                       |    }
-                       |  },
-                       |  "$schema" : "https://json-schema.org/draft/2020-12/schema"
-                       |}""".stripMargin
+      val expected   = f"""{"$$schema" : "https://json-schema.org/draft/2020-12/schema",""" +
+        """  "type" : "object",
+          |  "properties" : {
+          |    "number" : {
+          |      "type" : "integer",
+          |      "format" : "int32"
+          |    },
+          |    "string" : {
+          |      "type" : "string"
+          |    },
+          |    "child" : {
+          |      "anyOf" : [
+          |        {
+          |          "type" : "null"
+          |        },
+          |        {
+          |          "$ref" : "#/$defs/SealedTrait"
+          |        }
+          |      ]
+          |    }
+          |  },
+          |  "required" : [
+          |    "number",
+          |    "string"
+          |  ],
+          |  "$defs" : {
+          |    "One" : {
+          |      "type" : "object",
+          |      "properties" : {
+          |        "set" : {
+          |          "type" : "array",
+          |          "items" : {
+          |            "type" : "string"
+          |          },
+          |          "uniqueItems" : true
+          |        }
+          |      },
+          |      "required" : [
+          |        "set"
+          |      ]
+          |    },
+          |    "Two" : {
+          |      "type" : "object",
+          |      "properties" : {
+          |        "list" : {
+          |          "type" : "array",
+          |          "items" : {
+          |            "type" : "string"
+          |          }
+          |        }
+          |      },
+          |      "required" : [
+          |        "list"
+          |      ]
+          |    },
+          |    "SealedTrait" : {
+          |      "oneOf" : [
+          |        {
+          |          "$ref" : "#/$defs/One"
+          |        },
+          |        {
+          |          "$ref" : "#/$defs/Two"
+          |        }
+          |      ],
+          |      "discriminator" : {
+          |        "propertyName" : "type",
+          |        "mapping" : {
+          |          "One" : "#/$defs/One",
+          |          "Two" : "#/$defs/Two"
+          |        }
+          |      }
+          |    }
+          |  }
+          |}""".stripMargin
 
       assertTrue(toJsonAst(json) == toJsonAst(expected))
     },

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -1,14 +1,18 @@
 package zio.http.endpoint.openapi
 
 import java.util.UUID
+
 import scala.collection.immutable.ListMap
+
 import zio.json.ast.Json
 import zio.test._
+
+import zio.schema.annotation.discriminatorName
 import zio.schema.{DeriveSchema, Schema}
+
 import zio.http.endpoint.openapi.JsonSchema.{SchemaRef, SchemaStyle}
 import zio.http.endpoint.openapi.OpenAPI.ReferenceOr
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme._
-import zio.schema.annotation.discriminatorName
 
 object OpenAPISpec extends ZIOSpecDefault {
 


### PR DESCRIPTION
This PR introduces a new JsonSchema.jsonSchema(schema: Schema[_]) function that generates a fully compliant JSON Schema document.

The existing JsonSchema encoder already supports nearly all the structures required for generating JSON Schema. However, OpenAPI-style output expects definitions under components/schemas, while JSON Schema requires them under the top-level "$defs" key.  This makes necessary changes to support that.
