### PR TITLE
test(URL): add test to identify issue of double-encoding

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -99,6 +99,12 @@ object URLSpec extends ZIOHttpSpec {
           val expected     = urlWithSpace.encode
           assertTrue(expected == "/my%20folder/file.txt")
         },
+        test("decode url with percent-encoded space in path should not double-encode") {
+          val decoded = URL.decode("http://testsample.com/file/test%20hotel.pdf")
+          assertTrue(
+            decoded.map(_.toString) == Right("http://testsample.com/file/test%20hotel.pdf"),
+          )
+        },
         test("auto-gen") {
           check(HttpGen.url) { url =>
             val expected        = url.copy(path = url.path.addLeadingSlash)


### PR DESCRIPTION
- This will be used as example to an open issue. Not a solution.

I found a strange behavior when using `zio-http` to parse a URL and return a redirect response.
My original input to Response.redirect was of type `sttp.model.Uri`, so I converted it to a Java URI and then used `zio.http.URL.fromURI` to create the expected input type.

However, the redirected URL ended up being double-encoded.

Example:
http://testsample.com/file/test%20hotel.pdf
becomes
http://testsample.com/file/test%2520hotel.pdf
(where % is re-encoded as %25)

After investigating, I found two potential causes:

In the `fromAbsoluteURI` constructor, `getRawPath` is used. This returns an already-encoded path and stores it as the case class value. This part seems fine.

In the `.toString` method (which I assume is used when converting the URL into a response), it appears that encoding is applied again internally. This seems to be where the double-encoding happens.

I create this PR as an example of the issue.