### PR TITLE
[Datastar] Implement Datastar expressions for Endpoint invocations

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
@@ -16,7 +16,7 @@ import zio.http.codec._
 import zio.http.endpoint._
 import zio.http.template2._
 
-trait DatastarPackageBase extends Attributes {
+trait DatastarPackageBase extends Attributes with InvocationExtensions {
   self =>
   private val headers = Headers(
     Header.CacheControl.NoCache,
@@ -178,7 +178,7 @@ trait DatastarPackageBase extends Attributes {
     ((patchElementsCodec | executeScriptCodec).transform(_.merge) {
       case e: DatastarEvent.PatchElements => Left(e)
       case e: DatastarEvent.ExecuteScript => Right(e)
-      case e: DatastarEvent.PatchSignals  => throw new Exception("Unreachable")
+      case _: DatastarEvent.PatchSignals  => throw new Exception("Unreachable")
     } | patchSignalsCodec).transform(_.merge) {
       case e: DatastarEvent.PatchElements => Left(e)
       case e: DatastarEvent.ExecuteScript => Left(e)

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/InvocationExtensions.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/InvocationExtensions.scala
@@ -1,0 +1,46 @@
+package zio.http.datastar
+
+import java.nio.charset.StandardCharsets
+
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint._
+
+trait InvocationExtensions {
+  implicit class InvocationOps[P, I, E, O, A <: AuthType](val invocation: Invocation[P, I, E, O, A]) {
+
+    def datastarRequest: String = {
+      val request = invocation.endpoint.input.encodeRequest(invocation.input)
+      val url     = request.url.encode
+      val method  = request.method
+
+      val bodyOption = request.body match {
+        case b: Body.StringBody => Some(b.data)
+        case b: Body.ArrayBody  => Some(new String(b.data, StandardCharsets.UTF_8))
+        case b: Body.ChunkBody  => Some(new String(b.data.toArray, StandardCharsets.UTF_8))
+        case _                  => None
+      }
+
+      val methodStr = method.toString.toLowerCase
+
+      bodyOption match {
+        case Some(body) if method != Method.GET =>
+          val escapedBody = body.replace("'", "\\'")
+          val contentType = request.headers.get(Header.ContentType).map(_.mediaType.fullType)
+
+          val options = new StringBuilder
+          options.append("{")
+          options.append(s"body: '$escapedBody'")
+          contentType.foreach { ct =>
+            options.append(s", contentType: '$ct'")
+          }
+          options.append("}")
+
+          s"$$$$$methodStr('$url', $options)"
+
+        case _ =>
+          s"$$$$$methodStr('$url')"
+      }
+    }
+  }
+}

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/InvocationExtensionsSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/InvocationExtensionsSpec.scala
@@ -1,0 +1,40 @@
+package zio.http.datastar
+
+import zio.test._
+
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint._
+
+object InvocationExtensionsSpec extends ZIOSpecDefault {
+
+  case class User(name: String, age: Int)
+  object User { implicit val schema: Schema[User] = DeriveSchema.gen[User] }
+
+  override def spec = suite("InvocationExtensionsSpec")(
+    test("GET request with path param") {
+      val endpoint   = Endpoint(Method.GET / "users" / int("id"))
+      val invocation = endpoint(123)
+      val expression = invocation.datastarRequest
+      assertTrue(expression == "$$get('/users/123')")
+    },
+    test("POST request with body") {
+      val endpoint   = Endpoint(Method.POST / "users").in[User]
+      val invocation = endpoint(User("Alice", 30))
+      val expression = invocation.datastarRequest
+
+      val expectedBody = """{"name":"Alice","age":30}"""
+      val expected     = s"$$$$post('/users', {body: '$expectedBody', contentType: 'application/json'})"
+
+      assertTrue(expression == expected)
+    },
+    test("POST request with query param") {
+      val endpoint   = Endpoint(Method.POST / "search").query(HttpCodec.query[String]("q"))
+      val invocation = endpoint("foo")
+      val expression = invocation.datastarRequest
+      assertTrue(expression == "$$post('/search?q=foo')")
+    },
+  )
+}


### PR DESCRIPTION
Fixes #3697
/claim #3697

### Description
This PR implements the `datastarRequest` extension method for `Invocation`. It allows generating Datastar expression strings directly from ZIO HTTP Endpoint invocations.

It handles:
- Path parameter interpolation.
- Query parameter serialization.
- JSON body serialization.

### Verification
I have run sbt fmt and verified that all tests pass with sbt test.

### Demo Video
https://github.com/user-attachments/assets/e2e12560-244f-479d-bdc3-d707e0672511