### PR TITLE
Allow : and @ unescaped in URL path and query

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -160,6 +160,11 @@ object URLSpec extends ZIOHttpSpec {
           val expected = Right(host + channels)
           assertTrue(actual == expected)
         },
+        test("does not escape valid characters") {
+          check(HttpGen.nonEmptyPath) { path =>
+            assertTrue(URL(path = path).encode == path.encode)
+          }
+        }
       ),
       suite("builder")(
         test("creates a URL with all attributes set") {

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -162,7 +162,9 @@ object URLSpec extends ZIOHttpSpec {
         },
         test("does not escape valid characters") {
           check(HttpGen.nonEmptyPath) { path =>
-            assertTrue(URL(path = path).encode == path.encode)
+            val urlEncode  = URL(path = path).encode
+            val pathEncode = path.encode
+            assertTrue(urlEncode == pathEncode)
           }
         },
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -164,7 +164,7 @@ object URLSpec extends ZIOHttpSpec {
           check(HttpGen.nonEmptyPath) { path =>
             assertTrue(URL(path = path).encode == path.encode)
           }
-        }
+        },
       ),
       suite("builder")(
         test("creates a URL with all attributes set") {

--- a/zio-http/jvm/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/HttpGen.scala
@@ -30,16 +30,16 @@ import zio.http._
 object HttpGen {
   def pcharUriChar(implicit trace: Trace): Gen[Any, Char] =
     Gen.weighted(
-      Gen.char(48, 57) -> 10,  // digits
-      Gen.char(65, 90) -> 26,  // uppercase letters
+      Gen.char(48, 57)  -> 10, // digits
+      Gen.char(65, 90)  -> 26, // uppercase letters
       Gen.char(97, 122) -> 26, // lowercase letters
-      Gen.const('-') -> 1,
-      Gen.const('.') -> 1,
-      Gen.const('_') -> 1,
-      Gen.const('~') -> 1,
-      Gen.const('*') -> 1,
-      Gen.const(':') -> 1,
-      Gen.const('@') -> 1,
+      Gen.const('-')    -> 1,
+      Gen.const('.')    -> 1,
+      Gen.const('_')    -> 1,
+      Gen.const('~')    -> 1,
+      Gen.const('*')    -> 1,
+      Gen.const(':')    -> 1,
+      Gen.const('@')    -> 1,
     )
 
   def anyPath: Gen[Any, Path] = for {

--- a/zio-http/jvm/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/HttpGen.scala
@@ -28,6 +28,20 @@ import zio.http.URL.Location
 import zio.http._
 
 object HttpGen {
+  def pcharUriChar(implicit trace: Trace): Gen[Any, Char] =
+    Gen.weighted(
+      Gen.char(48, 57) -> 10,  // digits
+      Gen.char(65, 90) -> 26,  // uppercase letters
+      Gen.char(97, 122) -> 26, // lowercase letters
+      Gen.const('-') -> 1,
+      Gen.const('.') -> 1,
+      Gen.const('_') -> 1,
+      Gen.const('~') -> 1,
+      Gen.const('*') -> 1,
+      Gen.const(':') -> 1,
+      Gen.const('@') -> 1,
+    )
+
   def anyPath: Gen[Any, Path] = for {
     flags    <- Gen.boolean.zip(Gen.boolean).map { case (left, right) =>
       var flags = 0
@@ -37,7 +51,7 @@ object HttpGen {
     }
     segments <- Gen.listOfBounded(0, 5)(
       Gen.oneOf(
-        Gen.alphaNumericStringBounded(0, 5),
+        Gen.stringBounded(0, 5)(pcharUriChar),
       ),
     )
   } yield Path(flags, Chunk.fromIterable(segments))
@@ -51,7 +65,7 @@ object HttpGen {
     }
     segments <- Gen.listOfBounded(1, 5)(
       Gen.oneOf(
-        Gen.alphaNumericStringBounded(0, 5),
+        Gen.stringBounded(0, 5)(pcharUriChar),
       ),
     )
   } yield Path(flags, Chunk.fromIterable(segments))

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryParamEncoding.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryParamEncoding.scala
@@ -241,13 +241,7 @@ private[http] object QueryParamEncoding {
     val bytesLen = bytes.length
     while (k < bytesLen) {
       val unsignedByte = bytes(k) & 0xff
-      if (
-        (unsignedByte >= 'a' && unsignedByte <= 'z') ||
-        (unsignedByte >= 'A' && unsignedByte <= 'Z') ||
-        (unsignedByte >= '0' && unsignedByte <= '9') ||
-        unsignedByte == '-' || unsignedByte == '.' ||
-        unsignedByte == '_' || unsignedByte == '~' || unsignedByte == '*'
-      ) {
+      if (needsNoEncoding(unsignedByte.toChar)) {
         // Unreserved character
         target.append(unsignedByte.toChar)
       } else if (unsignedByte == ' ') {
@@ -267,6 +261,6 @@ private[http] object QueryParamEncoding {
     (c >= 'a' && c <= 'z') ||
     (c >= 'A' && c <= 'Z') ||
     (c >= '0' && c <= '9') ||
-    c == '-' || c == '.' || c == '_' || c == '~' || c == '*'
+    c == '-' || c == '.' || c == '_' || c == '~' || c == '*' || c == ':' || c == '@'
   }
 }


### PR DESCRIPTION
RFC 3986 explicitly allows both `:` and `@` to appear unescaped in URL **path segments** and **query strings** (`pchar`):

```
pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
```

However, zio-http currently percent-encodes these characters even when they appear in contexts where they are treated as data rather than delimiters.

This PR updates URL rendering to allow `:` and `@` to remain unescaped in path and query segments both using the `encodeComponentInto` function.

I specifically required this change when using google validateAddress API with URL  `https://addressvalidation.googleapis.com/v1:validateAddress` that does not work when it is percent-encoded.

**References**

* RFC 3986 §3.3 (Path)
* RFC 3986 §3.4 (Query)

