### PR TITLE
feat: Add HTTP Range header support for file serving

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -21,7 +21,7 @@ import java.io.File
 import zio._
 import zio.test.Assertion._
 import zio.test.TestAspect.{mac, os, sequential, unix, withLiveClock}
-import zio.test.{assertZIO, assertTrue}
+import zio.test.{assertTrue, assertZIO}
 
 import zio.http.internal.{DynamicServer, RoutesRunnableSpec, serverTestLayer}
 

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -129,7 +129,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         ZIO.blocking {
           for {
             tmpFile <- ZIO.succeed {
-              val f = File.createTempFile("range-test", ".txt")
+              val f      = File.createTempFile("range-test", ".txt")
               val writer = new java.io.FileWriter(f)
               writer.write("0123456789abcdefghij")
               writer.close()
@@ -139,7 +139,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
             request = Request.get(url"/file").addHeader(Header.Range.Single("bytes", 0, Some(9)))
             handler = Handler.fromFileWithRange(ZIO.succeed(tmpFile), request).sandbox
             response <- handler.toRoutes.deploy.run()
-            body <- response.body.asString
+            body     <- response.body.asString
           } yield assertTrue(
             response.status == Status.PartialContent,
             body == "0123456789",
@@ -152,7 +152,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         ZIO.blocking {
           for {
             tmpFile <- ZIO.succeed {
-              val f = File.createTempFile("range-invalid", ".txt")
+              val f      = File.createTempFile("range-invalid", ".txt")
               val writer = new java.io.FileWriter(f)
               writer.write("short")
               writer.close()
@@ -172,7 +172,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         ZIO.blocking {
           for {
             tmpFile <- ZIO.succeed {
-              val f = File.createTempFile("full-file", ".txt")
+              val f      = File.createTempFile("full-file", ".txt")
               val writer = new java.io.FileWriter(f)
               writer.write("content")
               writer.close()
@@ -192,7 +192,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         ZIO.blocking {
           for {
             tmpFile <- ZIO.succeed {
-              val f = File.createTempFile("suffix-test", ".txt")
+              val f      = File.createTempFile("suffix-test", ".txt")
               val writer = new java.io.FileWriter(f)
               writer.write("0123456789")
               writer.close()
@@ -202,7 +202,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
             request = Request.get(url"/file").addHeader(Header.Range.Suffix("bytes", 5))
             handler = Handler.fromFileWithRange(ZIO.succeed(tmpFile), request).sandbox
             response <- handler.toRoutes.deploy.run()
-            body <- response.body.asString
+            body     <- response.body.asString
           } yield assertTrue(
             response.status == Status.PartialContent,
             body == "56789",
@@ -213,7 +213,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         ZIO.blocking {
           for {
             tmpFile <- ZIO.succeed {
-              val f = File.createTempFile("prefix-test", ".txt")
+              val f      = File.createTempFile("prefix-test", ".txt")
               val writer = new java.io.FileWriter(f)
               writer.write("0123456789")
               writer.close()
@@ -223,7 +223,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
             request = Request.get(url"/file").addHeader(Header.Range.Prefix("bytes", 5))
             handler = Handler.fromFileWithRange(ZIO.succeed(tmpFile), request).sandbox
             response <- handler.toRoutes.deploy.run()
-            body <- response.body.asString
+            body     <- response.body.asString
           } yield assertTrue(
             response.status == Status.PartialContent,
             body == "56789",
@@ -234,4 +234,3 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
   )
 
 }
-

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -357,8 +357,8 @@ object Body {
   }
 
   /**
-   * Constructs a [[zio.http.Body]] from a byte range within a file.
-   * This is used for HTTP Range requests to serve partial content.
+   * Constructs a [[zio.http.Body]] from a byte range within a file. This is
+   * used for HTTP Range requests to serve partial content.
    *
    * @param file
    *   The file to read from
@@ -376,7 +376,6 @@ object Body {
       FileRangeBody(file, start, end, chunkSize)
     }
   }
-
 
   /**
    * Constructs a [[zio.http.Body]] from from form data, using multipart
@@ -705,8 +704,8 @@ object Body {
   }
 
   /**
-   * A Body that streams a specific byte range from a file.
-   * Used for HTTP Range requests to serve partial content.
+   * A Body that streams a specific byte range from a file. Used for HTTP Range
+   * requests to serve partial content.
    */
   private[zio] final case class FileRangeBody(
     file: java.io.File,
@@ -742,9 +741,9 @@ object Body {
         ZIO.blocking {
           ZIO.suspendSucceed {
             try {
-              val raf      = new java.io.RandomAccessFile(file, "r")
+              val raf       = new java.io.RandomAccessFile(file, "r")
               raf.seek(start)
-              val size     = Math.min(chunkSize.toLong, rangeLength).toInt
+              val size      = Math.min(chunkSize.toLong, rangeLength).toInt
               var bytesRead = 0L
 
               val read: Task[Option[Chunk[Byte]]] =
@@ -783,7 +782,6 @@ object Body {
 
     override def knownContentLength: Option[Long] = Some(rangeLength)
   }
-
 
   private[zio] final case class StreamBody(
     stream: ZStream[Any, Throwable, Byte],

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -955,9 +955,9 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
 
   /**
    * Creates a handler that serves a file with support for HTTP Range requests.
-   * When a Range header is present in the request, returns partial content (206)
-   * with appropriate Content-Range headers. Supports single byte range requests
-   * as specified in RFC 9110 §14.
+   * When a Range header is present in the request, returns partial content
+   * (206) with appropriate Content-Range headers. Supports single byte range
+   * requests as specified in RFC 9110 §14.
    *
    * @param getFile
    *   A ZIO effect that produces the file to serve
@@ -1025,7 +1025,8 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
         } else {
           // Valid range - return 206 Partial Content
           Body.fromFileRange(file, startPos, endPos + 1).flatMap { body =>
-            val response = http.Response(body = body, status = Status.PartialContent)
+            val response = http
+              .Response(body = body, status = Status.PartialContent)
               .addHeader(Header.ContentRange.EndTotal("bytes", startPos.toInt, endPos.toInt, fileLength.toInt))
               .addHeader(Header.AcceptRanges.Bytes)
               .addHeader(Header.ContentLength(rangeSize))
@@ -1039,7 +1040,8 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
         val rangeSize = endPos - startPos + 1
 
         Body.fromFileRange(file, startPos, fileLength).flatMap { body =>
-          val response = http.Response(body = body, status = Status.PartialContent)
+          val response = http
+            .Response(body = body, status = Status.PartialContent)
             .addHeader(Header.ContentRange.EndTotal("bytes", startPos.toInt, endPos.toInt, fileLength.toInt))
             .addHeader(Header.AcceptRanges.Bytes)
             .addHeader(Header.ContentLength(rangeSize))
@@ -1060,7 +1062,8 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
           )
         } else {
           Body.fromFileRange(file, startPos, fileLength).flatMap { body =>
-            val response = http.Response(body = body, status = Status.PartialContent)
+            val response = http
+              .Response(body = body, status = Status.PartialContent)
               .addHeader(Header.ContentRange.EndTotal("bytes", startPos.toInt, endPos.toInt, fileLength.toInt))
               .addHeader(Header.AcceptRanges.Bytes)
               .addHeader(Header.ContentLength(rangeSize))
@@ -1109,7 +1112,6 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
       case None            => ZIO.succeed(response)
     }
   }
-
 
   /**
    * Creates a Handler that always succeeds with a 200 status code and the


### PR DESCRIPTION
## Summary

This PR adds support for HTTP Range requests (RFC 9110 §14) when serving static files. Clients can now request specific byte ranges of files, enabling features like resumable downloads and video seeking.

## Changes

### New API

Added `Handler.fromFileWithRange` - a handler that serves files with Range header support:

```scala
Handler.fromFileWithRange(ZIO.succeed(file), request)
```

### Behavior

| Request | Response |
|---------|----------|
| No Range header | `200 OK` with full file + `Accept-Ranges: bytes` |
| Valid Range (e.g., `bytes=0-99`) | `206 Partial Content` + `Content-Range` header |
| Invalid Range (beyond file size) | `416 Range Not Satisfiable` + `Content-Range: bytes */<size>` |
| Suffix Range (e.g., `bytes=-100`) | `206 Partial Content` (last N bytes) |
| Prefix Range (e.g., `bytes=100-`) | `206 Partial Content` (from offset to end) |

## Usage Example

```scala
val app = Routes(
  Method.GET / "files" / string("name") -> handler { (name: String, req: Request) =>
    Handler.fromFileWithRange(ZIO.succeed(new File(s"/data/$name")), req)
  }
)
```

/fixes #709 
/ckaim #709 