### PR TITLE
Implement Smithy to zio-http code generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -389,6 +389,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
         .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
         .exclude("com.lihaoyi", "sourcecode_2.13"),
       `zio-json-yaml` % Test,
+      "software.amazon.smithy" % "smithy-model" % "1.53.0",
     ),
   )
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -15,14 +15,14 @@ ThisBuild / githubWorkflowEnv += ("SBT_OPTS" -> "-Xms4G -Xmx8G -XX:+UseG1GC -Xss
 
 ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
-ThisBuild / githubWorkflowJavaVersions := Seq(
+ThisBuild / githubWorkflowJavaVersions   := Seq(
   JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "17"),
   JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21"),
   JavaSpec.temurin("17"),
   JavaSpec.temurin("21"),
 )
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
-ThisBuild / githubWorkflowPREventTypes := Seq(
+ThisBuild / githubWorkflowPREventTypes   := Seq(
   PREventType.Opened,
   PREventType.Synchronize,
   PREventType.Reopened,
@@ -388,7 +388,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
         .cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
         .exclude("com.lihaoyi", "sourcecode_2.13"),
-      `zio-json-yaml` % Test,
+      `zio-json-yaml`          % Test,
       "software.amazon.smithy" % "smithy-model" % "1.53.0",
     ),
   )

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
@@ -1,0 +1,193 @@
+package zio.http.gen.smithy
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+import software.amazon.smithy.model.traits._
+import zio.http.gen.scala.Code
+import zio.http.Method
+import zio.http.Status
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+
+object SmithyEndpointGen {
+  def fromSmithy(model: Model): Code.Files = {
+    val serviceShapes = model.shapes(classOf[ServiceShape]).iterator().asScala.toList
+
+    val files = serviceShapes.flatMap { service =>
+      // For each service, we generate endpoints
+      // We might need a config to decide package name, etc.
+      // For now, let's derive it from namespace
+
+      val namespace = service.getId.getNamespace
+      val serviceName = service.getId.getName
+
+      val operations = service.getOperations.asScala.map(id => model.getShape(id).get.asOperationShape().get)
+
+      val endpoints = operations.map { op =>
+        val opName = op.getId.getName
+        val httpTrait = op.getTrait(classOf[HttpTrait]).toScala
+
+        val method = httpTrait.map(t => Method.fromString(t.getMethod)).getOrElse(Method.GET) // Default or error?
+        val uriPattern = httpTrait.map(_.getUri.toString).getOrElse("/")
+
+        val segments = parsePath(uriPattern, op, model)
+
+        // Input Shape
+        val inputShapeId = op.getInputShape
+        val inputShape = model.getShape(inputShapeId).toScala
+        val (inCode, inImports) = inputShape.map(s => shapeToInCode(s, model)).getOrElse(Code.InCode("Unit") -> Nil)
+
+        // Output Shape
+        val outputShapeId = op.getOutputShape
+        val outputShape = model.getShape(outputShapeId).toScala
+        val (outCodes, outImports) = outputShape.map(s => shapeToOutCode(s, model)).getOrElse(List(Code.OutCode("Unit", Status.Ok)) -> Nil)
+
+        // Query Parameters
+        val queryParams = inputShape.flatMap(_.asStructureShape().toScala).map { structure =>
+          structure.getAllMembers.asScala.values.flatMap { member =>
+            member.getTrait(classOf[HttpQueryTrait]).toScala.map { trait =>
+               val queryName = trait.getValue
+               val codecType = shapeToCodecType(model.getShape(member.getTarget).get)
+               // TODO: handle lists, optional
+               Code.QueryParamCode(queryName, codecType)
+            }
+          }.toSet
+        }.getOrElse(Set.empty)
+
+        // Headers
+        val headers = inputShape.flatMap(_.asStructureShape().toScala).map { structure =>
+           structure.getAllMembers.asScala.values.flatMap { member =>
+             member.getTrait(classOf[HttpHeaderTrait]).toScala.map { trait =>
+                Code.HeaderCode(trait.getValue)
+             }
+           }.toList
+        }.map(Code.HeadersCode(_)).getOrElse(Code.HeadersCode.empty)
+
+        // Fix InCode to exclude members bound to path/query/headers
+        // For now, simpler to just use the full input structure if it's a body
+        // But if @httpPayload is present, use that.
+        // If not, and no members are bound to http traits, use whole structure?
+        // Smithy rule: implicit body if no @httpPayload and no bindings?
+        // For now, keeping InCode simple.
+
+        val endpointCode = Code.EndpointCode(
+          method = method,
+          pathPatternCode = Code.PathPatternCode(segments),
+          queryParamsCode = queryParams,
+          headersCode = headers,
+          inCode = inCode,
+          outCodes = outCodes,
+          errorsCode = Nil, // TODO: Handle errors
+          authTypeCode = None
+        )
+
+        Code.Field(opName) -> endpointCode
+      }.toMap
+
+      val serviceObj = Code.Object(
+        name = serviceName,
+        extensions = Nil,
+        schema = None,
+        endpoints = endpoints,
+        objects = Nil,
+        caseClasses = Nil,
+        enums = Nil
+      )
+
+      val serviceFile = Code.File(
+        path = namespace.split('.').toList :+ s"$serviceName.scala",
+        pkgPath = namespace.split('.').toList,
+        imports = (Code.Import("zio.http._") :: Code.Import("zio.http.endpoint._") :: Code.Import("zio.schema._") :: Nil).distinct,
+        objects = List(serviceObj),
+        caseClasses = Nil,
+        enums = Nil
+      )
+
+      val dataModels = generateDataModels(service, model)
+
+      serviceFile :: dataModels
+    }
+
+
+    Code.Files(files)
+  }
+
+  private def parsePath(pattern: String, op: OperationShape, model: Model): List[Code.PathSegmentCode] = {
+    // Smithy path pattern example: /foo/{bar}/{baz}
+    // We split by / and check if segment is wrapped in {}
+    val segments = pattern.stripPrefix("/").split("/").filter(_.nonEmpty).toList
+    segments.map { segment =>
+      if (segment.startsWith("{") && segment.endsWith("}")) {
+        val paramName = segment.substring(1, segment.length - 1)
+        val labelMember = findLabelMember(op.getInputShape, paramName, model)
+        val paramType = labelMember.map(m => shapeToCodecType(model.getShape(m.getTarget).get)).getOrElse(Code.CodecType.String)
+        Code.PathSegmentCode(paramName, paramType)
+      } else {
+        Code.PathSegmentCode(segment)
+      }
+    }
+  }
+
+  private def findLabelMember(inputShapeId: ShapeId, paramName: String, model: Model): Option[MemberShape] = {
+    model.getShape(inputShapeId).flatMap(_.asStructureShape().toScala).flatMap { structure =>
+       structure.getAllMembers.asScala.values.find { member =>
+         member.getMemberName == paramName && member.hasTrait(classOf[HttpLabelTrait])
+       }
+    }.toScala
+  }
+
+  private def shapeToCodecType(shape: Shape): Code.CodecType = {
+     shape.getType match {
+       case ShapeType.STRING => Code.CodecType.String
+       case ShapeType.INTEGER => Code.CodecType.Int
+       case ShapeType.LONG => Code.CodecType.Long
+       case ShapeType.BOOLEAN => Code.CodecType.Boolean
+       // Use String for others for now or fallback
+       case _ => Code.CodecType.String
+     }
+  }
+
+  private def shapeToInCode(shape: Shape, model: Model): (Code.InCode, List[Code.Import]) = {
+    // Ideally we generate a case class for the structure and refer to it.
+    // For now returning Unit if empty or simple type
+    if (shape.getId.getName == "Unit") Code.InCode("Unit") -> Nil
+    else Code.InCode(shape.getId.getName) -> Nil // Assuming generated shape name matches
+  }
+
+
+  private def generateDataModels(service: ServiceShape, model: Model): List[Code.File] = {
+    val walker = new software.amazon.smithy.model.neighbor.Walker(model)
+    val connectedShapes = walker.walkShapes(service).asScala.toSet
+    val structures = connectedShapes.collect { case s: StructureShape if s.getId.getNamespace == service.getId.getNamespace => s }
+
+    structures.map { structure =>
+      val name = structure.getId.getName
+      val fields = structure.getAllMembers.asScala.map { case (memberName, memberShape) =>
+          val fieldType = shapeToScalaType(model.getShape(memberShape.getTarget).get, model)
+          Code.Field(memberName, fieldType)
+      }.toList
+
+      Code.File(
+        path = structure.getId.getNamespace.split('.').toList :+ s"$name.scala",
+        pkgPath = structure.getId.getNamespace.split('.').toList,
+        imports = (Code.Import("zio.schema._") :: Code.Import("zio.json._") :: Nil),
+        objects = Nil,
+        caseClasses = List(Code.CaseClass(name, fields, Some(Code.Object.schemaCompanion(name)), Nil)),
+        enums = Nil
+      )
+    }.toList
+  }
+
+  private def shapeToScalaType(shape: Shape, model: Model): Code.ScalaType = {
+    shape.getType match {
+      case ShapeType.STRING => Code.Primitive.ScalaString
+      case ShapeType.INTEGER => Code.Primitive.ScalaInt
+      case ShapeType.LONG => Code.Primitive.ScalaLong
+      case ShapeType.BOOLEAN => Code.Primitive.ScalaBoolean
+      case ShapeType.STRUCTURE => Code.TypeRef(shape.getId.getName)
+      case ShapeType.LIST =>
+        val list = shape.asListShape().get
+        Code.Collection.Seq(shapeToScalaType(model.getShape(list.getMember.getTarget).get, model), nonEmpty = false)
+      case _ => Code.Primitive.ScalaString // Fallback
+    }
+  }

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
@@ -18,50 +18,58 @@ object SmithyEndpointGen {
       // We might need a config to decide package name, etc.
       // For now, let's derive it from namespace
 
-      val namespace = service.getId.getNamespace
+      val namespace   = service.getId.getNamespace
       val serviceName = service.getId.getName
 
       val operations = service.getOperations.asScala.map(id => model.getShape(id).get.asOperationShape().get)
 
       val endpoints = operations.map { op =>
-        val opName = op.getId.getName
+        val opName    = op.getId.getName
         val httpTrait = op.getTrait(classOf[HttpTrait]).toScala
 
-        val method = httpTrait.map(t => Method.fromString(t.getMethod)).getOrElse(Method.GET) // Default or error?
+        val method     = httpTrait.map(t => Method.fromString(t.getMethod)).getOrElse(Method.GET) // Default or error?
         val uriPattern = httpTrait.map(_.getUri.toString).getOrElse("/")
 
         val segments = parsePath(uriPattern, op, model)
 
         // Input Shape
-        val inputShapeId = op.getInputShape
-        val inputShape = model.getShape(inputShapeId).toScala
+        val inputShapeId        = op.getInputShape
+        val inputShape          = model.getShape(inputShapeId).toScala
         val (inCode, inImports) = inputShape.map(s => shapeToInCode(s, model)).getOrElse(Code.InCode("Unit") -> Nil)
 
         // Output Shape
-        val outputShapeId = op.getOutputShape
-        val outputShape = model.getShape(outputShapeId).toScala
-        val (outCodes, outImports) = outputShape.map(s => shapeToOutCode(s, model)).getOrElse(List(Code.OutCode("Unit", Status.Ok)) -> Nil)
+        val outputShapeId          = op.getOutputShape
+        val outputShape            = model.getShape(outputShapeId).toScala
+        val (outCodes, outImports) =
+          outputShape.map(s => shapeToOutCode(s, model)).getOrElse(List(Code.OutCode("Unit", Status.Ok)) -> Nil)
 
         // Query Parameters
-        val queryParams = inputShape.flatMap(_.asStructureShape().toScala).map { structure =>
-          structure.getAllMembers.asScala.values.flatMap { member =>
-            member.getTrait(classOf[HttpQueryTrait]).toScala.map { trait =>
-               val queryName = trait.getValue
-               val codecType = shapeToCodecType(model.getShape(member.getTarget).get)
-               // TODO: handle lists, optional
-               Code.QueryParamCode(queryName, codecType)
-            }
-          }.toSet
-        }.getOrElse(Set.empty)
+        val queryParams = inputShape
+          .flatMap(_.asStructureShape().toScala)
+          .map { structure =>
+            structure.getAllMembers.asScala.values.flatMap { member =>
+              member.getTrait(classOf[HttpQueryTrait]).toScala.map { queryTrait =>
+                val queryName = queryTrait.getValue
+                val codecType = shapeToCodecType(model.getShape(member.getTarget).get)
+                // TODO: handle lists, optional
+                Code.QueryParamCode(queryName, codecType)
+              }
+            }.toSet
+          }
+          .getOrElse(Set.empty)
 
         // Headers
-        val headers = inputShape.flatMap(_.asStructureShape().toScala).map { structure =>
-           structure.getAllMembers.asScala.values.flatMap { member =>
-             member.getTrait(classOf[HttpHeaderTrait]).toScala.map { trait =>
-                Code.HeaderCode(trait.getValue)
-             }
-           }.toList
-        }.map(Code.HeadersCode(_)).getOrElse(Code.HeadersCode.empty)
+        val headers = inputShape
+          .flatMap(_.asStructureShape().toScala)
+          .map { structure =>
+            structure.getAllMembers.asScala.values.flatMap { member =>
+              member.getTrait(classOf[HttpHeaderTrait]).toScala.map { headerTrait =>
+                Code.HeaderCode(headerTrait.getValue)
+              }
+            }.toList
+          }
+          .map(Code.HeadersCode(_))
+          .getOrElse(Code.HeadersCode.empty)
 
         // Fix InCode to exclude members bound to path/query/headers
         // For now, simpler to just use the full input structure if it's a body
@@ -78,7 +86,7 @@ object SmithyEndpointGen {
           inCode = inCode,
           outCodes = outCodes,
           errorsCode = Nil, // TODO: Handle errors
-          authTypeCode = None
+          authTypeCode = None,
         )
 
         Code.Field(opName) -> endpointCode
@@ -91,23 +99,23 @@ object SmithyEndpointGen {
         endpoints = endpoints,
         objects = Nil,
         caseClasses = Nil,
-        enums = Nil
+        enums = Nil,
       )
 
       val serviceFile = Code.File(
         path = namespace.split('.').toList :+ s"$serviceName.scala",
         pkgPath = namespace.split('.').toList,
-        imports = (Code.Import("zio.http._") :: Code.Import("zio.http.endpoint._") :: Code.Import("zio.schema._") :: Nil).distinct,
+        imports = (Code
+          .Import("zio.http._") :: Code.Import("zio.http.endpoint._") :: Code.Import("zio.schema._") :: Nil).distinct,
         objects = List(serviceObj),
         caseClasses = Nil,
-        enums = Nil
+        enums = Nil,
       )
 
       val dataModels = generateDataModels(service, model)
 
       serviceFile :: dataModels
     }
-
 
     Code.Files(files)
   }
@@ -118,9 +126,10 @@ object SmithyEndpointGen {
     val segments = pattern.stripPrefix("/").split("/").filter(_.nonEmpty).toList
     segments.map { segment =>
       if (segment.startsWith("{") && segment.endsWith("}")) {
-        val paramName = segment.substring(1, segment.length - 1)
+        val paramName   = segment.substring(1, segment.length - 1)
         val labelMember = findLabelMember(op.getInputShape, paramName, model)
-        val paramType = labelMember.map(m => shapeToCodecType(model.getShape(m.getTarget).get)).getOrElse(Code.CodecType.String)
+        val paramType   =
+          labelMember.map(m => shapeToCodecType(model.getShape(m.getTarget).get)).getOrElse(Code.CodecType.String)
         Code.PathSegmentCode(paramName, paramType)
       } else {
         Code.PathSegmentCode(segment)
@@ -129,65 +138,71 @@ object SmithyEndpointGen {
   }
 
   private def findLabelMember(inputShapeId: ShapeId, paramName: String, model: Model): Option[MemberShape] = {
-    model.getShape(inputShapeId).flatMap(_.asStructureShape().toScala).flatMap { structure =>
-       structure.getAllMembers.asScala.values.find { member =>
-         member.getMemberName == paramName && member.hasTrait(classOf[HttpLabelTrait])
-       }
-    }.toScala
+    model
+      .getShape(inputShapeId)
+      .flatMap(_.asStructureShape().toScala)
+      .flatMap { structure =>
+        structure.getAllMembers.asScala.values.find { member =>
+          member.getMemberName == paramName && member.hasTrait(classOf[HttpLabelTrait])
+        }
+      }
+      .toScala
   }
 
   private def shapeToCodecType(shape: Shape): Code.CodecType = {
-     shape.getType match {
-       case ShapeType.STRING => Code.CodecType.String
-       case ShapeType.INTEGER => Code.CodecType.Int
-       case ShapeType.LONG => Code.CodecType.Long
-       case ShapeType.BOOLEAN => Code.CodecType.Boolean
-       // Use String for others for now or fallback
-       case _ => Code.CodecType.String
-     }
+    shape.getType match {
+      case ShapeType.STRING  => Code.CodecType.String
+      case ShapeType.INTEGER => Code.CodecType.Int
+      case ShapeType.LONG    => Code.CodecType.Long
+      case ShapeType.BOOLEAN => Code.CodecType.Boolean
+      // Use String for others for now or fallback
+      case _                 => Code.CodecType.String
+    }
   }
 
   private def shapeToInCode(shape: Shape, model: Model): (Code.InCode, List[Code.Import]) = {
     // Ideally we generate a case class for the structure and refer to it.
     // For now returning Unit if empty or simple type
     if (shape.getId.getName == "Unit") Code.InCode("Unit") -> Nil
-    else Code.InCode(shape.getId.getName) -> Nil // Assuming generated shape name matches
+    else Code.InCode(shape.getId.getName)                  -> Nil // Assuming generated shape name matches
   }
 
-
   private def generateDataModels(service: ServiceShape, model: Model): List[Code.File] = {
-    val walker = new software.amazon.smithy.model.neighbor.Walker(model)
+    val walker          = new software.amazon.smithy.model.neighbor.Walker(model)
     val connectedShapes = walker.walkShapes(service).asScala.toSet
-    val structures = connectedShapes.collect { case s: StructureShape if s.getId.getNamespace == service.getId.getNamespace => s }
+    val structures      = connectedShapes.collect {
+      case s: StructureShape if s.getId.getNamespace == service.getId.getNamespace => s
+    }
 
     structures.map { structure =>
-      val name = structure.getId.getName
+      val name   = structure.getId.getName
       val fields = structure.getAllMembers.asScala.map { case (memberName, memberShape) =>
-          val fieldType = shapeToScalaType(model.getShape(memberShape.getTarget).get, model)
-          Code.Field(memberName, fieldType)
+        val fieldType = shapeToScalaType(model.getShape(memberShape.getTarget).get, model)
+        Code.Field(memberName, fieldType)
       }.toList
 
       Code.File(
         path = structure.getId.getNamespace.split('.').toList :+ s"$name.scala",
         pkgPath = structure.getId.getNamespace.split('.').toList,
-        imports = (Code.Import("zio.schema._") :: Code.Import("zio.json._") :: Nil),
+        imports = Code.Import("zio.schema._") :: Code.Import("zio.json._") :: Nil,
         objects = Nil,
         caseClasses = List(Code.CaseClass(name, fields, Some(Code.Object.schemaCompanion(name)), Nil)),
-        enums = Nil
+        enums = Nil,
       )
     }.toList
   }
 
   private def shapeToScalaType(shape: Shape, model: Model): Code.ScalaType = {
     shape.getType match {
-      case ShapeType.STRING => Code.Primitive.ScalaString
-      case ShapeType.INTEGER => Code.Primitive.ScalaInt
-      case ShapeType.LONG => Code.Primitive.ScalaLong
-      case ShapeType.BOOLEAN => Code.Primitive.ScalaBoolean
+      case ShapeType.STRING    => Code.Primitive.ScalaString
+      case ShapeType.INTEGER   => Code.Primitive.ScalaInt
+      case ShapeType.LONG      => Code.Primitive.ScalaLong
+      case ShapeType.BOOLEAN   => Code.Primitive.ScalaBoolean
       case ShapeType.STRUCTURE => Code.TypeRef(shape.getId.getName)
-      case ShapeType.LIST =>
+      case ShapeType.LIST      =>
         val list = shape.asListShape().get
         Code.Collection.Seq(shapeToScalaType(model.getShape(list.getMember.getTarget).get, model), nonEmpty = false)
-      case _ => Code.Primitive.ScalaString // Fallback
+      case _                   => Code.Primitive.ScalaString // Fallback
     }
   }
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
@@ -36,7 +36,7 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
 
       val assembler = Model.assembler()
       assembler.addUnparsedModel("example.smithy", smithy)
-      val model = assembler.assemble().unwrap()
+      val model     = assembler.assemble().unwrap()
 
       val generated = SmithyEndpointGen.fromSmithy(model)
 
@@ -44,9 +44,8 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
       assertTrue(generated.files.exists(_.path.last == "HelloInput.scala"))
       assertTrue(generated.files.exists(_.path.last == "HelloOutput.scala"))
     },
-
     test("generates path parameters") {
-       val smithy =
+      val smithy =
         """namespace com.example
           |
           |use smithy.api#http
@@ -72,14 +71,14 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
 
       val assembler = Model.assembler()
       assembler.addUnparsedModel("user.smithy", smithy)
-      val model = assembler.assemble().unwrap()
+      val model     = assembler.assemble().unwrap()
 
       val generated = SmithyEndpointGen.fromSmithy(model)
 
       val serviceFile = generated.files.find(_.path.last == "User.scala").get
-      val endpoint = serviceFile.objects.head.endpoints.head._2
+      val endpoint    = serviceFile.objects.head.endpoints.head._2
 
       assertTrue(endpoint.pathPatternCode.segments.exists(_.name == "userId"))
-    }
+    },
   )
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
@@ -1,0 +1,85 @@
+package zio.http.gen.smithy
+
+import zio.test._
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.ModelAssembler
+import zio.http.gen.scala.Code
+import zio.http.Method
+import zio.http.Status
+
+object SmithyEndpointGenSpec extends ZIOSpecDefault {
+
+  def spec = suite("SmithyEndpointGenSpec")(
+    test("generates simple service") {
+      val smithy =
+        """namespace com.example
+          |
+          |use smithy.api#http
+          |use smithy.api#readonly
+          |
+          |@http(method: "GET", uri: "/hello")
+          |@readonly
+          |operation Hello {
+          |    input: HelloInput,
+          |    output: HelloOutput
+          |}
+          |
+          |structure HelloInput {}
+          |
+          |structure HelloOutput {}
+          |
+          |service Example {
+          |    version: "1.0.0",
+          |    operations: [Hello]
+          |}
+          |""".stripMargin
+
+      val assembler = Model.assembler()
+      assembler.addUnparsedModel("example.smithy", smithy)
+      val model = assembler.assemble().unwrap()
+
+      val generated = SmithyEndpointGen.fromSmithy(model)
+
+      assertTrue(generated.files.exists(_.path.last == "Example.scala"))
+      assertTrue(generated.files.exists(_.path.last == "HelloInput.scala"))
+      assertTrue(generated.files.exists(_.path.last == "HelloOutput.scala"))
+    },
+
+    test("generates path parameters") {
+       val smithy =
+        """namespace com.example
+          |
+          |use smithy.api#http
+          |use smithy.api#httpLabel
+          |
+          |@http(method: "GET", uri: "/users/{userId}")
+          |operation GetUser {
+          |    input: GetUserInput,
+          |    output: GetUserOutput
+          |}
+          |structure GetUserInput {
+          |    @httpLabel
+          |    @required
+          |    userId: String
+          |}
+          |structure GetUserOutput {}
+          |
+          |service User {
+          |    version: "1.0.0",
+          |    operations: [GetUser]
+          |}
+          |""".stripMargin
+
+      val assembler = Model.assembler()
+      assembler.addUnparsedModel("user.smithy", smithy)
+      val model = assembler.assemble().unwrap()
+
+      val generated = SmithyEndpointGen.fromSmithy(model)
+
+      val serviceFile = generated.files.find(_.path.last == "User.scala").get
+      val endpoint = serviceFile.objects.head.endpoints.head._2
+
+      assertTrue(endpoint.pathPatternCode.segments.exists(_.name == "userId"))
+    }
+  )
+}


### PR DESCRIPTION

Fixes: #1522
Description: This PR introduces a new code generator that takes Smithy models and generates zio.http.api.EndpointSpec values, enabling a spec-first approach to API development with zio-http.


Changes:
Dependency: Added software.amazon.smithy:smithy-model to zio-http-gen dependencies.
Generator: Implemented zio.http.gen.smithy.SmithyEndpointGen.
Supports parsing Smithy Service shapes to generate zio-http endpoints.
Maps http traits to HTTP methods and paths.
Handles path parameters via httpLabel.
Extracts query parameters and headers from httpQuery and httpHeader traits.
Generates Case Classes for Smithy Structure shapes acting as data models.


Testing: Added zio.http.gen.smithy.SmithyEndpointGenSpec with unit tests for service generation and path parameter extraction.