### PR TITLE
Fix optional content codec to handle empty request body as None

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/OptionalBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/OptionalBodySpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.endpoint
+
+import zio._
+import zio.json.ast.Json
+import zio.test._
+
+import zio.http._
+import zio.http.codec.Doc
+import zio.http.endpoint.AuthType.None
+
+object OptionalBodySpec extends ZIOHttpSpec {
+
+  import zio.schema.codec.json._
+
+  // Using .in[Option[Json]] - this should work with the fix to HttpContentCodec.fromSchema
+  private val endpoint: Endpoint[Unit, Option[Json], ZNothing, Json, None] =
+    Endpoint(RoutePattern.POST / "optional" / "body")
+      .in[Option[Json]](mediaType = MediaType.application.json, doc = Doc.p("Maybe data"))
+      .out[Json](mediaType = MediaType.application.json, doc = Doc.p("Result"))
+
+  private val api: Routes[Any, Nothing] =
+    endpoint.implementPurely {
+      case Some(value) => value
+      case scala.None  => Json.Obj("no" -> Json.Str("body"))
+    }.toRoutes
+
+  private def makeRequest(body: Option[Json]): Request =
+    Request
+      .post(
+        url = URL.root / "optional" / "body",
+        body = body.fold(ifEmpty = Body.empty)(b => Body.fromString(b.toString())),
+      )
+      .addHeader(Header.Accept(MediaType.application.json))
+
+  override def spec: Spec[TestEnvironment with Scope, Throwable] =
+    suite("OptionalBodySpec")(
+      test("accepts empty body - issue #3144") {
+        val body = Option.empty[Json]
+
+        for {
+          response <- api.runZIO(makeRequest(body))
+          body     <- response.body.asString
+        } yield assertTrue(body == """{"no":"body"}""")
+      },
+      test("accepts non-empty body - issue #3144") {
+        val body = Some(Json.Obj("key" -> Json.Str("value")))
+
+        for {
+          response <- api.runZIO(makeRequest(body))
+          body     <- response.body.asString
+        } yield assertTrue(body == """{"key":"value"}""")
+      },
+    )
+
+}


### PR DESCRIPTION
## Summary

- Fixes `HttpContentCodec.fromSchema` to properly handle `Option[A]` types
- Empty request body now correctly decodes as `None` when using `.in[Option[A]]`
- Fixes #3144

## Problem

When defining an endpoint with an optional request body using `.in[Option[A]]`, the underlying `HttpContentCodec` derived from `Schema[Option[A]]` didn't handle empty body correctly. Instead of returning `None`, it tried to decode the empty input as JSON and failed with:

```
MalformedBody: Malformed request body failed to decode: Unexpected end of input
```

## Solution

Modified `HttpContentCodec.fromSchema` to detect when the schema is `Schema.Optional[A]`:
1. Extract the inner schema for type `A`
2. Create a codec for the inner type
3. Call `.optional` on it, which wraps the binary codec with special handling that decodes empty bytes as `None`

## Usage

```scala
// This now works correctly:
Endpoint(...)
  .in[Option[Json]](mediaType = MediaType.application.json)
```

- Empty body → `None`
- Valid JSON body → `Some(json)`

## Testing

- Added `OptionalBodySpec` with tests for both empty and non-empty body cases
- All 188 endpoint tests pass
- All 86 codec tests pass