### PR TITLE
Add inOptional methods for optional request body support

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/OptionalBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/OptionalBodySpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.endpoint
+
+import zio._
+import zio.json.ast.Json
+import zio.test._
+
+import zio.http._
+import zio.http.codec.Doc
+import zio.http.endpoint.AuthType.None
+
+object OptionalBodySpec extends ZIOHttpSpec {
+
+  import zio.schema.codec.json._
+
+  // Using inOptional to properly handle optional request body
+  private val endpoint: Endpoint[Unit, Option[Json], ZNothing, Json, None] =
+    Endpoint(RoutePattern.POST / "optional" / "body")
+      .inOptional[Json](mediaType = MediaType.application.json, doc = Doc.p("Maybe data"))
+      .out[Json](mediaType = MediaType.application.json, doc = Doc.p("Result"))
+
+  private val api: Routes[Any, Nothing] =
+    endpoint.implementPurely {
+      case Some(value) => value
+      case scala.None  => Json.Obj("no" -> Json.Str("body"))
+    }.toRoutes
+
+  private def makeRequest(body: Option[Json]): Request =
+    Request
+      .post(
+        url = URL.root / "optional" / "body",
+        body = body.fold(ifEmpty = Body.empty)(b => Body.fromString(b.toString())),
+      )
+      .addHeader(Header.Accept(MediaType.application.json))
+
+  override def spec: Spec[TestEnvironment with Scope, Throwable] =
+    suite("OptionalBodySpec")(
+      test("accepts empty body") {
+        val body = Option.empty[Json]
+
+        for {
+          response <- api.runZIO(makeRequest(body))
+          body     <- response.body.asString
+        } yield assertTrue(body == """{"no":"body"}""")
+      },
+      test("accepts non-empty body") {
+        val body = Some(Json.Obj("key" -> Json.Str("value")))
+
+        for {
+          response <- api.runZIO(makeRequest(body))
+          body     <- response.body.asString
+        } yield assertTrue(body == """{"key":"value"}""")
+      },
+    )
+
+}

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -532,6 +532,80 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
     copy(input = input ++ codec)
 
   /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional. If the request body is empty, the input will be `None`. If the
+   * request body is non-empty, it will be decoded and wrapped in `Some`.
+   */
+  def inOptional[Input2: HttpContentCodec](implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.content[Input2].optional)
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional and is documented.
+   */
+  def inOptional[Input2: HttpContentCodec](doc: Doc)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.content[Input2].optional ?? doc)
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional and has the specified name.
+   */
+  def inOptional[Input2: HttpContentCodec](name: String)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.content[Input2](name).optional)
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional, has the specified name, and is documented.
+   */
+  def inOptional[Input2: HttpContentCodec](name: String, doc: Doc)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ (HttpCodec.content[Input2](name).optional ?? doc))
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional and uses the specified media type.
+   */
+  def inOptional[Input2: HttpContentCodec](mediaType: MediaType)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.content[Input2](mediaType).optional)
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional, uses the specified media type, and is documented.
+   */
+  def inOptional[Input2: HttpContentCodec](mediaType: MediaType, doc: Doc)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ (HttpCodec.content[Input2](mediaType).optional ?? doc))
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional, uses the specified media type, and has the specified name.
+   */
+  def inOptional[Input2: HttpContentCodec](mediaType: MediaType, name: String)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ HttpCodec.content[Input2](name, mediaType).optional)
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * optional, uses the specified media type, has the specified name, and is
+   * documented.
+   */
+  def inOptional[Input2: HttpContentCodec](mediaType: MediaType, name: String, doc: Doc)(implicit
+    combiner: Combiner[Input, Option[Input2]],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input = input ++ (HttpCodec.content[Input2](name, mediaType).optional ?? doc))
+
+  /**
    * Returns a new endpoint derived from this one, whose input type is a stream
    * of the specified typ.
    */


### PR DESCRIPTION
## Summary

- Adds `inOptional` methods to `Endpoint` for properly handling optional request bodies
- Fixes #3144

## Problem

When defining an endpoint with an optional request body using `.in[Option[A]]`, the underlying codec doesn't handle empty body as `None`. Instead, it tries to decode the empty input as JSON and fails with:

```
MalformedBody: Malformed request body failed to decode: Unexpected end of input
```

## Solution

Added `inOptional[A]` methods that:
1. Create a `HttpCodec.content[A]` for the inner type
2. Call `.optional` on it, which wraps the binary codec with special handling for empty body
3. Empty body properly decodes to `None`, non-empty body decodes to `Some(value)`

## Usage

```scala
// Before (doesn't work):
Endpoint(...)
  .in[Option[Json]](mediaType = MediaType.application.json)

// After (works correctly):
Endpoint(...)
  .inOptional[Json](mediaType = MediaType.application.json)
```

## Testing

- Added `OptionalBodySpec` with tests for both empty and non-empty body cases
- All 188 endpoint tests pass