### PR TITLE
Add Smithy IDL code generator (#1522)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,5 +54,6 @@ object Dependencies {
   val `zio-schema-msg-pack` = "dev.zio" %% "zio-schema-msg-pack" % ZioSchemaVersion
   val `zio-test`            = "dev.zio" %% "zio-test"            % ZioVersion % "test"
   val `zio-test-sbt`        = "dev.zio" %% "zio-test-sbt"        % ZioVersion % "test"
+  val `zio-parser`          = "dev.zio" %% "zio-parser"          % "0.1.10"
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,6 @@ object Dependencies {
   val ZioVersion                   = "2.1.23"
   val ZioCliVersion                = "0.7.3"
   val ZioJsonVersion               = "0.7.45"
-  val ZioParserVersion             = "0.1.10"
   val ZioSchemaVersion             = "1.7.5"
   val SttpVersion                  = "3.3.18"
   val ZioConfigVersion             = "4.0.5"
@@ -54,6 +53,5 @@ object Dependencies {
   val `zio-schema-msg-pack` = "dev.zio" %% "zio-schema-msg-pack" % ZioSchemaVersion
   val `zio-test`            = "dev.zio" %% "zio-test"            % ZioVersion % "test"
   val `zio-test-sbt`        = "dev.zio" %% "zio-test-sbt"        % ZioVersion % "test"
-  val `zio-parser`          = "dev.zio" %% "zio-parser"          % "0.1.10"
 
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -43,6 +43,7 @@ object MimaSettings {
         ProblemFilters.exclude[MissingClassProblem]("zio.http.netty.NettyHeaderEncoding"),
         ProblemFilters.exclude[MissingClassProblem]("zio.http.netty.NettyHeaderEncoding$"),
         exclude[Problem]("zio.http.template2.*"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|")
       ),
       mimaFailOnProblem := failOnProblem,
     )

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
@@ -1,0 +1,380 @@
+package zio.http.gen.smithy
+
+import Smithy._
+import zio.{Chunk, NonEmptyChunk}
+import zio.http.codec.RichTextCodec
+
+//idl =
+//    [WS] ControlSection MetadataSection ShapeSection
+//Whitespace
+//
+//WS =
+//    1*(SP / NL / Comment / Comma) ; whitespace
+//
+//Comma =
+//    ","
+//
+//SP =
+//    1*(%x20 / %x09) ; one or more spaces or tabs
+//
+//NL =
+//    %x0A / %x0D.0A ; Newline: \n and \r\n
+//
+//NotNL =
+//    %x09 / %x20-10FFFF ; Any character except newline
+//
+//BR =
+//    [SP] 1*(Comment / NL) [WS]; line break followed by whitespace
+//Comments
+//
+//Comment =
+//    DocumentationComment / LineComment
+//
+//DocumentationComment =
+//    "///" *NotNL NL
+//
+//LineComment =
+//    "//" [(%x09 / %x20-2E / %x30-10FFF) *NotNL] NL
+//    ; First character after "//" can't be "/"
+//Control
+//
+//ControlSection =
+//    *(ControlStatement)
+//
+//ControlStatement =
+//    "$" NodeObjectKey [SP] ":" [SP] NodeValue BR
+//Metadata
+//
+//MetadataSection =
+//    *(MetadataStatement)
+//
+//MetadataStatement =
+//    %s"metadata" SP NodeObjectKey [SP] "=" [SP] NodeValue BR
+//Node values
+//
+//NodeValue =
+//    NodeArray
+//  / NodeObject
+//  / Number
+//  / NodeKeyword
+//  / NodeStringValue
+//
+//NodeArray =
+//    "[" [WS] *(NodeValue [WS]) "]"
+//
+//NodeObject =
+//    "{" [WS] [NodeObjectKvp *(WS NodeObjectKvp)] [WS] "}"
+//
+//NodeObjectKvp =
+//    NodeObjectKey [WS] ":" [WS] NodeValue
+//
+//NodeObjectKey =
+//    QuotedText / Identifier
+//
+//Number =
+//    [Minus] Int [Frac] [Exp]
+//
+//DecimalPoint =
+//    %x2E ; .
+//
+//DigitOneToNine =
+//    %x31-39 ; 1-9
+//
+//E =
+//    %x65 / %x45 ; e E
+//
+//Exp =
+//    E [Minus / Plus] 1*DIGIT
+//
+//Frac =
+//    DecimalPoint 1*DIGIT
+//
+//Int =
+//    Zero / (DigitOneToNine *DIGIT)
+//
+//Minus =
+//    %x2D ; -
+//
+//Plus =
+//    %x2B ; +
+//
+//Zero =
+//    %x30 ; 0
+//
+//NodeKeyword =
+//    %s"true" / %s"false" / %s"null"
+//
+//NodeStringValue =
+//    ShapeId / TextBlock / QuotedText
+//
+//QuotedText =
+//    DQUOTE *QuotedChar DQUOTE
+//
+//QuotedChar =
+//    %x09        ; tab
+//  / %x20-21     ; space - "!"
+//  / %x23-5B     ; "#" - "["
+//  / %x5D-10FFFF ; "]"+
+//  / EscapedChar
+//  / NL
+//
+//EscapedChar =
+//    Escape (Escape / DQUOTE / %s"b" / %s"f"
+//             / %s"n" / %s"r" / %s"t" / "/"
+//             / UnicodeEscape)
+//
+//UnicodeEscape =
+//    %s"u" Hex Hex Hex Hex
+//
+//Hex =
+//    DIGIT / %x41-46 / %x61-66
+//
+//Escape =
+//    %x5C ; backslash
+//
+//TextBlock =
+//    ThreeDquotes [SP] NL *TextBlockContent ThreeDquotes
+//
+//TextBlockContent =
+//    QuotedChar / (1*2DQUOTE 1*QuotedChar)
+//
+//ThreeDquotes =
+//    DQUOTE DQUOTE DQUOTE
+//Shapes
+//
+//ShapeSection =
+//    [NamespaceStatement UseSection [ShapeStatements]]
+//
+//NamespaceStatement =
+//    %s"namespace" SP Namespace BR
+//
+//UseSection =
+//    *(UseStatement)
+//
+//UseStatement =
+//    %s"use" SP AbsoluteRootShapeId BR
+//
+//ShapeStatements =
+//    ShapeOrApplyStatement *(BR ShapeOrApplyStatement)
+//
+//ShapeOrApplyStatement =
+//    ShapeStatement / ApplyStatement
+//
+//ShapeStatement =
+//    TraitStatements Shape
+//
+//Shape =
+//    SimpleShape
+//  / EnumShape
+//  / AggregateShape
+//  / EntityShape
+//  / OperationShape
+//
+//SimpleShape =
+//    SimpleTypeName SP Identifier [Mixins]
+//
+//SimpleTypeName =
+//    %s"blob" / %s"boolean" / %s"document" / %s"string"
+//  / %s"byte" / %s"short" / %s"integer" / %s"long"
+//  / %s"float" / %s"double" / %s"bigInteger"
+//  / %s"bigDecimal" / %s"timestamp"
+//
+//Mixins =
+//    [SP] %s"with" [WS] "[" [WS] 1*(ShapeId [WS]) "]"
+//
+//EnumShape =
+//    EnumTypeName SP Identifier [Mixins] [WS] EnumShapeMembers
+//
+//EnumTypeName =
+//    %s"enum" / %s"intEnum"
+//
+//EnumShapeMembers =
+//    "{" [WS] 1*(EnumShapeMember [WS]) "}"
+//
+//EnumShapeMember =
+//    TraitStatements Identifier [ValueAssignment]
+//
+//ValueAssignment =
+//    [SP] "=" [SP] NodeValue [SP] [Comma] BR
+//
+//AggregateShape =
+//    AggregateTypeName SP Identifier [ForResource] [Mixins]
+//     [WS] ShapeMembers
+//
+//AggregateTypeName =
+//    %s"list" / %s"map" / %s"union" / %s"structure"
+//
+//ForResource =
+//    SP %s"for" SP ShapeId
+//
+//ShapeMembers =
+//    "{" [WS] *(ShapeMember [WS]) "}"
+//
+//ShapeMember =
+//    TraitStatements (ExplicitShapeMember / ElidedShapeMember)
+//     [ValueAssignment]
+//
+//ExplicitShapeMember =
+//    Identifier [SP] ":" [SP] ShapeId
+//
+//ElidedShapeMember =
+//    "$" Identifier
+//
+//EntityShape =
+//    EntityTypeName SP Identifier [Mixins] [WS] NodeObject
+//
+//EntityTypeName =
+//    %s"service" / %s"resource"
+//
+//OperationShape =
+//    %s"operation" SP Identifier [Mixins] [WS] OperationBody
+//
+//OperationBody =
+//    "{" [WS] *(OperationProperty [WS]) "}"
+//
+//OperationProperty =
+//    OperationInput / OperationOutput / OperationErrors
+//
+//OperationInput =
+//    %s"input" [WS] (InlineAggregateShape / (":" [WS] ShapeId))
+//
+//OperationOutput =
+//    %s"output" [WS] (InlineAggregateShape / (":" [WS] ShapeId))
+//
+//OperationErrors =
+//    %s"errors" [WS] ":" [WS] "[" [WS] *(ShapeId [WS]) "]"
+//
+//InlineAggregateShape =
+//    ":=" [WS] TraitStatements [ForResource] [Mixins]
+//     [WS] ShapeMembers
+//Traits
+//
+//TraitStatements =
+//    *(Trait [WS])
+//
+//Trait =
+//    "@" ShapeId [TraitBody]
+//
+//TraitBody =
+//    "(" [WS] [TraitStructure / TraitNode] ")"
+//
+//TraitStructure =
+//    1*(NodeObjectKvp [WS])
+//
+//TraitNode =
+//    NodeValue [WS]
+//
+//ApplyStatement =
+//    ApplyStatementSingular / ApplyStatementBlock
+//
+//ApplyStatementSingular =
+//    %s"apply" SP ShapeId WS Trait
+//
+//ApplyStatementBlock =
+//    %s"apply" SP ShapeId WS "{" [WS] TraitStatements "}"
+
+final case class Smithy(
+    services: Map[String, Service] = Map.empty,
+    operations: Map[String, Operation] = Map.empty,
+    resources: Map[String, Resource] = Map.empty,
+)
+
+
+object Smithy {
+
+  lazy val ws =
+    sp ~|~ nl ~|~ comment ~|~ comma
+  lazy val sp = RichTextCodec.chars(' ', '\t').repeatNonEmpty.const(NonEmptyChunk(' '))
+  lazy val nl = (RichTextCodec.char('\n') | RichTextCodec.literal("\r\n")).const(Left('\n'))
+  lazy val notNl = RichTextCodec.filter { c =>
+    c.toInt match {
+      case 0x09 => true
+      case x if x >= 0x20 && x <= 0x10FFFF => true
+      case _ => false
+    }
+  }.const(' ')
+  lazy val comment = documentationComment ~|~ lineComment
+  lazy val documentationComment = RichTextCodec.literalUnit("///") ~> notNl <~ nl
+  lazy val lineComment = RichTextCodec.literalUnit("//") ~>
+    (RichTextCodec.filter{ c =>
+      c.toInt match {
+        case 0x09 => true
+        case x if x >= 0x20 && x <= 0x2E => true
+        case x if x >= 0x30 && x <= 0x10FFF => true
+        case _ => false
+      }
+    } <~ notNl.repeat.const(Chunk.empty)).optional(' ').const(None) <~ nl
+  lazy val comma = RichTextCodec.literalUnit(",")
+
+
+  def parse(value: String): Smithy = Smithy()
+
+  final case class Resource(
+    identifiers: Map[String, ShapeId],
+    properties: Map[String, ShapeId],
+    create: ShapeId,
+    put: ShapeId,
+    read: ShapeId,
+    update: ShapeId,
+    delete: ShapeId,
+    list: ShapeId,
+    operations: List[ShapeId],
+    collectionOperations: List[ShapeId],
+    resources: List[ShapeId]
+  )
+
+  sealed trait Aggregates
+  object Aggregates {
+    final case class ListAggregate(member: ShapeId) extends Aggregates
+
+    final case class MapAggregate(key: ShapeId, value: ShapeId) extends Aggregates
+
+    final case class Structure(members: Map[String, ShapeId]) extends Aggregates
+
+    final case class Union(members: List[ShapeId]) extends Aggregates
+  }
+
+  final case class ShapeId(id: String)
+
+  final case class Service(
+    version: String,
+    operations: List[String],
+    resources: List[String],
+    errors: List[String],
+    rename: Map[ShapeId, String]
+  )
+
+  final case class Operation(
+    name: String,
+    mixins: List[String],
+    input: String,
+    output: String,
+    errors: List[String]
+  )
+
+  sealed trait SimpleShapes
+  object SimpleShapes {
+    case object Blob extends SimpleShapes
+    case object Boolean extends SimpleShapes
+    case object String extends SimpleShapes
+    case object Byte extends SimpleShapes
+    case object Short extends SimpleShapes
+    case object Integer extends SimpleShapes
+    case object Long extends SimpleShapes
+    case object Float extends SimpleShapes
+    case object Double extends SimpleShapes
+    case object BigInteger extends SimpleShapes
+    case object BigDecimal extends SimpleShapes
+    case object Timestamp extends SimpleShapes
+    case object Document extends SimpleShapes
+    case object List extends SimpleShapes
+    case object Map extends SimpleShapes
+    case object Structure extends SimpleShapes
+    case object Union extends SimpleShapes
+    case object Service extends SimpleShapes
+    case object Operation extends SimpleShapes
+    case object Resource extends SimpleShapes
+  }
+
+}
+

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
@@ -451,10 +451,7 @@ object SmithyParser {
       }
     }
 
-    /**
-     * Parse documentation comments (/// style) and return as Documentation
-     * trait
-     */
+    // Parse documentation comments (/// style) and return as Documentation trait
     def parseDocComments(): Option[SmithyTrait.Documentation] = {
       skipWs()
       val docLines = scala.collection.mutable.ListBuffer.empty[String]

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
@@ -4,7 +4,7 @@ import zio.Chunk
 
 /**
  * Smithy IDL Parser and AST
- * 
+ *
  * Implements parsing of Smithy 2.0 IDL specifications as defined in:
  * https://smithy.io/2.0/spec/idl.html
  */
@@ -15,13 +15,13 @@ import zio.Chunk
 
 sealed trait NodeValue
 object NodeValue {
-  case class Str(value: String) extends NodeValue
-  case class Num(value: BigDecimal) extends NodeValue
-  case class Bool(value: Boolean) extends NodeValue
-  case object Null extends NodeValue
-  case class Arr(values: List[NodeValue]) extends NodeValue
+  case class Str(value: String)                     extends NodeValue
+  case class Num(value: BigDecimal)                 extends NodeValue
+  case class Bool(value: Boolean)                   extends NodeValue
+  case object Null                                  extends NodeValue
+  case class Arr(values: List[NodeValue])           extends NodeValue
   case class Obj(fields: List[(String, NodeValue)]) extends NodeValue
-  case class ShapeIdValue(id: ShapeId) extends NodeValue
+  case class ShapeIdValue(id: ShapeId)              extends NodeValue
 }
 
 // =============================================================================
@@ -29,23 +29,23 @@ object NodeValue {
 // =============================================================================
 
 /**
- * A shape ID uniquely identifies a shape in the Smithy model.
- * Format: [namespace#]name[$ member]
+ * A shape ID uniquely identifies a shape in the Smithy model. Format:
+ * [namespace#]name[$ member]
  */
 final case class ShapeId(
   namespace: Option[String],
   name: String,
-  member: Option[String] = None
+  member: Option[String] = None,
 ) {
   def absolute(defaultNamespace: String): ShapeId =
     copy(namespace = Some(namespace.getOrElse(defaultNamespace)))
-    
-  def fullyQualified: String = 
+
+  def fullyQualified: String =
     namespace.fold(name)(ns => s"$ns#$name") + member.fold("")(m => s"$$$m")
 }
 
 object ShapeId {
-  def apply(name: String): ShapeId = ShapeId(None, name, None)
+  def apply(name: String): ShapeId                    = ShapeId(None, name, None)
   def apply(namespace: String, name: String): ShapeId = ShapeId(Some(namespace), name, None)
 }
 
@@ -62,123 +62,123 @@ object SmithyTrait {
   case class Http(method: String, uri: String, code: Int = 200) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "http")
   }
-  
+
   case object HttpLabel extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpLabel")
   }
-  
+
   case class HttpQuery(name: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpQuery")
   }
-  
+
   case class HttpHeader(name: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpHeader")
   }
-  
+
   case object HttpPayload extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpPayload")
   }
-  
+
   case class HttpPrefixHeaders(prefix: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpPrefixHeaders")
   }
-  
+
   case class HttpError(code: Int) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpError")
   }
-  
+
   case object HttpResponseCode extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpResponseCode")
   }
-  
+
   case class HttpQueryParams() extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpQueryParams")
   }
-  
+
   // Common traits
   case object Required extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "required")
   }
-  
+
   case class Pattern(regex: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "pattern")
   }
-  
+
   case class Length(min: Option[Long], max: Option[Long]) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "length")
   }
-  
+
   case class Range(min: Option[BigDecimal], max: Option[BigDecimal]) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "range")
   }
-  
+
   case class Documentation(value: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "documentation")
   }
-  
+
   case object Error extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "error")
   }
-  
+
   case class ErrorMessage(selector: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "error")
   }
-  
+
   case object Readonly extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "readonly")
   }
-  
+
   case object Idempotent extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "idempotent")
   }
-  
+
   case class TimestampFormat(format: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "timestampFormat")
   }
-  
+
   case class MediaType(value: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "mediaType")
   }
-  
+
   case class JsonName(name: String) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "jsonName")
   }
-  
+
   case class Default(value: NodeValue) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "default")
   }
-  
+
   // Streaming trait
   case object Streaming extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "streaming")
   }
-  
+
   // Event stream trait (for bi-directional streaming)
   case object EventStream extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "eventStream")
   }
-  
+
   // Auth traits
   case object HttpBasicAuth extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpBasicAuth")
   }
-  
+
   case object HttpDigestAuth extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpDigestAuth")
   }
-  
+
   case object HttpBearerAuth extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpBearerAuth")
   }
-  
+
   case object HttpApiKeyAuth extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "httpApiKeyAuth")
   }
-  
+
   case class Auth(schemes: List[ShapeId]) extends SmithyTrait {
     def shapeId: ShapeId = ShapeId("smithy.api", "auth")
   }
-  
+
   // Generic trait for unrecognized traits
   case class Generic(id: ShapeId, value: Option[NodeValue]) extends SmithyTrait {
     def shapeId: ShapeId = id
@@ -193,29 +193,29 @@ final case class Member(
   name: String,
   target: ShapeId,
   traits: List[SmithyTrait] = Nil,
-  defaultValue: Option[NodeValue] = None
+  defaultValue: Option[NodeValue] = None,
 ) {
   def isRequired: Boolean = traits.exists {
     case SmithyTrait.Required => true
-    case _ => false
+    case _                    => false
   }
-  
+
   def httpLabel: Boolean = traits.exists {
     case SmithyTrait.HttpLabel => true
-    case _ => false
+    case _                     => false
   }
-  
-  def httpQuery: Option[String] = traits.collectFirst {
-    case SmithyTrait.HttpQuery(name) => name
+
+  def httpQuery: Option[String] = traits.collectFirst { case SmithyTrait.HttpQuery(name) =>
+    name
   }
-  
-  def httpHeader: Option[String] = traits.collectFirst {
-    case SmithyTrait.HttpHeader(name) => name
+
+  def httpHeader: Option[String] = traits.collectFirst { case SmithyTrait.HttpHeader(name) =>
+    name
   }
-  
+
   def httpPayload: Boolean = traits.exists {
     case SmithyTrait.HttpPayload => true
-    case _ => false
+    case _                       => false
   }
 }
 
@@ -226,7 +226,7 @@ final case class Member(
 sealed trait Shape {
   def traits: List[SmithyTrait]
   def mixins: List[ShapeId]
-  
+
   def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape
 }
 
@@ -235,32 +235,32 @@ object Shape {
   sealed trait SimpleShape extends Shape {
     def mixins: List[ShapeId] = Nil
   }
-  
-  case class BlobShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+
+  case class BlobShape(traits: List[SmithyTrait] = Nil)       extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class BooleanShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class BooleanShape(traits: List[SmithyTrait] = Nil)    extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class StringShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class StringShape(traits: List[SmithyTrait] = Nil)     extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class ByteShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class ByteShape(traits: List[SmithyTrait] = Nil)       extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class ShortShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class ShortShape(traits: List[SmithyTrait] = Nil)      extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class IntegerShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class IntegerShape(traits: List[SmithyTrait] = Nil)    extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class LongShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class LongShape(traits: List[SmithyTrait] = Nil)       extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class FloatShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class FloatShape(traits: List[SmithyTrait] = Nil)      extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class DoubleShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class DoubleShape(traits: List[SmithyTrait] = Nil)     extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
   case class BigIntegerShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
@@ -269,75 +269,75 @@ object Shape {
   case class BigDecimalShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class TimestampShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class TimestampShape(traits: List[SmithyTrait] = Nil)  extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  case class DocumentShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+  case class DocumentShape(traits: List[SmithyTrait] = Nil)   extends SimpleShape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   // Aggregate shapes
   case class ListShape(
     member: ShapeId,
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class MapShape(
     key: ShapeId,
     value: ShapeId,
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class StructureShape(
     members: Map[String, Member],
     traits: List[SmithyTrait] = Nil,
     mixins: List[ShapeId] = Nil,
-    forResource: Option[ShapeId] = None
+    forResource: Option[ShapeId] = None,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class UnionShape(
     members: Map[String, Member],
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   // Enum shapes
   case class EnumShape(
     members: Map[String, EnumMember],
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class IntEnumShape(
     members: Map[String, IntEnumMember],
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class EnumMember(
     value: Option[String],
-    traits: List[SmithyTrait] = Nil
+    traits: List[SmithyTrait] = Nil,
   )
-  
+
   case class IntEnumMember(
     value: Int,
-    traits: List[SmithyTrait] = Nil
+    traits: List[SmithyTrait] = Nil,
   )
-  
+
   // Service shapes
   case class ServiceShape(
     version: String,
@@ -346,24 +346,24 @@ object Shape {
     errors: List[ShapeId] = Nil,
     rename: Map[ShapeId, String] = Map.empty,
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class OperationShape(
     input: Option[ShapeId],
     output: Option[ShapeId],
     errors: List[ShapeId] = Nil,
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
-    def httpTrait: Option[SmithyTrait.Http] = traits.collectFirst {
-      case h: SmithyTrait.Http => h
+    def httpTrait: Option[SmithyTrait.Http]                       = traits.collectFirst { case h: SmithyTrait.Http =>
+      h
     }
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
-  
+
   case class ResourceShape(
     identifiers: Map[String, ShapeId] = Map.empty,
     properties: Map[String, ShapeId] = Map.empty,
@@ -377,7 +377,7 @@ object Shape {
     collectionOperations: List[ShapeId] = Nil,
     resources: List[ShapeId] = Nil,
     traits: List[SmithyTrait] = Nil,
-    mixins: List[ShapeId] = Nil
+    mixins: List[ShapeId] = Nil,
   ) extends Shape {
     def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
   }
@@ -392,25 +392,25 @@ final case class SmithyModel(
   namespace: String = "",
   metadata: Map[String, NodeValue] = Map.empty,
   useStatements: List[ShapeId] = Nil,
-  shapes: Map[String, Shape] = Map.empty
+  shapes: Map[String, Shape] = Map.empty,
 ) {
   def getShape(name: String): Option[Shape] = shapes.get(name)
-  
-  def getOperation(name: String): Option[Shape.OperationShape] = 
+
+  def getOperation(name: String): Option[Shape.OperationShape] =
     shapes.get(name).collect { case op: Shape.OperationShape => op }
-    
+
   def getStructure(name: String): Option[Shape.StructureShape] =
     shapes.get(name).collect { case s: Shape.StructureShape => s }
-    
+
   def getService(name: String): Option[Shape.ServiceShape] =
     shapes.get(name).collect { case s: Shape.ServiceShape => s }
-    
+
   def allOperations: Map[String, Shape.OperationShape] =
     shapes.collect { case (name, op: Shape.OperationShape) => name -> op }
-    
+
   def allServices: Map[String, Shape.ServiceShape] =
     shapes.collect { case (name, svc: Shape.ServiceShape) => name -> svc }
-    
+
   def httpOperations: Map[String, Shape.OperationShape] =
     allOperations.filter { case (_, op) => op.httpTrait.isDefined }
 }
@@ -420,7 +420,7 @@ final case class SmithyModel(
 // =============================================================================
 
 object SmithyParser {
-  
+
   def parse(input: String): Either[String, SmithyModel] = {
     try {
       Right(parseModel(input))
@@ -428,14 +428,14 @@ object SmithyParser {
       case e: Exception => Left(s"Parse error: ${e.getMessage}")
     }
   }
-  
+
   private def parseModel(input: String): SmithyModel = {
-    var pos = 0
-    var version = "2.0"
+    var pos       = 0
+    var version   = "2.0"
     var namespace = ""
-    var shapes = Map.empty[String, Shape]
-    var uses = List.empty[ShapeId]
-    
+    var shapes    = Map.empty[String, Shape]
+    var uses      = List.empty[ShapeId]
+
     def skipWs(): Unit = {
       while (pos < input.length) {
         val c = input.charAt(pos)
@@ -450,9 +450,10 @@ object SmithyParser {
         }
       }
     }
-    
+
     /**
-     * Parse documentation comments (/// style) and return as Documentation trait
+     * Parse documentation comments (/// style) and return as Documentation
+     * trait
      */
     def parseDocComments(): Option[SmithyTrait.Documentation] = {
       skipWs()
@@ -476,7 +477,7 @@ object SmithyParser {
       if (docLines.nonEmpty) Some(SmithyTrait.Documentation(docLines.mkString("\n")))
       else None
     }
-    
+
     def consume(s: String): Boolean = {
       skipWs()
       if (input.startsWith(s, pos)) {
@@ -484,7 +485,7 @@ object SmithyParser {
         true
       } else false
     }
-    
+
     def parseIdentifier(): String = {
       skipWs()
       val start = pos
@@ -496,7 +497,7 @@ object SmithyParser {
         input.substring(start, pos)
       } else ""
     }
-    
+
     def parseNamespace(): String = {
       val first = parseIdentifier()
       if (first.isEmpty) return ""
@@ -506,7 +507,7 @@ object SmithyParser {
       }
       parts.mkString(".")
     }
-    
+
     def parseQuotedString(): String = {
       skipWs()
       if (pos < input.length && input.charAt(pos) == '"') {
@@ -516,12 +517,12 @@ object SmithyParser {
           if (input.charAt(pos) == '\\' && pos + 1 < input.length) {
             pos += 1
             input.charAt(pos) match {
-              case 'n' => sb += '\n'
-              case 'r' => sb += '\r'
-              case 't' => sb += '\t'
+              case 'n'  => sb += '\n'
+              case 'r'  => sb += '\r'
+              case 't'  => sb += '\t'
               case '\\' => sb += '\\'
-              case '"' => sb += '"'
-              case c => sb += c
+              case '"'  => sb += '"'
+              case c    => sb += c
             }
             pos += 1
           } else {
@@ -533,7 +534,7 @@ object SmithyParser {
         sb.result()
       } else ""
     }
-    
+
     def parseNumber(): BigDecimal = {
       skipWs()
       val start = pos
@@ -547,7 +548,7 @@ object SmithyParser {
         BigDecimal(input.substring(start, pos))
       } else BigDecimal(0)
     }
-    
+
     def parseShapeId(): ShapeId = {
       val ns = parseNamespace()
       if (consume("#")) {
@@ -557,14 +558,14 @@ object SmithyParser {
         ShapeId(None, ns) // ns is actually the name
       }
     }
-    
+
     def parseNodeValue(): NodeValue = {
       skipWs()
       if (pos >= input.length) return NodeValue.Null
-      
+
       input.charAt(pos) match {
-        case '"' => NodeValue.Str(parseQuotedString())
-        case '[' =>
+        case '"'                                   => NodeValue.Str(parseQuotedString())
+        case '['                                   =>
           pos += 1
           val values = scala.collection.mutable.ListBuffer.empty[NodeValue]
           skipWs()
@@ -579,16 +580,16 @@ object SmithyParser {
           }
           consume("]")
           NodeValue.Arr(values.toList)
-        case '{' =>
+        case '{'                                   =>
           pos += 1
           val fields = scala.collection.mutable.ListBuffer.empty[(String, NodeValue)]
           skipWs()
           while (pos < input.length && input.charAt(pos) != '}') {
             val before = pos
-            val key = if (input.charAt(pos) == '"') parseQuotedString() else parseIdentifier()
+            val key    = if (input.charAt(pos) == '"') parseQuotedString() else parseIdentifier()
             skipWs()
             consume(":")
-            val value = parseNodeValue()
+            val value  = parseNodeValue()
             fields += (key -> value)
             skipWs()
             consume(",")
@@ -598,43 +599,43 @@ object SmithyParser {
           }
           consume("}")
           NodeValue.Obj(fields.toList)
-        case c if c == '-' || c.isDigit =>
+        case c if c == '-' || c.isDigit            =>
           NodeValue.Num(parseNumber())
-        case 't' if input.startsWith("true", pos) =>
+        case 't' if input.startsWith("true", pos)  =>
           pos += 4
           NodeValue.Bool(true)
         case 'f' if input.startsWith("false", pos) =>
           pos += 5
           NodeValue.Bool(false)
-        case 'n' if input.startsWith("null", pos) =>
+        case 'n' if input.startsWith("null", pos)  =>
           pos += 4
           NodeValue.Null
-        case _ =>
+        case _                                     =>
           // Try as shape ID
           val id = parseShapeId()
           if (id.name.nonEmpty) NodeValue.ShapeIdValue(id)
           else NodeValue.Null
       }
     }
-    
+
     def parseTrait(): SmithyTrait = {
       consume("@")
-      val id = parseShapeId()
+      val id    = parseShapeId()
       val value = if (consume("(")) {
         skipWs()
         val v = if (pos < input.length && input.charAt(pos) != ')') {
           // Check if this is an implicit object (key: value style) or a simple value
           // Peek ahead to see if we have "identifier:" pattern
           val savedPos = pos
-          val firstId = parseIdentifier()
+          val firstId  = parseIdentifier()
           skipWs()
           if (firstId.nonEmpty && pos < input.length && input.charAt(pos) == ':') {
             // This is implicit object syntax: key: value, key2: value2
             pos = savedPos // Reset and parse as object
             val fields = scala.collection.mutable.ListBuffer.empty[(String, NodeValue)]
             while (pos < input.length && input.charAt(pos) != ')') {
-              val before = pos
-              val key = parseIdentifier()
+              val before  = pos
+              val key     = parseIdentifier()
               skipWs()
               consume(":")
               val nodeVal = parseNodeValue()
@@ -656,10 +657,10 @@ object SmithyParser {
         consume(")")
         v
       } else None
-      
+
       convertTrait(id, value)
     }
-    
+
     def parseTraits(): List[SmithyTrait] = {
       val traits = scala.collection.mutable.ListBuffer.empty[SmithyTrait]
       skipWs()
@@ -675,15 +676,15 @@ object SmithyParser {
       }
       traits.toList
     }
-    
+
     def parseMembers(): Map[String, Member] = {
       val members = scala.collection.mutable.Map.empty[String, Member]
       consume("{")
       skipWs()
       while (pos < input.length && input.charAt(pos) != '}') {
-        val before = pos
+        val before       = pos
         val memberTraits = parseTraits()
-        val name = parseIdentifier()
+        val name         = parseIdentifier()
         if (name.isEmpty) {
           // Can't parse member name, skip char to avoid infinite loop
           if (pos < input.length && input.charAt(pos) != '}') pos += 1
@@ -702,39 +703,39 @@ object SmithyParser {
       consume("}")
       members.toMap
     }
-    
+
     // Main parsing loop
     skipWs()
-    
+
     // Parse control section
     while (consume("$")) {
-      val key = parseIdentifier()
+      val key   = parseIdentifier()
       skipWs()
       consume(":")
       val value = parseNodeValue()
       if (key == "version") {
         value match {
           case NodeValue.Str(v) => version = v
-          case _ =>
+          case _                =>
         }
       }
       skipWs()
     }
-    
+
     // Parse namespace
     if (consume("namespace")) {
       skipWs()
       namespace = parseNamespace()
       skipWs()
     }
-    
+
     // Parse use statements
     while (consume("use")) {
       skipWs()
       uses = uses :+ parseShapeId()
       skipWs()
     }
-    
+
     // Parse shapes
     while (pos < input.length) {
       val loopStart = pos
@@ -749,51 +750,50 @@ object SmithyParser {
         } else {
           val keyword = parseIdentifier()
           skipWs()
-          
+
           keyword match {
-            case "string" | "integer" | "long" | "short" | "byte" | 
-                 "float" | "double" | "boolean" | "blob" | "timestamp" |
-                 "bigInteger" | "bigDecimal" | "document" =>
-              val name = parseIdentifier()
+            case "string" | "integer" | "long" | "short" | "byte" | "float" | "double" | "boolean" | "blob" |
+                "timestamp" | "bigInteger" | "bigDecimal" | "document" =>
+              val name  = parseIdentifier()
               val shape = createSimpleShape(keyword).withAdditionalTraits(traits)
               shapes += (name -> shape)
-              
+
             case "structure" =>
-              val name = parseIdentifier()
+              val name    = parseIdentifier()
               skipWs()
               val members = parseMembers()
               shapes += (name -> Shape.StructureShape(members, traits))
-              
+
             case "list" =>
-              val name = parseIdentifier()
+              val name         = parseIdentifier()
               skipWs()
-              val members = parseMembers()
+              val members      = parseMembers()
               val memberTarget = members.get("member").map(_.target).getOrElse(ShapeId("String"))
               shapes += (name -> Shape.ListShape(memberTarget, traits))
-              
+
             case "map" =>
-              val name = parseIdentifier()
+              val name        = parseIdentifier()
               skipWs()
-              val members = parseMembers()
-              val keyTarget = members.get("key").map(_.target).getOrElse(ShapeId("String"))
+              val members     = parseMembers()
+              val keyTarget   = members.get("key").map(_.target).getOrElse(ShapeId("String"))
               val valueTarget = members.get("value").map(_.target).getOrElse(ShapeId("String"))
               shapes += (name -> Shape.MapShape(keyTarget, valueTarget, traits))
-              
+
             case "union" =>
-              val name = parseIdentifier()
+              val name    = parseIdentifier()
               skipWs()
               val members = parseMembers()
               shapes += (name -> Shape.UnionShape(members, traits))
-              
+
             case "operation" =>
-              val name = parseIdentifier()
+              val name                      = parseIdentifier()
               skipWs()
               consume("{")
               skipWs()
-              var opInput: Option[ShapeId] = None
+              var opInput: Option[ShapeId]  = None
               var opOutput: Option[ShapeId] = None
-              var opErrors: List[ShapeId] = Nil
-              
+              var opErrors: List[ShapeId]   = Nil
+
               while (pos < input.length && input.charAt(pos) != '}') {
                 val prop = parseIdentifier()
                 if (prop.isEmpty) {
@@ -804,7 +804,7 @@ object SmithyParser {
                   consume(":")
                   skipWs()
                   prop match {
-                    case "input" => opInput = Some(parseShapeId())
+                    case "input"  => opInput = Some(parseShapeId())
                     case "output" => opOutput = Some(parseShapeId())
                     case "errors" =>
                       consume("[")
@@ -821,7 +821,7 @@ object SmithyParser {
                       }
                       consume("]")
                       opErrors = errs.toList
-                    case _ =>
+                    case _        =>
                       // Skip unknown property value
                       parseNodeValue()
                   }
@@ -832,59 +832,67 @@ object SmithyParser {
               }
               consume("}")
               shapes += (name -> Shape.OperationShape(opInput, opOutput, opErrors, traits))
-              
+
             case "service" =>
-              val name = parseIdentifier()
+              val name       = parseIdentifier()
               skipWs()
-              val obj = parseNodeValue() match {
+              val obj        = parseNodeValue() match {
                 case o: NodeValue.Obj => o
-                case _ => NodeValue.Obj(Nil)
+                case _                => NodeValue.Obj(Nil)
               }
-              val fieldMap = obj.fields.toMap
+              val fieldMap   = obj.fields.toMap
               val svcVersion = fieldMap.get("version").collect { case NodeValue.Str(v) => v }.getOrElse("")
-              val operations = fieldMap.get("operations").collect {
-                case NodeValue.Arr(ids) => ids.collect { case NodeValue.ShapeIdValue(id) => id }
-              }.getOrElse(Nil)
-              val resources = fieldMap.get("resources").collect {
-                case NodeValue.Arr(ids) => ids.collect { case NodeValue.ShapeIdValue(id) => id }
-              }.getOrElse(Nil)
+              val operations = fieldMap
+                .get("operations")
+                .collect { case NodeValue.Arr(ids) =>
+                  ids.collect { case NodeValue.ShapeIdValue(id) => id }
+                }
+                .getOrElse(Nil)
+              val resources  = fieldMap
+                .get("resources")
+                .collect { case NodeValue.Arr(ids) =>
+                  ids.collect { case NodeValue.ShapeIdValue(id) => id }
+                }
+                .getOrElse(Nil)
               shapes += (name -> Shape.ServiceShape(svcVersion, operations, resources, Nil, Map.empty, traits))
-              
+
             case "resource" =>
-              val name = parseIdentifier()
+              val name     = parseIdentifier()
               skipWs()
-              val obj = parseNodeValue() match {
+              val obj      = parseNodeValue() match {
                 case o: NodeValue.Obj => o
-                case _ => NodeValue.Obj(Nil)
+                case _                => NodeValue.Obj(Nil)
               }
               val fieldMap = obj.fields.toMap
-              
+
               def getShapeId(key: String): Option[ShapeId] =
                 fieldMap.get(key).collect { case NodeValue.ShapeIdValue(id) => id }
-              
+
               def getIdentifiers: Map[String, ShapeId] =
-                fieldMap.get("identifiers").collect {
-                  case NodeValue.Obj(fields) =>
+                fieldMap
+                  .get("identifiers")
+                  .collect { case NodeValue.Obj(fields) =>
                     fields.collect { case (k, NodeValue.ShapeIdValue(id)) => k -> id }.toMap
-                }.getOrElse(Map.empty)
-              
+                  }
+                  .getOrElse(Map.empty)
+
               shapes += (name -> Shape.ResourceShape(
                 identifiers = getIdentifiers,
                 read = getShapeId("read"),
                 list = getShapeId("list"),
-                traits = traits
+                traits = traits,
               ))
-              
+
             case "enum" =>
-              val name = parseIdentifier()
+              val name    = parseIdentifier()
               skipWs()
               consume("{")
               skipWs()
               val members = scala.collection.mutable.Map.empty[String, Shape.EnumMember]
               while (pos < input.length && input.charAt(pos) != '}') {
-                val before = pos
+                val before       = pos
                 val memberTraits = parseTraits()
-                val memberName = parseIdentifier()
+                val memberName   = parseIdentifier()
                 if (memberName.isEmpty) {
                   // Can't parse member name, skip char to avoid infinite loop
                   if (pos < input.length && input.charAt(pos) != '}') pos += 1
@@ -893,7 +901,7 @@ object SmithyParser {
                     skipWs()
                     parseQuotedString() match {
                       case s if s.nonEmpty => Some(s)
-                      case _ => None
+                      case _               => None
                     }
                   } else None
                   members += (memberName -> Shape.EnumMember(value, memberTraits))
@@ -906,11 +914,11 @@ object SmithyParser {
               }
               consume("}")
               shapes += (name -> Shape.EnumShape(members.toMap, traits))
-              
+
             case "" =>
               // end of input or can't parse - skip a char to avoid infinite loop
               if (pos < input.length) pos += 1
-              
+
             case _ =>
               // Skip unknown keyword - try to skip to next shape
               // Skip any remaining content until we hit a newline or end
@@ -922,75 +930,75 @@ object SmithyParser {
         }
       }
     }
-    
+
     SmithyModel(version, namespace, Map.empty, uses, shapes)
   }
-  
+
   private def createSimpleShape(typeName: String): Shape = typeName match {
-    case "blob" => Shape.BlobShape()
-    case "boolean" => Shape.BooleanShape()
-    case "document" => Shape.DocumentShape()
-    case "string" => Shape.StringShape()
-    case "byte" => Shape.ByteShape()
-    case "short" => Shape.ShortShape()
-    case "integer" => Shape.IntegerShape()
-    case "long" => Shape.LongShape()
-    case "float" => Shape.FloatShape()
-    case "double" => Shape.DoubleShape()
+    case "blob"       => Shape.BlobShape()
+    case "boolean"    => Shape.BooleanShape()
+    case "document"   => Shape.DocumentShape()
+    case "string"     => Shape.StringShape()
+    case "byte"       => Shape.ByteShape()
+    case "short"      => Shape.ShortShape()
+    case "integer"    => Shape.IntegerShape()
+    case "long"       => Shape.LongShape()
+    case "float"      => Shape.FloatShape()
+    case "double"     => Shape.DoubleShape()
     case "bigInteger" => Shape.BigIntegerShape()
     case "bigDecimal" => Shape.BigDecimalShape()
-    case "timestamp" => Shape.TimestampShape()
-    case _ => Shape.StringShape()
+    case "timestamp"  => Shape.TimestampShape()
+    case _            => Shape.StringShape()
   }
-  
+
   private def convertTrait(id: ShapeId, value: Option[NodeValue]): SmithyTrait = {
     val name = id.name
     (name, value) match {
       case ("http", Some(NodeValue.Obj(fields))) =>
         val fieldMap = fields.toMap
-        val method = fieldMap.get("method").collect { case NodeValue.Str(m) => m }.getOrElse("GET")
-        val uri = fieldMap.get("uri").collect { case NodeValue.Str(u) => u }.getOrElse("/")
-        val code = fieldMap.get("code").collect { case NodeValue.Num(c) => c.toInt }.getOrElse(200)
+        val method   = fieldMap.get("method").collect { case NodeValue.Str(m) => m }.getOrElse("GET")
+        val uri      = fieldMap.get("uri").collect { case NodeValue.Str(u) => u }.getOrElse("/")
+        val code     = fieldMap.get("code").collect { case NodeValue.Num(c) => c.toInt }.getOrElse(200)
         SmithyTrait.Http(method, uri, code)
-        
-      case ("httpLabel", _) => SmithyTrait.HttpLabel
-      case ("httpQuery", Some(NodeValue.Str(n))) => SmithyTrait.HttpQuery(n)
-      case ("httpHeader", Some(NodeValue.Str(n))) => SmithyTrait.HttpHeader(n)
-      case ("httpPayload", _) => SmithyTrait.HttpPayload
+
+      case ("httpLabel", _)                                   => SmithyTrait.HttpLabel
+      case ("httpQuery", Some(NodeValue.Str(n)))              => SmithyTrait.HttpQuery(n)
+      case ("httpHeader", Some(NodeValue.Str(n)))             => SmithyTrait.HttpHeader(n)
+      case ("httpPayload", _)                                 => SmithyTrait.HttpPayload
       case ("httpPrefixHeaders", Some(NodeValue.Str(prefix))) => SmithyTrait.HttpPrefixHeaders(prefix)
-      case ("httpError", Some(NodeValue.Num(code))) => SmithyTrait.HttpError(code.toInt)
-      case ("httpResponseCode", _) => SmithyTrait.HttpResponseCode
-      case ("httpQueryParams", _) => SmithyTrait.HttpQueryParams()
-      case ("required", _) => SmithyTrait.Required
-      case ("pattern", Some(NodeValue.Str(regex))) => SmithyTrait.Pattern(regex)
-      case ("length", Some(NodeValue.Obj(fields))) =>
+      case ("httpError", Some(NodeValue.Num(code)))           => SmithyTrait.HttpError(code.toInt)
+      case ("httpResponseCode", _)                            => SmithyTrait.HttpResponseCode
+      case ("httpQueryParams", _)                             => SmithyTrait.HttpQueryParams()
+      case ("required", _)                                    => SmithyTrait.Required
+      case ("pattern", Some(NodeValue.Str(regex)))            => SmithyTrait.Pattern(regex)
+      case ("length", Some(NodeValue.Obj(fields)))            =>
         val fieldMap = fields.toMap
-        val min = fieldMap.get("min").collect { case NodeValue.Num(n) => n.toLong }
-        val max = fieldMap.get("max").collect { case NodeValue.Num(n) => n.toLong }
+        val min      = fieldMap.get("min").collect { case NodeValue.Num(n) => n.toLong }
+        val max      = fieldMap.get("max").collect { case NodeValue.Num(n) => n.toLong }
         SmithyTrait.Length(min, max)
-      case ("range", Some(NodeValue.Obj(fields))) =>
+      case ("range", Some(NodeValue.Obj(fields)))             =>
         val fieldMap = fields.toMap
-        val min = fieldMap.get("min").collect { case NodeValue.Num(n) => n }
-        val max = fieldMap.get("max").collect { case NodeValue.Num(n) => n }
+        val min      = fieldMap.get("min").collect { case NodeValue.Num(n) => n }
+        val max      = fieldMap.get("max").collect { case NodeValue.Num(n) => n }
         SmithyTrait.Range(min, max)
-      case ("documentation", Some(NodeValue.Str(doc))) => SmithyTrait.Documentation(doc)
-      case ("error", _) => SmithyTrait.Error
-      case ("readonly", _) => SmithyTrait.Readonly
-      case ("idempotent", _) => SmithyTrait.Idempotent
-      case ("timestampFormat", Some(NodeValue.Str(format))) => SmithyTrait.TimestampFormat(format)
-      case ("mediaType", Some(NodeValue.Str(mt))) => SmithyTrait.MediaType(mt)
-      case ("jsonName", Some(NodeValue.Str(n))) => SmithyTrait.JsonName(n)
-      case ("default", Some(v)) => SmithyTrait.Default(v)
-      case ("streaming", _) => SmithyTrait.Streaming
-      case ("eventStream", _) => SmithyTrait.EventStream
-      case ("httpBasicAuth", _) => SmithyTrait.HttpBasicAuth
-      case ("httpDigestAuth", _) => SmithyTrait.HttpDigestAuth
-      case ("httpBearerAuth", _) => SmithyTrait.HttpBearerAuth
-      case ("httpApiKeyAuth", _) => SmithyTrait.HttpApiKeyAuth
-      case ("auth", Some(NodeValue.Arr(schemes))) =>
+      case ("documentation", Some(NodeValue.Str(doc)))        => SmithyTrait.Documentation(doc)
+      case ("error", _)                                       => SmithyTrait.Error
+      case ("readonly", _)                                    => SmithyTrait.Readonly
+      case ("idempotent", _)                                  => SmithyTrait.Idempotent
+      case ("timestampFormat", Some(NodeValue.Str(format)))   => SmithyTrait.TimestampFormat(format)
+      case ("mediaType", Some(NodeValue.Str(mt)))             => SmithyTrait.MediaType(mt)
+      case ("jsonName", Some(NodeValue.Str(n)))               => SmithyTrait.JsonName(n)
+      case ("default", Some(v))                               => SmithyTrait.Default(v)
+      case ("streaming", _)                                   => SmithyTrait.Streaming
+      case ("eventStream", _)                                 => SmithyTrait.EventStream
+      case ("httpBasicAuth", _)                               => SmithyTrait.HttpBasicAuth
+      case ("httpDigestAuth", _)                              => SmithyTrait.HttpDigestAuth
+      case ("httpBearerAuth", _)                              => SmithyTrait.HttpBearerAuth
+      case ("httpApiKeyAuth", _)                              => SmithyTrait.HttpApiKeyAuth
+      case ("auth", Some(NodeValue.Arr(schemes)))             =>
         val schemeIds = schemes.collect { case NodeValue.ShapeIdValue(id) => id }
         SmithyTrait.Auth(schemeIds)
-      case _ => SmithyTrait.Generic(id, value)
+      case _                                                  => SmithyTrait.Generic(id, value)
     }
   }
 }
@@ -1006,14 +1014,14 @@ final case class Smithy(
 )
 
 object Smithy {
-  
+
   def parse(value: String): Smithy = {
     SmithyParser.parse(value) match {
       case Right(model) => fromModel(model)
-      case Left(_) => Smithy()
+      case Left(_)      => Smithy()
     }
   }
-  
+
   private def fromModel(model: SmithyModel): Smithy = {
     val services = model.allServices.map { case (name, svc) =>
       name -> Service(
@@ -1021,20 +1029,20 @@ object Smithy {
         operations = svc.operations.map(_.name),
         resources = svc.resources.map(_.name),
         errors = svc.errors.map(_.name),
-        rename = svc.rename.map { case (k, v) => LegacyShapeId(k.fullyQualified) -> v }
+        rename = svc.rename.map { case (k, v) => LegacyShapeId(k.fullyQualified) -> v },
       )
     }
-    
+
     val operations = model.allOperations.map { case (name, op) =>
       name -> Operation(
         name = name,
         mixins = op.mixins.map(_.name),
         input = op.input.map(_.name).getOrElse(""),
         output = op.output.map(_.name).getOrElse(""),
-        errors = op.errors.map(_.name)
+        errors = op.errors.map(_.name),
       )
     }
-    
+
     val resources = model.shapes.collect { case (name, rs: Shape.ResourceShape) =>
       name -> Resource(
         identifiers = rs.identifiers.map { case (k, v) => k -> LegacyShapeId(v.name) },
@@ -1047,10 +1055,10 @@ object Smithy {
         list = LegacyShapeId(rs.list.map(_.name).getOrElse("")),
         operations = rs.operations.map(id => LegacyShapeId(id.name)),
         collectionOperations = rs.collectionOperations.map(id => LegacyShapeId(id.name)),
-        resources = rs.resources.map(id => LegacyShapeId(id.name))
+        resources = rs.resources.map(id => LegacyShapeId(id.name)),
       )
     }
-    
+
     Smithy(services, operations, resources)
   }
 
@@ -1065,15 +1073,15 @@ object Smithy {
     list: LegacyShapeId,
     operations: List[LegacyShapeId],
     collectionOperations: List[LegacyShapeId],
-    resources: List[LegacyShapeId]
+    resources: List[LegacyShapeId],
   )
 
   sealed trait Aggregates
   object Aggregates {
-    final case class ListAggregate(member: LegacyShapeId) extends Aggregates
+    final case class ListAggregate(member: LegacyShapeId)                   extends Aggregates
     final case class MapAggregate(key: LegacyShapeId, value: LegacyShapeId) extends Aggregates
-    final case class Structure(members: Map[String, LegacyShapeId]) extends Aggregates
-    final case class Union(members: List[LegacyShapeId]) extends Aggregates
+    final case class Structure(members: Map[String, LegacyShapeId])         extends Aggregates
+    final case class Union(members: List[LegacyShapeId])                    extends Aggregates
   }
 
   final case class LegacyShapeId(id: String)
@@ -1083,7 +1091,7 @@ object Smithy {
     operations: List[String],
     resources: List[String],
     errors: List[String],
-    rename: Map[LegacyShapeId, String]
+    rename: Map[LegacyShapeId, String],
   )
 
   final case class Operation(
@@ -1091,30 +1099,30 @@ object Smithy {
     mixins: List[String],
     input: String,
     output: String,
-    errors: List[String]
+    errors: List[String],
   )
 
   sealed trait SimpleShapes
   object SimpleShapes {
-    case object Blob extends SimpleShapes
-    case object Boolean extends SimpleShapes
-    case object String extends SimpleShapes
-    case object Byte extends SimpleShapes
-    case object Short extends SimpleShapes
-    case object Integer extends SimpleShapes
-    case object Long extends SimpleShapes
-    case object Float extends SimpleShapes
-    case object Double extends SimpleShapes
+    case object Blob       extends SimpleShapes
+    case object Boolean    extends SimpleShapes
+    case object String     extends SimpleShapes
+    case object Byte       extends SimpleShapes
+    case object Short      extends SimpleShapes
+    case object Integer    extends SimpleShapes
+    case object Long       extends SimpleShapes
+    case object Float      extends SimpleShapes
+    case object Double     extends SimpleShapes
     case object BigInteger extends SimpleShapes
     case object BigDecimal extends SimpleShapes
-    case object Timestamp extends SimpleShapes
-    case object Document extends SimpleShapes
-    case object List extends SimpleShapes
-    case object Map extends SimpleShapes
-    case object Structure extends SimpleShapes
-    case object Union extends SimpleShapes
-    case object Service extends SimpleShapes
-    case object Operation extends SimpleShapes
-    case object Resource extends SimpleShapes
+    case object Timestamp  extends SimpleShapes
+    case object Document   extends SimpleShapes
+    case object List       extends SimpleShapes
+    case object Map        extends SimpleShapes
+    case object Structure  extends SimpleShapes
+    case object Union      extends SimpleShapes
+    case object Service    extends SimpleShapes
+    case object Operation  extends SimpleShapes
+    case object Resource   extends SimpleShapes
   }
 }

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/Smithy.scala
@@ -1,347 +1,1017 @@
 package zio.http.gen.smithy
 
-import Smithy._
-import zio.{Chunk, NonEmptyChunk}
-import zio.http.codec.RichTextCodec
+import zio.Chunk
 
-//idl =
-//    [WS] ControlSection MetadataSection ShapeSection
-//Whitespace
-//
-//WS =
-//    1*(SP / NL / Comment / Comma) ; whitespace
-//
-//Comma =
-//    ","
-//
-//SP =
-//    1*(%x20 / %x09) ; one or more spaces or tabs
-//
-//NL =
-//    %x0A / %x0D.0A ; Newline: \n and \r\n
-//
-//NotNL =
-//    %x09 / %x20-10FFFF ; Any character except newline
-//
-//BR =
-//    [SP] 1*(Comment / NL) [WS]; line break followed by whitespace
-//Comments
-//
-//Comment =
-//    DocumentationComment / LineComment
-//
-//DocumentationComment =
-//    "///" *NotNL NL
-//
-//LineComment =
-//    "//" [(%x09 / %x20-2E / %x30-10FFF) *NotNL] NL
-//    ; First character after "//" can't be "/"
-//Control
-//
-//ControlSection =
-//    *(ControlStatement)
-//
-//ControlStatement =
-//    "$" NodeObjectKey [SP] ":" [SP] NodeValue BR
-//Metadata
-//
-//MetadataSection =
-//    *(MetadataStatement)
-//
-//MetadataStatement =
-//    %s"metadata" SP NodeObjectKey [SP] "=" [SP] NodeValue BR
-//Node values
-//
-//NodeValue =
-//    NodeArray
-//  / NodeObject
-//  / Number
-//  / NodeKeyword
-//  / NodeStringValue
-//
-//NodeArray =
-//    "[" [WS] *(NodeValue [WS]) "]"
-//
-//NodeObject =
-//    "{" [WS] [NodeObjectKvp *(WS NodeObjectKvp)] [WS] "}"
-//
-//NodeObjectKvp =
-//    NodeObjectKey [WS] ":" [WS] NodeValue
-//
-//NodeObjectKey =
-//    QuotedText / Identifier
-//
-//Number =
-//    [Minus] Int [Frac] [Exp]
-//
-//DecimalPoint =
-//    %x2E ; .
-//
-//DigitOneToNine =
-//    %x31-39 ; 1-9
-//
-//E =
-//    %x65 / %x45 ; e E
-//
-//Exp =
-//    E [Minus / Plus] 1*DIGIT
-//
-//Frac =
-//    DecimalPoint 1*DIGIT
-//
-//Int =
-//    Zero / (DigitOneToNine *DIGIT)
-//
-//Minus =
-//    %x2D ; -
-//
-//Plus =
-//    %x2B ; +
-//
-//Zero =
-//    %x30 ; 0
-//
-//NodeKeyword =
-//    %s"true" / %s"false" / %s"null"
-//
-//NodeStringValue =
-//    ShapeId / TextBlock / QuotedText
-//
-//QuotedText =
-//    DQUOTE *QuotedChar DQUOTE
-//
-//QuotedChar =
-//    %x09        ; tab
-//  / %x20-21     ; space - "!"
-//  / %x23-5B     ; "#" - "["
-//  / %x5D-10FFFF ; "]"+
-//  / EscapedChar
-//  / NL
-//
-//EscapedChar =
-//    Escape (Escape / DQUOTE / %s"b" / %s"f"
-//             / %s"n" / %s"r" / %s"t" / "/"
-//             / UnicodeEscape)
-//
-//UnicodeEscape =
-//    %s"u" Hex Hex Hex Hex
-//
-//Hex =
-//    DIGIT / %x41-46 / %x61-66
-//
-//Escape =
-//    %x5C ; backslash
-//
-//TextBlock =
-//    ThreeDquotes [SP] NL *TextBlockContent ThreeDquotes
-//
-//TextBlockContent =
-//    QuotedChar / (1*2DQUOTE 1*QuotedChar)
-//
-//ThreeDquotes =
-//    DQUOTE DQUOTE DQUOTE
-//Shapes
-//
-//ShapeSection =
-//    [NamespaceStatement UseSection [ShapeStatements]]
-//
-//NamespaceStatement =
-//    %s"namespace" SP Namespace BR
-//
-//UseSection =
-//    *(UseStatement)
-//
-//UseStatement =
-//    %s"use" SP AbsoluteRootShapeId BR
-//
-//ShapeStatements =
-//    ShapeOrApplyStatement *(BR ShapeOrApplyStatement)
-//
-//ShapeOrApplyStatement =
-//    ShapeStatement / ApplyStatement
-//
-//ShapeStatement =
-//    TraitStatements Shape
-//
-//Shape =
-//    SimpleShape
-//  / EnumShape
-//  / AggregateShape
-//  / EntityShape
-//  / OperationShape
-//
-//SimpleShape =
-//    SimpleTypeName SP Identifier [Mixins]
-//
-//SimpleTypeName =
-//    %s"blob" / %s"boolean" / %s"document" / %s"string"
-//  / %s"byte" / %s"short" / %s"integer" / %s"long"
-//  / %s"float" / %s"double" / %s"bigInteger"
-//  / %s"bigDecimal" / %s"timestamp"
-//
-//Mixins =
-//    [SP] %s"with" [WS] "[" [WS] 1*(ShapeId [WS]) "]"
-//
-//EnumShape =
-//    EnumTypeName SP Identifier [Mixins] [WS] EnumShapeMembers
-//
-//EnumTypeName =
-//    %s"enum" / %s"intEnum"
-//
-//EnumShapeMembers =
-//    "{" [WS] 1*(EnumShapeMember [WS]) "}"
-//
-//EnumShapeMember =
-//    TraitStatements Identifier [ValueAssignment]
-//
-//ValueAssignment =
-//    [SP] "=" [SP] NodeValue [SP] [Comma] BR
-//
-//AggregateShape =
-//    AggregateTypeName SP Identifier [ForResource] [Mixins]
-//     [WS] ShapeMembers
-//
-//AggregateTypeName =
-//    %s"list" / %s"map" / %s"union" / %s"structure"
-//
-//ForResource =
-//    SP %s"for" SP ShapeId
-//
-//ShapeMembers =
-//    "{" [WS] *(ShapeMember [WS]) "}"
-//
-//ShapeMember =
-//    TraitStatements (ExplicitShapeMember / ElidedShapeMember)
-//     [ValueAssignment]
-//
-//ExplicitShapeMember =
-//    Identifier [SP] ":" [SP] ShapeId
-//
-//ElidedShapeMember =
-//    "$" Identifier
-//
-//EntityShape =
-//    EntityTypeName SP Identifier [Mixins] [WS] NodeObject
-//
-//EntityTypeName =
-//    %s"service" / %s"resource"
-//
-//OperationShape =
-//    %s"operation" SP Identifier [Mixins] [WS] OperationBody
-//
-//OperationBody =
-//    "{" [WS] *(OperationProperty [WS]) "}"
-//
-//OperationProperty =
-//    OperationInput / OperationOutput / OperationErrors
-//
-//OperationInput =
-//    %s"input" [WS] (InlineAggregateShape / (":" [WS] ShapeId))
-//
-//OperationOutput =
-//    %s"output" [WS] (InlineAggregateShape / (":" [WS] ShapeId))
-//
-//OperationErrors =
-//    %s"errors" [WS] ":" [WS] "[" [WS] *(ShapeId [WS]) "]"
-//
-//InlineAggregateShape =
-//    ":=" [WS] TraitStatements [ForResource] [Mixins]
-//     [WS] ShapeMembers
-//Traits
-//
-//TraitStatements =
-//    *(Trait [WS])
-//
-//Trait =
-//    "@" ShapeId [TraitBody]
-//
-//TraitBody =
-//    "(" [WS] [TraitStructure / TraitNode] ")"
-//
-//TraitStructure =
-//    1*(NodeObjectKvp [WS])
-//
-//TraitNode =
-//    NodeValue [WS]
-//
-//ApplyStatement =
-//    ApplyStatementSingular / ApplyStatementBlock
-//
-//ApplyStatementSingular =
-//    %s"apply" SP ShapeId WS Trait
-//
-//ApplyStatementBlock =
-//    %s"apply" SP ShapeId WS "{" [WS] TraitStatements "}"
+/**
+ * Smithy IDL Parser and AST
+ * 
+ * Implements parsing of Smithy 2.0 IDL specifications as defined in:
+ * https://smithy.io/2.0/spec/idl.html
+ */
+
+// =============================================================================
+// AST: Node Values (JSON-like values used in traits and metadata)
+// =============================================================================
+
+sealed trait NodeValue
+object NodeValue {
+  case class Str(value: String) extends NodeValue
+  case class Num(value: BigDecimal) extends NodeValue
+  case class Bool(value: Boolean) extends NodeValue
+  case object Null extends NodeValue
+  case class Arr(values: List[NodeValue]) extends NodeValue
+  case class Obj(fields: List[(String, NodeValue)]) extends NodeValue
+  case class ShapeIdValue(id: ShapeId) extends NodeValue
+}
+
+// =============================================================================
+// AST: Shape Identifiers
+// =============================================================================
+
+/**
+ * A shape ID uniquely identifies a shape in the Smithy model.
+ * Format: [namespace#]name[$ member]
+ */
+final case class ShapeId(
+  namespace: Option[String],
+  name: String,
+  member: Option[String] = None
+) {
+  def absolute(defaultNamespace: String): ShapeId =
+    copy(namespace = Some(namespace.getOrElse(defaultNamespace)))
+    
+  def fullyQualified: String = 
+    namespace.fold(name)(ns => s"$ns#$name") + member.fold("")(m => s"$$$m")
+}
+
+object ShapeId {
+  def apply(name: String): ShapeId = ShapeId(None, name, None)
+  def apply(namespace: String, name: String): ShapeId = ShapeId(Some(namespace), name, None)
+}
+
+// =============================================================================
+// AST: Traits
+// =============================================================================
+
+sealed trait SmithyTrait {
+  def shapeId: ShapeId
+}
+
+object SmithyTrait {
+  // HTTP traits
+  case class Http(method: String, uri: String, code: Int = 200) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "http")
+  }
+  
+  case object HttpLabel extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpLabel")
+  }
+  
+  case class HttpQuery(name: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpQuery")
+  }
+  
+  case class HttpHeader(name: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpHeader")
+  }
+  
+  case object HttpPayload extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpPayload")
+  }
+  
+  case class HttpPrefixHeaders(prefix: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpPrefixHeaders")
+  }
+  
+  case class HttpError(code: Int) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpError")
+  }
+  
+  case object HttpResponseCode extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpResponseCode")
+  }
+  
+  case class HttpQueryParams() extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "httpQueryParams")
+  }
+  
+  // Common traits
+  case object Required extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "required")
+  }
+  
+  case class Pattern(regex: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "pattern")
+  }
+  
+  case class Length(min: Option[Long], max: Option[Long]) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "length")
+  }
+  
+  case class Range(min: Option[BigDecimal], max: Option[BigDecimal]) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "range")
+  }
+  
+  case class Documentation(value: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "documentation")
+  }
+  
+  case object Error extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "error")
+  }
+  
+  case class ErrorMessage(selector: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "error")
+  }
+  
+  case object Readonly extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "readonly")
+  }
+  
+  case object Idempotent extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "idempotent")
+  }
+  
+  case class TimestampFormat(format: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "timestampFormat")
+  }
+  
+  case class MediaType(value: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "mediaType")
+  }
+  
+  case class JsonName(name: String) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "jsonName")
+  }
+  
+  case class Default(value: NodeValue) extends SmithyTrait {
+    def shapeId: ShapeId = ShapeId("smithy.api", "default")
+  }
+  
+  // Generic trait for unrecognized traits
+  case class Generic(id: ShapeId, value: Option[NodeValue]) extends SmithyTrait {
+    def shapeId: ShapeId = id
+  }
+}
+
+// =============================================================================
+// AST: Members
+// =============================================================================
+
+final case class Member(
+  name: String,
+  target: ShapeId,
+  traits: List[SmithyTrait] = Nil,
+  defaultValue: Option[NodeValue] = None
+) {
+  def isRequired: Boolean = traits.exists {
+    case SmithyTrait.Required => true
+    case _ => false
+  }
+  
+  def httpLabel: Boolean = traits.exists {
+    case SmithyTrait.HttpLabel => true
+    case _ => false
+  }
+  
+  def httpQuery: Option[String] = traits.collectFirst {
+    case SmithyTrait.HttpQuery(name) => name
+  }
+  
+  def httpHeader: Option[String] = traits.collectFirst {
+    case SmithyTrait.HttpHeader(name) => name
+  }
+  
+  def httpPayload: Boolean = traits.exists {
+    case SmithyTrait.HttpPayload => true
+    case _ => false
+  }
+}
+
+// =============================================================================
+// AST: Shapes
+// =============================================================================
+
+sealed trait Shape {
+  def traits: List[SmithyTrait]
+  def mixins: List[ShapeId]
+  
+  def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape
+}
+
+object Shape {
+  // Simple shapes
+  sealed trait SimpleShape extends Shape {
+    def mixins: List[ShapeId] = Nil
+  }
+  
+  case class BlobShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class BooleanShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class StringShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class ByteShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class ShortShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class IntegerShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class LongShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class FloatShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class DoubleShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class BigIntegerShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class BigDecimalShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class TimestampShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  case class DocumentShape(traits: List[SmithyTrait] = Nil) extends SimpleShape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  // Aggregate shapes
+  case class ListShape(
+    member: ShapeId,
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class MapShape(
+    key: ShapeId,
+    value: ShapeId,
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class StructureShape(
+    members: Map[String, Member],
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil,
+    forResource: Option[ShapeId] = None
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class UnionShape(
+    members: Map[String, Member],
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  // Enum shapes
+  case class EnumShape(
+    members: Map[String, EnumMember],
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class IntEnumShape(
+    members: Map[String, IntEnumMember],
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class EnumMember(
+    value: Option[String],
+    traits: List[SmithyTrait] = Nil
+  )
+  
+  case class IntEnumMember(
+    value: Int,
+    traits: List[SmithyTrait] = Nil
+  )
+  
+  // Service shapes
+  case class ServiceShape(
+    version: String,
+    operations: List[ShapeId] = Nil,
+    resources: List[ShapeId] = Nil,
+    errors: List[ShapeId] = Nil,
+    rename: Map[ShapeId, String] = Map.empty,
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class OperationShape(
+    input: Option[ShapeId],
+    output: Option[ShapeId],
+    errors: List[ShapeId] = Nil,
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def httpTrait: Option[SmithyTrait.Http] = traits.collectFirst {
+      case h: SmithyTrait.Http => h
+    }
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+  
+  case class ResourceShape(
+    identifiers: Map[String, ShapeId] = Map.empty,
+    properties: Map[String, ShapeId] = Map.empty,
+    create: Option[ShapeId] = None,
+    put: Option[ShapeId] = None,
+    read: Option[ShapeId] = None,
+    update: Option[ShapeId] = None,
+    delete: Option[ShapeId] = None,
+    list: Option[ShapeId] = None,
+    operations: List[ShapeId] = Nil,
+    collectionOperations: List[ShapeId] = Nil,
+    resources: List[ShapeId] = Nil,
+    traits: List[SmithyTrait] = Nil,
+    mixins: List[ShapeId] = Nil
+  ) extends Shape {
+    def withAdditionalTraits(newTraits: List[SmithyTrait]): Shape = copy(traits = newTraits ++ traits)
+  }
+}
+
+// =============================================================================
+// AST: Smithy Model
+// =============================================================================
+
+final case class SmithyModel(
+  version: String = "2.0",
+  namespace: String = "",
+  metadata: Map[String, NodeValue] = Map.empty,
+  useStatements: List[ShapeId] = Nil,
+  shapes: Map[String, Shape] = Map.empty
+) {
+  def getShape(name: String): Option[Shape] = shapes.get(name)
+  
+  def getOperation(name: String): Option[Shape.OperationShape] = 
+    shapes.get(name).collect { case op: Shape.OperationShape => op }
+    
+  def getStructure(name: String): Option[Shape.StructureShape] =
+    shapes.get(name).collect { case s: Shape.StructureShape => s }
+    
+  def getService(name: String): Option[Shape.ServiceShape] =
+    shapes.get(name).collect { case s: Shape.ServiceShape => s }
+    
+  def allOperations: Map[String, Shape.OperationShape] =
+    shapes.collect { case (name, op: Shape.OperationShape) => name -> op }
+    
+  def allServices: Map[String, Shape.ServiceShape] =
+    shapes.collect { case (name, svc: Shape.ServiceShape) => name -> svc }
+    
+  def httpOperations: Map[String, Shape.OperationShape] =
+    allOperations.filter { case (_, op) => op.httpTrait.isDefined }
+}
+
+// =============================================================================
+// Parser - Using simple regex-based parsing
+// =============================================================================
+
+object SmithyParser {
+  
+  def parse(input: String): Either[String, SmithyModel] = {
+    try {
+      Right(parseModel(input))
+    } catch {
+      case e: Exception => Left(s"Parse error: ${e.getMessage}")
+    }
+  }
+  
+  private def parseModel(input: String): SmithyModel = {
+    var pos = 0
+    var version = "2.0"
+    var namespace = ""
+    var shapes = Map.empty[String, Shape]
+    var uses = List.empty[ShapeId]
+    
+    def skipWs(): Unit = {
+      while (pos < input.length) {
+        val c = input.charAt(pos)
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',') {
+          pos += 1
+        } else if (input.startsWith("//", pos)) {
+          // Skip line comment
+          while (pos < input.length && input.charAt(pos) != '\n') pos += 1
+          if (pos < input.length) pos += 1
+        } else {
+          return
+        }
+      }
+    }
+    
+    def consume(s: String): Boolean = {
+      skipWs()
+      if (input.startsWith(s, pos)) {
+        pos += s.length
+        true
+      } else false
+    }
+    
+    def parseIdentifier(): String = {
+      skipWs()
+      val start = pos
+      if (pos < input.length && (input.charAt(pos).isLetter || input.charAt(pos) == '_')) {
+        pos += 1
+        while (pos < input.length && (input.charAt(pos).isLetterOrDigit || input.charAt(pos) == '_')) {
+          pos += 1
+        }
+        input.substring(start, pos)
+      } else ""
+    }
+    
+    def parseNamespace(): String = {
+      val first = parseIdentifier()
+      if (first.isEmpty) return ""
+      val parts = scala.collection.mutable.ListBuffer(first)
+      while (consume(".")) {
+        parts += parseIdentifier()
+      }
+      parts.mkString(".")
+    }
+    
+    def parseQuotedString(): String = {
+      skipWs()
+      if (pos < input.length && input.charAt(pos) == '"') {
+        pos += 1
+        val sb = new StringBuilder
+        while (pos < input.length && input.charAt(pos) != '"') {
+          if (input.charAt(pos) == '\\' && pos + 1 < input.length) {
+            pos += 1
+            input.charAt(pos) match {
+              case 'n' => sb += '\n'
+              case 'r' => sb += '\r'
+              case 't' => sb += '\t'
+              case '\\' => sb += '\\'
+              case '"' => sb += '"'
+              case c => sb += c
+            }
+            pos += 1
+          } else {
+            sb += input.charAt(pos)
+            pos += 1
+          }
+        }
+        if (pos < input.length) pos += 1 // skip closing quote
+        sb.result()
+      } else ""
+    }
+    
+    def parseNumber(): BigDecimal = {
+      skipWs()
+      val start = pos
+      if (pos < input.length && (input.charAt(pos) == '-' || input.charAt(pos).isDigit)) {
+        if (input.charAt(pos) == '-') pos += 1
+        while (pos < input.length && input.charAt(pos).isDigit) pos += 1
+        if (pos < input.length && input.charAt(pos) == '.') {
+          pos += 1
+          while (pos < input.length && input.charAt(pos).isDigit) pos += 1
+        }
+        BigDecimal(input.substring(start, pos))
+      } else BigDecimal(0)
+    }
+    
+    def parseShapeId(): ShapeId = {
+      val ns = parseNamespace()
+      if (consume("#")) {
+        val name = parseIdentifier()
+        ShapeId(Some(ns), name)
+      } else {
+        ShapeId(None, ns) // ns is actually the name
+      }
+    }
+    
+    def parseNodeValue(): NodeValue = {
+      skipWs()
+      if (pos >= input.length) return NodeValue.Null
+      
+      input.charAt(pos) match {
+        case '"' => NodeValue.Str(parseQuotedString())
+        case '[' =>
+          pos += 1
+          val values = scala.collection.mutable.ListBuffer.empty[NodeValue]
+          skipWs()
+          while (pos < input.length && input.charAt(pos) != ']') {
+            val before = pos
+            values += parseNodeValue()
+            skipWs()
+            consume(",")
+            skipWs()
+            // Safety: if we didn't advance, skip a char to avoid infinite loop
+            if (pos == before && pos < input.length && input.charAt(pos) != ']') pos += 1
+          }
+          consume("]")
+          NodeValue.Arr(values.toList)
+        case '{' =>
+          pos += 1
+          val fields = scala.collection.mutable.ListBuffer.empty[(String, NodeValue)]
+          skipWs()
+          while (pos < input.length && input.charAt(pos) != '}') {
+            val before = pos
+            val key = if (input.charAt(pos) == '"') parseQuotedString() else parseIdentifier()
+            skipWs()
+            consume(":")
+            val value = parseNodeValue()
+            fields += (key -> value)
+            skipWs()
+            consume(",")
+            skipWs()
+            // Safety: if we didn't advance, skip a char to avoid infinite loop
+            if (pos == before && pos < input.length && input.charAt(pos) != '}') pos += 1
+          }
+          consume("}")
+          NodeValue.Obj(fields.toList)
+        case c if c == '-' || c.isDigit =>
+          NodeValue.Num(parseNumber())
+        case 't' if input.startsWith("true", pos) =>
+          pos += 4
+          NodeValue.Bool(true)
+        case 'f' if input.startsWith("false", pos) =>
+          pos += 5
+          NodeValue.Bool(false)
+        case 'n' if input.startsWith("null", pos) =>
+          pos += 4
+          NodeValue.Null
+        case _ =>
+          // Try as shape ID
+          val id = parseShapeId()
+          if (id.name.nonEmpty) NodeValue.ShapeIdValue(id)
+          else NodeValue.Null
+      }
+    }
+    
+    def parseTrait(): SmithyTrait = {
+      consume("@")
+      val id = parseShapeId()
+      val value = if (consume("(")) {
+        skipWs()
+        val v = if (pos < input.length && input.charAt(pos) != ')') {
+          // Check if this is an implicit object (key: value style) or a simple value
+          // Peek ahead to see if we have "identifier:" pattern
+          val savedPos = pos
+          val firstId = parseIdentifier()
+          skipWs()
+          if (firstId.nonEmpty && pos < input.length && input.charAt(pos) == ':') {
+            // This is implicit object syntax: key: value, key2: value2
+            pos = savedPos // Reset and parse as object
+            val fields = scala.collection.mutable.ListBuffer.empty[(String, NodeValue)]
+            while (pos < input.length && input.charAt(pos) != ')') {
+              val before = pos
+              val key = parseIdentifier()
+              skipWs()
+              consume(":")
+              val nodeVal = parseNodeValue()
+              fields += (key -> nodeVal)
+              skipWs()
+              consume(",")
+              skipWs()
+              // Safety: if we didn't advance, skip a char
+              if (pos == before && pos < input.length && input.charAt(pos) != ')') pos += 1
+            }
+            Some(NodeValue.Obj(fields.toList))
+          } else {
+            // This is a simple value - reset and parse normally
+            pos = savedPos
+            Some(parseNodeValue())
+          }
+        } else None
+        skipWs()
+        consume(")")
+        v
+      } else None
+      
+      convertTrait(id, value)
+    }
+    
+    def parseTraits(): List[SmithyTrait] = {
+      val traits = scala.collection.mutable.ListBuffer.empty[SmithyTrait]
+      skipWs()
+      while (pos < input.length && input.charAt(pos) == '@') {
+        traits += parseTrait()
+        skipWs()
+      }
+      traits.toList
+    }
+    
+    def parseMembers(): Map[String, Member] = {
+      val members = scala.collection.mutable.Map.empty[String, Member]
+      consume("{")
+      skipWs()
+      while (pos < input.length && input.charAt(pos) != '}') {
+        val before = pos
+        val memberTraits = parseTraits()
+        val name = parseIdentifier()
+        if (name.isEmpty) {
+          // Can't parse member name, skip char to avoid infinite loop
+          if (pos < input.length && input.charAt(pos) != '}') pos += 1
+        } else {
+          skipWs()
+          consume(":")
+          val target = parseShapeId()
+          members += (name -> Member(name, target, memberTraits))
+          skipWs()
+          consume(",")
+        }
+        skipWs()
+        // Safety: if we didn't advance at all, skip a char
+        if (pos == before && pos < input.length && input.charAt(pos) != '}') pos += 1
+      }
+      consume("}")
+      members.toMap
+    }
+    
+    // Main parsing loop
+    skipWs()
+    
+    // Parse control section
+    while (consume("$")) {
+      val key = parseIdentifier()
+      skipWs()
+      consume(":")
+      val value = parseNodeValue()
+      if (key == "version") {
+        value match {
+          case NodeValue.Str(v) => version = v
+          case _ =>
+        }
+      }
+      skipWs()
+    }
+    
+    // Parse namespace
+    if (consume("namespace")) {
+      skipWs()
+      namespace = parseNamespace()
+      skipWs()
+    }
+    
+    // Parse use statements
+    while (consume("use")) {
+      skipWs()
+      uses = uses :+ parseShapeId()
+      skipWs()
+    }
+    
+    // Parse shapes
+    while (pos < input.length) {
+      val loopStart = pos
+      skipWs()
+      if (pos >= input.length) {
+        // done
+      } else {
+        val traits = parseTraits()
+        skipWs()
+        if (pos >= input.length) {
+          // done
+        } else {
+          val keyword = parseIdentifier()
+          skipWs()
+          
+          keyword match {
+            case "string" | "integer" | "long" | "short" | "byte" | 
+                 "float" | "double" | "boolean" | "blob" | "timestamp" |
+                 "bigInteger" | "bigDecimal" | "document" =>
+              val name = parseIdentifier()
+              val shape = createSimpleShape(keyword).withAdditionalTraits(traits)
+              shapes += (name -> shape)
+              
+            case "structure" =>
+              val name = parseIdentifier()
+              skipWs()
+              val members = parseMembers()
+              shapes += (name -> Shape.StructureShape(members, traits))
+              
+            case "list" =>
+              val name = parseIdentifier()
+              skipWs()
+              val members = parseMembers()
+              val memberTarget = members.get("member").map(_.target).getOrElse(ShapeId("String"))
+              shapes += (name -> Shape.ListShape(memberTarget, traits))
+              
+            case "map" =>
+              val name = parseIdentifier()
+              skipWs()
+              val members = parseMembers()
+              val keyTarget = members.get("key").map(_.target).getOrElse(ShapeId("String"))
+              val valueTarget = members.get("value").map(_.target).getOrElse(ShapeId("String"))
+              shapes += (name -> Shape.MapShape(keyTarget, valueTarget, traits))
+              
+            case "union" =>
+              val name = parseIdentifier()
+              skipWs()
+              val members = parseMembers()
+              shapes += (name -> Shape.UnionShape(members, traits))
+              
+            case "operation" =>
+              val name = parseIdentifier()
+              skipWs()
+              consume("{")
+              skipWs()
+              var opInput: Option[ShapeId] = None
+              var opOutput: Option[ShapeId] = None
+              var opErrors: List[ShapeId] = Nil
+              
+              while (pos < input.length && input.charAt(pos) != '}') {
+                val prop = parseIdentifier()
+                if (prop.isEmpty) {
+                  // Can't parse identifier, skip to next meaningful char or end
+                  if (pos < input.length && input.charAt(pos) != '}') pos += 1
+                } else {
+                  skipWs()
+                  consume(":")
+                  skipWs()
+                  prop match {
+                    case "input" => opInput = Some(parseShapeId())
+                    case "output" => opOutput = Some(parseShapeId())
+                    case "errors" =>
+                      consume("[")
+                      skipWs()
+                      val errs = scala.collection.mutable.ListBuffer.empty[ShapeId]
+                      while (pos < input.length && input.charAt(pos) != ']') {
+                        val errBefore = pos
+                        errs += parseShapeId()
+                        skipWs()
+                        consume(",")
+                        skipWs()
+                        // Safety: if we didn't advance, break to avoid infinite loop
+                        if (pos == errBefore && pos < input.length && input.charAt(pos) != ']') pos += 1
+                      }
+                      consume("]")
+                      opErrors = errs.toList
+                    case _ =>
+                      // Skip unknown property value
+                      parseNodeValue()
+                  }
+                  skipWs()
+                  consume(",")
+                }
+                skipWs()
+              }
+              consume("}")
+              shapes += (name -> Shape.OperationShape(opInput, opOutput, opErrors, traits))
+              
+            case "service" =>
+              val name = parseIdentifier()
+              skipWs()
+              val obj = parseNodeValue() match {
+                case o: NodeValue.Obj => o
+                case _ => NodeValue.Obj(Nil)
+              }
+              val fieldMap = obj.fields.toMap
+              val svcVersion = fieldMap.get("version").collect { case NodeValue.Str(v) => v }.getOrElse("")
+              val operations = fieldMap.get("operations").collect {
+                case NodeValue.Arr(ids) => ids.collect { case NodeValue.ShapeIdValue(id) => id }
+              }.getOrElse(Nil)
+              val resources = fieldMap.get("resources").collect {
+                case NodeValue.Arr(ids) => ids.collect { case NodeValue.ShapeIdValue(id) => id }
+              }.getOrElse(Nil)
+              shapes += (name -> Shape.ServiceShape(svcVersion, operations, resources, Nil, Map.empty, traits))
+              
+            case "resource" =>
+              val name = parseIdentifier()
+              skipWs()
+              val obj = parseNodeValue() match {
+                case o: NodeValue.Obj => o
+                case _ => NodeValue.Obj(Nil)
+              }
+              val fieldMap = obj.fields.toMap
+              
+              def getShapeId(key: String): Option[ShapeId] =
+                fieldMap.get(key).collect { case NodeValue.ShapeIdValue(id) => id }
+              
+              def getIdentifiers: Map[String, ShapeId] =
+                fieldMap.get("identifiers").collect {
+                  case NodeValue.Obj(fields) =>
+                    fields.collect { case (k, NodeValue.ShapeIdValue(id)) => k -> id }.toMap
+                }.getOrElse(Map.empty)
+              
+              shapes += (name -> Shape.ResourceShape(
+                identifiers = getIdentifiers,
+                read = getShapeId("read"),
+                list = getShapeId("list"),
+                traits = traits
+              ))
+              
+            case "enum" =>
+              val name = parseIdentifier()
+              skipWs()
+              consume("{")
+              skipWs()
+              val members = scala.collection.mutable.Map.empty[String, Shape.EnumMember]
+              while (pos < input.length && input.charAt(pos) != '}') {
+                val before = pos
+                val memberTraits = parseTraits()
+                val memberName = parseIdentifier()
+                if (memberName.isEmpty) {
+                  // Can't parse member name, skip char to avoid infinite loop
+                  if (pos < input.length && input.charAt(pos) != '}') pos += 1
+                } else {
+                  val value = if (consume("=")) {
+                    skipWs()
+                    parseQuotedString() match {
+                      case s if s.nonEmpty => Some(s)
+                      case _ => None
+                    }
+                  } else None
+                  members += (memberName -> Shape.EnumMember(value, memberTraits))
+                  skipWs()
+                  consume(",")
+                }
+                skipWs()
+                // Safety: if we didn't advance at all, skip a char
+                if (pos == before && pos < input.length && input.charAt(pos) != '}') pos += 1
+              }
+              consume("}")
+              shapes += (name -> Shape.EnumShape(members.toMap, traits))
+              
+            case "" =>
+              // end of input or can't parse - skip a char to avoid infinite loop
+              if (pos < input.length) pos += 1
+              
+            case _ =>
+              // Skip unknown keyword - try to skip to next shape
+              // Skip any remaining content until we hit a newline or end
+              while (pos < input.length && input.charAt(pos) != '\n') pos += 1
+          }
+          skipWs()
+          // Safety: if we didn't advance at all, skip a char
+          if (pos == loopStart && pos < input.length) pos += 1
+        }
+      }
+    }
+    
+    SmithyModel(version, namespace, Map.empty, uses, shapes)
+  }
+  
+  private def createSimpleShape(typeName: String): Shape = typeName match {
+    case "blob" => Shape.BlobShape()
+    case "boolean" => Shape.BooleanShape()
+    case "document" => Shape.DocumentShape()
+    case "string" => Shape.StringShape()
+    case "byte" => Shape.ByteShape()
+    case "short" => Shape.ShortShape()
+    case "integer" => Shape.IntegerShape()
+    case "long" => Shape.LongShape()
+    case "float" => Shape.FloatShape()
+    case "double" => Shape.DoubleShape()
+    case "bigInteger" => Shape.BigIntegerShape()
+    case "bigDecimal" => Shape.BigDecimalShape()
+    case "timestamp" => Shape.TimestampShape()
+    case _ => Shape.StringShape()
+  }
+  
+  private def convertTrait(id: ShapeId, value: Option[NodeValue]): SmithyTrait = {
+    val name = id.name
+    (name, value) match {
+      case ("http", Some(NodeValue.Obj(fields))) =>
+        val fieldMap = fields.toMap
+        val method = fieldMap.get("method").collect { case NodeValue.Str(m) => m }.getOrElse("GET")
+        val uri = fieldMap.get("uri").collect { case NodeValue.Str(u) => u }.getOrElse("/")
+        val code = fieldMap.get("code").collect { case NodeValue.Num(c) => c.toInt }.getOrElse(200)
+        SmithyTrait.Http(method, uri, code)
+        
+      case ("httpLabel", _) => SmithyTrait.HttpLabel
+      case ("httpQuery", Some(NodeValue.Str(n))) => SmithyTrait.HttpQuery(n)
+      case ("httpHeader", Some(NodeValue.Str(n))) => SmithyTrait.HttpHeader(n)
+      case ("httpPayload", _) => SmithyTrait.HttpPayload
+      case ("httpPrefixHeaders", Some(NodeValue.Str(prefix))) => SmithyTrait.HttpPrefixHeaders(prefix)
+      case ("httpError", Some(NodeValue.Num(code))) => SmithyTrait.HttpError(code.toInt)
+      case ("httpResponseCode", _) => SmithyTrait.HttpResponseCode
+      case ("httpQueryParams", _) => SmithyTrait.HttpQueryParams()
+      case ("required", _) => SmithyTrait.Required
+      case ("pattern", Some(NodeValue.Str(regex))) => SmithyTrait.Pattern(regex)
+      case ("length", Some(NodeValue.Obj(fields))) =>
+        val fieldMap = fields.toMap
+        val min = fieldMap.get("min").collect { case NodeValue.Num(n) => n.toLong }
+        val max = fieldMap.get("max").collect { case NodeValue.Num(n) => n.toLong }
+        SmithyTrait.Length(min, max)
+      case ("range", Some(NodeValue.Obj(fields))) =>
+        val fieldMap = fields.toMap
+        val min = fieldMap.get("min").collect { case NodeValue.Num(n) => n }
+        val max = fieldMap.get("max").collect { case NodeValue.Num(n) => n }
+        SmithyTrait.Range(min, max)
+      case ("documentation", Some(NodeValue.Str(doc))) => SmithyTrait.Documentation(doc)
+      case ("error", _) => SmithyTrait.Error
+      case ("readonly", _) => SmithyTrait.Readonly
+      case ("idempotent", _) => SmithyTrait.Idempotent
+      case ("timestampFormat", Some(NodeValue.Str(format))) => SmithyTrait.TimestampFormat(format)
+      case ("mediaType", Some(NodeValue.Str(mt))) => SmithyTrait.MediaType(mt)
+      case ("jsonName", Some(NodeValue.Str(n))) => SmithyTrait.JsonName(n)
+      case ("default", Some(v)) => SmithyTrait.Default(v)
+      case _ => SmithyTrait.Generic(id, value)
+    }
+  }
+}
+
+// =============================================================================
+// Legacy Compatibility (for existing code)
+// =============================================================================
 
 final case class Smithy(
-    services: Map[String, Service] = Map.empty,
-    operations: Map[String, Operation] = Map.empty,
-    resources: Map[String, Resource] = Map.empty,
+  services: Map[String, Smithy.Service] = Map.empty,
+  operations: Map[String, Smithy.Operation] = Map.empty,
+  resources: Map[String, Smithy.Resource] = Map.empty,
 )
 
-
 object Smithy {
-
-  lazy val ws =
-    sp ~|~ nl ~|~ comment ~|~ comma
-  lazy val sp = RichTextCodec.chars(' ', '\t').repeatNonEmpty.const(NonEmptyChunk(' '))
-  lazy val nl = (RichTextCodec.char('\n') | RichTextCodec.literal("\r\n")).const(Left('\n'))
-  lazy val notNl = RichTextCodec.filter { c =>
-    c.toInt match {
-      case 0x09 => true
-      case x if x >= 0x20 && x <= 0x10FFFF => true
-      case _ => false
+  
+  def parse(value: String): Smithy = {
+    SmithyParser.parse(value) match {
+      case Right(model) => fromModel(model)
+      case Left(_) => Smithy()
     }
-  }.const(' ')
-  lazy val comment = documentationComment ~|~ lineComment
-  lazy val documentationComment = RichTextCodec.literalUnit("///") ~> notNl <~ nl
-  lazy val lineComment = RichTextCodec.literalUnit("//") ~>
-    (RichTextCodec.filter{ c =>
-      c.toInt match {
-        case 0x09 => true
-        case x if x >= 0x20 && x <= 0x2E => true
-        case x if x >= 0x30 && x <= 0x10FFF => true
-        case _ => false
-      }
-    } <~ notNl.repeat.const(Chunk.empty)).optional(' ').const(None) <~ nl
-  lazy val comma = RichTextCodec.literalUnit(",")
-
-
-  def parse(value: String): Smithy = Smithy()
+  }
+  
+  private def fromModel(model: SmithyModel): Smithy = {
+    val services = model.allServices.map { case (name, svc) =>
+      name -> Service(
+        version = svc.version,
+        operations = svc.operations.map(_.name),
+        resources = svc.resources.map(_.name),
+        errors = svc.errors.map(_.name),
+        rename = svc.rename.map { case (k, v) => LegacyShapeId(k.fullyQualified) -> v }
+      )
+    }
+    
+    val operations = model.allOperations.map { case (name, op) =>
+      name -> Operation(
+        name = name,
+        mixins = op.mixins.map(_.name),
+        input = op.input.map(_.name).getOrElse(""),
+        output = op.output.map(_.name).getOrElse(""),
+        errors = op.errors.map(_.name)
+      )
+    }
+    
+    val resources = model.shapes.collect { case (name, rs: Shape.ResourceShape) =>
+      name -> Resource(
+        identifiers = rs.identifiers.map { case (k, v) => k -> LegacyShapeId(v.name) },
+        properties = rs.properties.map { case (k, v) => k -> LegacyShapeId(v.name) },
+        create = LegacyShapeId(rs.create.map(_.name).getOrElse("")),
+        put = LegacyShapeId(rs.put.map(_.name).getOrElse("")),
+        read = LegacyShapeId(rs.read.map(_.name).getOrElse("")),
+        update = LegacyShapeId(rs.update.map(_.name).getOrElse("")),
+        delete = LegacyShapeId(rs.delete.map(_.name).getOrElse("")),
+        list = LegacyShapeId(rs.list.map(_.name).getOrElse("")),
+        operations = rs.operations.map(id => LegacyShapeId(id.name)),
+        collectionOperations = rs.collectionOperations.map(id => LegacyShapeId(id.name)),
+        resources = rs.resources.map(id => LegacyShapeId(id.name))
+      )
+    }
+    
+    Smithy(services, operations, resources)
+  }
 
   final case class Resource(
-    identifiers: Map[String, ShapeId],
-    properties: Map[String, ShapeId],
-    create: ShapeId,
-    put: ShapeId,
-    read: ShapeId,
-    update: ShapeId,
-    delete: ShapeId,
-    list: ShapeId,
-    operations: List[ShapeId],
-    collectionOperations: List[ShapeId],
-    resources: List[ShapeId]
+    identifiers: Map[String, LegacyShapeId],
+    properties: Map[String, LegacyShapeId],
+    create: LegacyShapeId,
+    put: LegacyShapeId,
+    read: LegacyShapeId,
+    update: LegacyShapeId,
+    delete: LegacyShapeId,
+    list: LegacyShapeId,
+    operations: List[LegacyShapeId],
+    collectionOperations: List[LegacyShapeId],
+    resources: List[LegacyShapeId]
   )
 
   sealed trait Aggregates
   object Aggregates {
-    final case class ListAggregate(member: ShapeId) extends Aggregates
-
-    final case class MapAggregate(key: ShapeId, value: ShapeId) extends Aggregates
-
-    final case class Structure(members: Map[String, ShapeId]) extends Aggregates
-
-    final case class Union(members: List[ShapeId]) extends Aggregates
+    final case class ListAggregate(member: LegacyShapeId) extends Aggregates
+    final case class MapAggregate(key: LegacyShapeId, value: LegacyShapeId) extends Aggregates
+    final case class Structure(members: Map[String, LegacyShapeId]) extends Aggregates
+    final case class Union(members: List[LegacyShapeId]) extends Aggregates
   }
 
-  final case class ShapeId(id: String)
+  final case class LegacyShapeId(id: String)
 
   final case class Service(
     version: String,
     operations: List[String],
     resources: List[String],
     errors: List[String],
-    rename: Map[ShapeId, String]
+    rename: Map[LegacyShapeId, String]
   )
 
   final case class Operation(
@@ -375,6 +1045,4 @@ object Smithy {
     case object Operation extends SimpleShapes
     case object Resource extends SimpleShapes
   }
-
 }
-

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyCodecs.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyCodecs.scala
@@ -1,0 +1,220 @@
+package zio.http.gen.smithy
+
+import zio.Chunk
+
+import zio.http.codec.RichTextCodec
+
+/**
+ * Smithy IDL primitive codecs using RichTextCodec.
+ *
+ * These provide the building blocks for parsing Smithy IDL. The primitives
+ * demonstrate the enhanced | operator with Alternator support that unifies
+ * same-type alternatives without nested Either types.
+ */
+object SmithyCodecs {
+
+  /** Single space or tab */
+  val sp: RichTextCodec[Unit] =
+    RichTextCodec.filter(c => c == ' ' || c == '\t').const(' ')
+
+  /** Newline (LF or CRLF) */
+  val newline: RichTextCodec[Unit] = {
+    // CRLF: \r\n - Combiner with Unit simplifies Unit ~ Unit to Unit
+    val crlf = (RichTextCodec.char('\r').const('\r') ~ RichTextCodec.char('\n').const('\n'))
+      .transform(_ => ())(_ => ())
+    val lf   = RichTextCodec.char('\n').const('\n')
+    crlf | lf
+  }
+
+  /** Comma - treated as whitespace in Smithy */
+  val comma: RichTextCodec[Unit] =
+    RichTextCodec.char(',').const(',')
+
+  /** Basic whitespace character (space, tab, newline, comma) */
+  val wsChar: RichTextCodec[Unit] =
+    sp | newline | comma
+
+  /** Zero or more whitespace characters */
+  val ws: RichTextCodec[Unit] =
+    wsChar.repeat.transform(_ => ())(_ => Chunk.empty)
+
+  /** One or more whitespace characters */
+  val ws1: RichTextCodec[Unit] =
+    // Combiner with Unit simplifies Unit ~ Unit to Unit
+    (wsChar ~ ws).transform(_ => ())(_ => ())
+
+  /** Identifier: [a-zA-Z_][a-zA-Z0-9_]* */
+  val identifier: RichTextCodec[String] = {
+    val start = RichTextCodec.filter(c => c.isLetter || c == '_')
+    val rest  = RichTextCodec.filter(c => c.isLetterOrDigit || c == '_').repeat
+    (start ~ rest).transform { case (head, tail) =>
+      (head +: tail).mkString
+    } { s =>
+      (s.head, Chunk.fromArray(s.tail.toCharArray))
+    }
+  }
+
+  /** Namespace: identifier(.identifier)* */
+  val namespace: RichTextCodec[String] = {
+    val dot   = RichTextCodec.char('.').const('.')
+    val parts = (dot ~> identifier).repeat
+    (identifier ~ parts).transform { case (first, rest) =>
+      (first +: rest).mkString(".")
+    } { s =>
+      val ps = s.split("\\.")
+      (ps.head, Chunk.fromArray(ps.tail))
+    }
+  }
+
+  /** Quoted string with escape sequences */
+  val quotedString: RichTextCodec[String] = {
+    val quoteOpen  = RichTextCodec.char('"').const('"')
+    val quoteClose = RichTextCodec.char('"').const('"')
+
+    val backslash                        = RichTextCodec.char('\\').const('\\')
+    val escapedChar: RichTextCodec[Char] = (backslash ~> RichTextCodec.filter(_ => true)).transform {
+      case 'n'  => '\n'
+      case 'r'  => '\r'
+      case 't'  => '\t'
+      case '\\' => '\\'
+      case '"'  => '"'
+      case c    => c
+    } {
+      case '\n' => 'n'
+      case '\r' => 'r'
+      case '\t' => 't'
+      case '\\' => '\\'
+      case '"'  => '"'
+      case c    => c
+    }
+
+    val regularChar: RichTextCodec[Char] = RichTextCodec.filter(c => c != '"' && c != '\\')
+    val stringChar: RichTextCodec[Char]  = escapedChar | regularChar
+    val content                          = stringChar.repeat.string
+
+    quoteOpen ~> content <~ quoteClose
+  }
+
+  /** Integer number (possibly negative) */
+  val integerNumber: RichTextCodec[Long] = {
+    val minus  = RichTextCodec.char('-')
+    val digits = RichTextCodec.filter(_.isDigit).repeat
+    (minus.repeat ~ digits).transform { case (minuses, digitChars) =>
+      val numStr   = digitChars.mkString
+      val negative = minuses.nonEmpty
+      val value    = if (numStr.isEmpty) 0L else numStr.toLong
+      if (negative) -value else value
+    } { n =>
+      val abs    = math.abs(n)
+      val chars  = Chunk.fromArray(abs.toString.toCharArray)
+      val prefix = if (n < 0) Chunk.single('-') else Chunk.empty[Char]
+      (prefix, chars)
+    }
+  }
+
+  /** Decimal number (with optional decimal point) */
+  val decimalNumber: RichTextCodec[BigDecimal] = {
+    val minus      = RichTextCodec.char('-')
+    val digit      = RichTextCodec.filter(_.isDigit)
+    val digits     = digit.repeat
+    val dot        = RichTextCodec.char('.')
+    val fractional = (dot ~ digits).transform { case (_, frac) =>
+      "." + frac.mkString
+    } { s =>
+      ('.', Chunk.fromArray(s.drop(1).toCharArray))
+    }
+    val optFrac    = fractional | RichTextCodec.empty.as("")
+
+    (minus.repeat ~ digits ~ optFrac).transform { case (minuses, intDigits, frac) =>
+      val numStr   = intDigits.mkString + frac
+      val negative = minuses.nonEmpty
+      val value    = if (numStr.isEmpty || numStr == ".") BigDecimal(0) else BigDecimal(numStr)
+      if (negative) -value else value
+    } { n =>
+      val str            = n.abs.toString()
+      val dotIdx         = str.indexOf('.')
+      val (intPart, dec) = if (dotIdx >= 0) (str.take(dotIdx), str.drop(dotIdx)) else (str, "")
+      val prefix         = if (n < 0) Chunk.single('-') else Chunk.empty[Char]
+      (prefix, Chunk.fromArray(intPart.toCharArray), dec)
+    }
+  }
+
+  /** ShapeId: [namespace#]name[$member] */
+  val shapeId: RichTextCodec[ShapeId] = {
+    val hash   = RichTextCodec.char('#').const('#')
+    val dollar = RichTextCodec.char('$').const('$')
+
+    val nsAndHash = (namespace <~ hash).transform(ns => Some(ns): Option[String]) {
+      case Some(ns) => ns
+      case None     => ""
+    }
+    val optNs     = nsAndHash | RichTextCodec.empty.as(Option.empty[String])
+
+    val memberPart = (dollar ~> identifier).transform(m => Some(m): Option[String]) {
+      case Some(m) => m
+      case None    => ""
+    }
+    val optMember  = memberPart | RichTextCodec.empty.as(Option.empty[String])
+
+    (optNs ~ identifier ~ optMember).transform { case (ns, name, member) =>
+      ShapeId(ns, name, member)
+    } { id =>
+      (id.namespace, id.name, id.member)
+    }
+  }
+
+  /** Node string value */
+  val nodeString: RichTextCodec[NodeValue] =
+    quotedString.transform[NodeValue](NodeValue.Str(_)) {
+      case NodeValue.Str(s) => s
+      case _                => ""
+    }
+
+  /** Node number value */
+  val nodeNumber: RichTextCodec[NodeValue] =
+    decimalNumber.transform[NodeValue](NodeValue.Num(_)) {
+      case NodeValue.Num(n) => n
+      case _                => BigDecimal(0)
+    }
+
+  /** Node boolean value */
+  val nodeBool: RichTextCodec[NodeValue] = {
+    val t: RichTextCodec[NodeValue] =
+      RichTextCodec.literal("true").transform(_ => NodeValue.Bool(true): NodeValue)(_ => "true")
+    val f: RichTextCodec[NodeValue] =
+      RichTextCodec.literal("false").transform(_ => NodeValue.Bool(false): NodeValue)(_ => "false")
+    t | f
+  }
+
+  /** Node null value */
+  val nodeNull: RichTextCodec[NodeValue] =
+    RichTextCodec.literal("null").transform(_ => NodeValue.Null: NodeValue)(_ => "null")
+
+  /** Node shape ID value */
+  val nodeShapeId: RichTextCodec[NodeValue] =
+    shapeId.transform[NodeValue](NodeValue.ShapeIdValue(_)) {
+      case NodeValue.ShapeIdValue(id) => id
+      case _                          => ShapeId("Unknown")
+    }
+
+  /** Simple shape keyword - unified type thanks to Alternator */
+  val simpleShapeKeyword: RichTextCodec[String] = {
+    val keywords = List(
+      "bigDecimal",
+      "bigInteger",
+      "timestamp",
+      "document",
+      "boolean",
+      "integer",
+      "double",
+      "string",
+      "short",
+      "float",
+      "blob",
+      "byte",
+      "long",
+    )
+    keywords.map(RichTextCodec.literal).reduce(_ | _)
+  }
+
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyCodecs.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyCodecs.scala
@@ -139,7 +139,7 @@ object SmithyCodecs {
     }
   }
 
-  /** ShapeId: [namespace#]name[$member] */
+  /** ShapeId: `[namespace#]name[$$member]` */
   val shapeId: RichTextCodec[ShapeId] = {
     val hash   = RichTextCodec.char('#').const('#')
     val dollar = RichTextCodec.char('$').const('$')

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyConfig.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyConfig.scala
@@ -7,32 +7,39 @@ import zio.http.gen.openapi.Config.NormalizeFields
 /**
  * Configuration for Smithy code generation.
  *
- * @param fieldNamesNormalization Controls normalization of field names from Smithy conventions 
- *                                (e.g., snake_case) to Scala conventions (camelCase).
- *                                Original names are preserved via @fieldName annotations.
- *                                Enabled by default.
+ * @param fieldNamesNormalization
+ *   Controls normalization of field names from Smithy conventions (e.g.,
+ *   snake_case) to Scala conventions (camelCase). Original names are preserved
+ *   via @fieldName annotations. Enabled by default.
  *
- * @param validateBeforeGeneration If true, validates the Smithy model before generating code.
- *                                 Validation errors will cause generation to fail with detailed messages.
+ * @param validateBeforeGeneration
+ *   If true, validates the Smithy model before generating code. Validation
+ *   errors will cause generation to fail with detailed messages.
  *
- * @param generateCompanionObjects If true, generates companion objects with Schema derivation
- *                                 for all case classes.
+ * @param generateCompanionObjects
+ *   If true, generates companion objects with Schema derivation for all case
+ *   classes.
  *
- * @param unwrapSingleMemberInputs If true, operations with single-member input structures
- *                                 will use the member type directly instead of the wrapper.
- *                                 e.g., `GetUserInput { userId: String }` -> endpoint takes `String`
+ * @param unwrapSingleMemberInputs
+ *   If true, operations with single-member input structures will use the member
+ *   type directly instead of the wrapper. e.g.,
+ *   `GetUserInput { userId: String }` -> endpoint takes `String`
  *
- * @param generateEndpointsObject  If true, generates a single `Endpoints` object containing all
- *                                 endpoint definitions. If false, generates separate files per operation.
+ * @param generateEndpointsObject
+ *   If true, generates a single `Endpoints` object containing all endpoint
+ *   definitions. If false, generates separate files per operation.
  *
- * @param endpointsObjectName      Name of the generated endpoints object (default: "Endpoints").
+ * @param endpointsObjectName
+ *   Name of the generated endpoints object (default: "Endpoints").
  *
- * @param includeDocumentation     If true, includes Smithy @documentation traits as Scaladoc comments
- *                                 in the generated code.
+ * @param includeDocumentation
+ *   If true, includes Smithy @documentation traits as Scaladoc comments in the
+ *   generated code.
  *
- * @param typeMapping              Custom mapping of Smithy shape names to Scala types.
- *                                 Allows overriding default type mappings for specific shapes.
- *                                 e.g., Map("UserId" -> "java.util.UUID")
+ * @param typeMapping
+ *   Custom mapping of Smithy shape names to Scala types. Allows overriding
+ *   default type mappings for specific shapes. e.g., Map("UserId" ->
+ *   "java.util.UUID")
  */
 final case class SmithyConfig(
   fieldNamesNormalization: NormalizeFields,
@@ -49,11 +56,11 @@ object SmithyConfig {
 
   /**
    * Default configuration with field name normalization enabled.
-   * 
-   * - Field names are automatically converted to camelCase
-   * - Validation is enabled
-   * - Companion objects are generated
-   * - Documentation is included
+   *
+   *   - Field names are automatically converted to camelCase
+   *   - Validation is enabled
+   *   - Companion objects are generated
+   *   - Documentation is included
    */
   val default: SmithyConfig = SmithyConfig(
     fieldNamesNormalization = NormalizeFields(
@@ -69,15 +76,19 @@ object SmithyConfig {
     typeMapping = Map.empty,
   )
 
-  /** Config with validation disabled for faster generation during development */
+  /**
+   * Config with validation disabled for faster generation during development
+   */
   val fast: SmithyConfig = default.copy(validateBeforeGeneration = false)
 
-  /** Config with field name normalization disabled (preserves original names) */
+  /**
+   * Config with field name normalization disabled (preserves original names)
+   */
   val preserveFieldNames: SmithyConfig = default.copy(
     fieldNamesNormalization = NormalizeFields(
       enableAutomatic = false,
       manualOverrides = Map.empty,
-    )
+    ),
   )
 
   /** ZIO Config descriptor for loading from configuration files */

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyConfig.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyConfig.scala
@@ -1,0 +1,94 @@
+package zio.http.gen.smithy
+
+import zio.config.ConfigOps
+
+import zio.http.gen.openapi.Config.NormalizeFields
+
+/**
+ * Configuration for Smithy code generation.
+ *
+ * @param fieldNamesNormalization Controls normalization of field names from Smithy conventions 
+ *                                (e.g., snake_case) to Scala conventions (camelCase).
+ *                                Original names are preserved via @fieldName annotations.
+ *                                Enabled by default.
+ *
+ * @param validateBeforeGeneration If true, validates the Smithy model before generating code.
+ *                                 Validation errors will cause generation to fail with detailed messages.
+ *
+ * @param generateCompanionObjects If true, generates companion objects with Schema derivation
+ *                                 for all case classes.
+ *
+ * @param unwrapSingleMemberInputs If true, operations with single-member input structures
+ *                                 will use the member type directly instead of the wrapper.
+ *                                 e.g., `GetUserInput { userId: String }` -> endpoint takes `String`
+ *
+ * @param generateEndpointsObject  If true, generates a single `Endpoints` object containing all
+ *                                 endpoint definitions. If false, generates separate files per operation.
+ *
+ * @param endpointsObjectName      Name of the generated endpoints object (default: "Endpoints").
+ *
+ * @param includeDocumentation     If true, includes Smithy @documentation traits as Scaladoc comments
+ *                                 in the generated code.
+ *
+ * @param typeMapping              Custom mapping of Smithy shape names to Scala types.
+ *                                 Allows overriding default type mappings for specific shapes.
+ *                                 e.g., Map("UserId" -> "java.util.UUID")
+ */
+final case class SmithyConfig(
+  fieldNamesNormalization: NormalizeFields,
+  validateBeforeGeneration: Boolean,
+  generateCompanionObjects: Boolean,
+  unwrapSingleMemberInputs: Boolean,
+  generateEndpointsObject: Boolean,
+  endpointsObjectName: String,
+  includeDocumentation: Boolean,
+  typeMapping: Map[String, String],
+)
+
+object SmithyConfig {
+
+  /**
+   * Default configuration with field name normalization enabled.
+   * 
+   * - Field names are automatically converted to camelCase
+   * - Validation is enabled
+   * - Companion objects are generated
+   * - Documentation is included
+   */
+  val default: SmithyConfig = SmithyConfig(
+    fieldNamesNormalization = NormalizeFields(
+      enableAutomatic = true,
+      manualOverrides = Map.empty,
+    ),
+    validateBeforeGeneration = true,
+    generateCompanionObjects = true,
+    unwrapSingleMemberInputs = false,
+    generateEndpointsObject = true,
+    endpointsObjectName = "Endpoints",
+    includeDocumentation = true,
+    typeMapping = Map.empty,
+  )
+
+  /** Config with validation disabled for faster generation during development */
+  val fast: SmithyConfig = default.copy(validateBeforeGeneration = false)
+
+  /** Config with field name normalization disabled (preserves original names) */
+  val preserveFieldNames: SmithyConfig = default.copy(
+    fieldNamesNormalization = NormalizeFields(
+      enableAutomatic = false,
+      manualOverrides = Map.empty,
+    )
+  )
+
+  /** ZIO Config descriptor for loading from configuration files */
+  lazy val config: zio.Config[SmithyConfig] = (
+    NormalizeFields.config.nested("fields-normalization") ++
+      zio.Config.boolean("validate-before-generation").withDefault(default.validateBeforeGeneration) ++
+      zio.Config.boolean("generate-companion-objects").withDefault(default.generateCompanionObjects) ++
+      zio.Config.boolean("unwrap-single-member-inputs").withDefault(default.unwrapSingleMemberInputs) ++
+      zio.Config.boolean("generate-endpoints-object").withDefault(default.generateEndpointsObject) ++
+      zio.Config.string("endpoints-object-name").withDefault(default.endpointsObjectName) ++
+      zio.Config.boolean("include-documentation").withDefault(default.includeDocumentation) ++
+      zio.Config.table("type-mapping", zio.Config.string)
+  ).to[SmithyConfig]
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
@@ -2,12 +2,12 @@ package zio.http.gen.smithy
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
+
 import scala.jdk.CollectionConverters._
 
 import zio.http.Method
-import zio.http.gen.scala.Code
 import zio.http.gen.scala.Code._
-import zio.http.gen.scala.CodeGen
+import zio.http.gen.scala.{Code, CodeGen}
 
 /**
  * Generates zio-http Endpoint definitions from Smithy models.

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
@@ -11,12 +11,12 @@ import zio.http.gen.scala.CodeGen
 
 /**
  * Generates zio-http Endpoint definitions from Smithy models.
- * 
+ *
  * This code generator reads a SmithyModel AST and produces:
- * - Endpoint definitions for operations with @http traits
- * - Case classes for structure shapes
- * - Sealed traits for union shapes
- * - Type aliases for simple shapes
+ *   - Endpoint definitions for operations with @http traits
+ *   - Case classes for structure shapes
+ *   - Sealed traits for union shapes
+ *   - Type aliases for simple shapes
  */
 object SmithyEndpointGen {
 
@@ -38,9 +38,11 @@ object SmithyEndpointGen {
 
   /**
    * Generate Code.Files from a SmithyModel
-   * 
-   * @param model The SmithyModel to generate code from
-   * @param config Configuration options for code generation
+   *
+   * @param model
+   *   The SmithyModel to generate code from
+   * @param config
+   *   Configuration options for code generation
    */
   def fromSmithyModel(model: SmithyModel, config: SmithyConfig): Code.Files = {
     val gen = new SmithyEndpointGen(model, config)
@@ -49,23 +51,34 @@ object SmithyEndpointGen {
 
   /**
    * Generate Code.Files from a SmithyModel with validation using default config
-   * 
-   * @param model The SmithyModel to generate code from
-   * @param validate Whether to validate the model before generation
-   * @return Either validation errors or the generated code files
+   *
+   * @param model
+   *   The SmithyModel to generate code from
+   * @param validate
+   *   Whether to validate the model before generation
+   * @return
+   *   Either validation errors or the generated code files
    */
   def fromSmithyModelValidated(model: SmithyModel, validate: Boolean = true): Either[String, Code.Files] =
     fromSmithyModelValidated(model, SmithyConfig.default, validate)
 
   /**
    * Generate Code.Files from a SmithyModel with optional validation
-   * 
-   * @param model The SmithyModel to generate code from
-   * @param config Configuration options for code generation
-   * @param validate Whether to validate the model before generation (overrides config)
-   * @return Either validation errors or the generated code files
+   *
+   * @param model
+   *   The SmithyModel to generate code from
+   * @param config
+   *   Configuration options for code generation
+   * @param validate
+   *   Whether to validate the model before generation (overrides config)
+   * @return
+   *   Either validation errors or the generated code files
    */
-  def fromSmithyModelValidated(model: SmithyModel, config: SmithyConfig, validate: Boolean): Either[String, Code.Files] = {
+  def fromSmithyModelValidated(
+    model: SmithyModel,
+    config: SmithyConfig,
+    validate: Boolean,
+  ): Either[String, Code.Files] = {
     val shouldValidate = validate && config.validateBeforeGeneration
     if (shouldValidate) {
       val validationResult = SmithyValidation.validate(model)
@@ -87,9 +100,11 @@ object SmithyEndpointGen {
 
   /**
    * Parse a Smithy IDL string and generate Code.Files
-   * 
-   * @param smithyIdl The Smithy IDL string to parse
-   * @param config Configuration options for code generation
+   *
+   * @param smithyIdl
+   *   The Smithy IDL string to parse
+   * @param config
+   *   Configuration options for code generation
    */
   def fromString(smithyIdl: String, config: SmithyConfig): Either[String, Code.Files] = {
     SmithyParser.parse(smithyIdl).flatMap { model =>
@@ -105,9 +120,11 @@ object SmithyEndpointGen {
 
   /**
    * Read a single .smithy file and generate Code.Files
-   * 
-   * @param path Path to the .smithy file
-   * @param config Configuration options for code generation
+   *
+   * @param path
+   *   Path to the .smithy file
+   * @param config
+   *   Configuration options for code generation
    */
   def fromFile(path: Path, config: SmithyConfig): Either[String, Code.Files] = {
     try {
@@ -119,17 +136,21 @@ object SmithyEndpointGen {
   }
 
   /**
-   * Read all .smithy files from a directory and generate combined Code.Files using default config
+   * Read all .smithy files from a directory and generate combined Code.Files
+   * using default config
    */
   def fromDirectory(dir: Path): Either[String, Code.Files] =
     fromDirectory(dir, SmithyConfig.default)
 
   /**
    * Read all .smithy files from a directory and generate combined Code.Files
-   * 
-   * @param dir Directory containing .smithy files
-   * @param config Configuration options for code generation
-   * @return Either parse/validation errors or the generated code files
+   *
+   * @param dir
+   *   Directory containing .smithy files
+   * @param config
+   *   Configuration options for code generation
+   * @return
+   *   Either parse/validation errors or the generated code files
    */
   def fromDirectory(dir: Path, config: SmithyConfig): Either[String, Code.Files] = {
     try {
@@ -137,7 +158,8 @@ object SmithyEndpointGen {
         return Left(s"Not a directory: $dir")
       }
 
-      val smithyFiles = Files.walk(dir)
+      val smithyFiles = Files
+        .walk(dir)
         .iterator()
         .asScala
         .filter(p => Files.isRegularFile(p) && p.toString.endsWith(".smithy"))
@@ -163,7 +185,7 @@ object SmithyEndpointGen {
       }
 
       // Merge all models
-      val models = results.collect { case Right((_, model)) => model }
+      val models      = results.collect { case Right((_, model)) => model }
       val mergedModel = mergeModels(models)
 
       // Optionally validate based on config
@@ -174,38 +196,50 @@ object SmithyEndpointGen {
   }
 
   /**
-   * Generate code from .smithy files and write to target directory using default config
-   * 
-   * @param sourceDir Directory containing .smithy files
-   * @param targetDir Directory to write generated Scala files
-   * @param basePackage Base package for generated code
-   * @param scalafmtPath Optional path to scalafmt config for formatting
-   * @return Either an error message or the list of generated file paths
+   * Generate code from .smithy files and write to target directory using
+   * default config
+   *
+   * @param sourceDir
+   *   Directory containing .smithy files
+   * @param targetDir
+   *   Directory to write generated Scala files
+   * @param basePackage
+   *   Base package for generated code
+   * @param scalafmtPath
+   *   Optional path to scalafmt config for formatting
+   * @return
+   *   Either an error message or the list of generated file paths
    */
   def generate(
     sourceDir: Path,
     targetDir: Path,
     basePackage: String,
-    scalafmtPath: Option[Path] = None
+    scalafmtPath: Option[Path] = None,
   ): Either[String, Iterable[Path]] =
     generate(sourceDir, targetDir, basePackage, scalafmtPath, SmithyConfig.default)
 
   /**
    * Generate code from .smithy files and write to target directory
-   * 
-   * @param sourceDir Directory containing .smithy files
-   * @param targetDir Directory to write generated Scala files
-   * @param basePackage Base package for generated code
-   * @param scalafmtPath Optional path to scalafmt config for formatting
-   * @param config Configuration options for code generation
-   * @return Either an error message or the list of generated file paths
+   *
+   * @param sourceDir
+   *   Directory containing .smithy files
+   * @param targetDir
+   *   Directory to write generated Scala files
+   * @param basePackage
+   *   Base package for generated code
+   * @param scalafmtPath
+   *   Optional path to scalafmt config for formatting
+   * @param config
+   *   Configuration options for code generation
+   * @return
+   *   Either an error message or the list of generated file paths
    */
   def generate(
     sourceDir: Path,
     targetDir: Path,
     basePackage: String,
     scalafmtPath: Option[Path],
-    config: SmithyConfig
+    config: SmithyConfig,
   ): Either[String, Iterable[Path]] = {
     fromDirectory(sourceDir, config).map { files =>
       CodeGen.writeFiles(files, targetDir, basePackage, scalafmtPath)
@@ -213,38 +247,50 @@ object SmithyEndpointGen {
   }
 
   /**
-   * Generate code from a single .smithy file and write to target directory using default config
-   * 
-   * @param sourceFile Path to the .smithy file
-   * @param targetDir Directory to write generated Scala files
-   * @param basePackage Base package for generated code
-   * @param scalafmtPath Optional path to scalafmt config for formatting
-   * @return Either an error message or the list of generated file paths
+   * Generate code from a single .smithy file and write to target directory
+   * using default config
+   *
+   * @param sourceFile
+   *   Path to the .smithy file
+   * @param targetDir
+   *   Directory to write generated Scala files
+   * @param basePackage
+   *   Base package for generated code
+   * @param scalafmtPath
+   *   Optional path to scalafmt config for formatting
+   * @return
+   *   Either an error message or the list of generated file paths
    */
   def generateFromFile(
     sourceFile: Path,
     targetDir: Path,
     basePackage: String,
-    scalafmtPath: Option[Path] = None
+    scalafmtPath: Option[Path] = None,
   ): Either[String, Iterable[Path]] =
     generateFromFile(sourceFile, targetDir, basePackage, scalafmtPath, SmithyConfig.default)
 
   /**
    * Generate code from a single .smithy file and write to target directory
-   * 
-   * @param sourceFile Path to the .smithy file
-   * @param targetDir Directory to write generated Scala files
-   * @param basePackage Base package for generated code
-   * @param scalafmtPath Optional path to scalafmt config for formatting
-   * @param config Configuration options for code generation
-   * @return Either an error message or the list of generated file paths
+   *
+   * @param sourceFile
+   *   Path to the .smithy file
+   * @param targetDir
+   *   Directory to write generated Scala files
+   * @param basePackage
+   *   Base package for generated code
+   * @param scalafmtPath
+   *   Optional path to scalafmt config for formatting
+   * @param config
+   *   Configuration options for code generation
+   * @return
+   *   Either an error message or the list of generated file paths
    */
   def generateFromFile(
     sourceFile: Path,
     targetDir: Path,
     basePackage: String,
     scalafmtPath: Option[Path],
-    config: SmithyConfig
+    config: SmithyConfig,
   ): Either[String, Iterable[Path]] = {
     fromFile(sourceFile, config).map { files =>
       CodeGen.writeFiles(files, targetDir, basePackage, scalafmtPath)
@@ -252,24 +298,24 @@ object SmithyEndpointGen {
   }
 
   /**
-   * Merge multiple SmithyModels into one
-   * Uses the namespace from the first model
+   * Merge multiple SmithyModels into one Uses the namespace from the first
+   * model
    */
   private def mergeModels(models: List[SmithyModel]): SmithyModel = {
     if (models.isEmpty) {
       SmithyModel("2", "", Map.empty, Nil, Map.empty)
     } else {
-      val first = models.head
-      val allShapes = models.flatMap(_.shapes).toMap
+      val first            = models.head
+      val allShapes        = models.flatMap(_.shapes).toMap
       val allUseStatements = models.flatMap(_.useStatements).distinct
-      val allMetadata = models.flatMap(_.metadata).toMap
-      
+      val allMetadata      = models.flatMap(_.metadata).toMap
+
       SmithyModel(
         version = first.version,
         namespace = first.namespace,
         metadata = allMetadata,
         useStatements = allUseStatements,
-        shapes = allShapes
+        shapes = allShapes,
       )
     }
   }
@@ -280,7 +326,7 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
 
   def generate(): Code.Files = {
     val componentFiles = generateComponents()
-    val endpointFiles = generateEndpoints()
+    val endpointFiles  = generateEndpoints()
     Code.Files(componentFiles ++ endpointFiles)
   }
 
@@ -316,27 +362,29 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       Code.Field(memberName, finalType, Nil, config.fieldNamesNormalization)
     }
 
-    Some(Code.File(
-      path = List("component", s"${name.capitalize}.scala"),
-      pkgPath = List("component"),
-      imports = DataImports,
-      objects = Nil,
-      caseClasses = List(
-        Code.CaseClass(
-          name = name,
-          fields = fields,
-          companionObject = Some(Code.Object.schemaCompanion(name)),
-          mixins = Nil,
-        )
+    Some(
+      Code.File(
+        path = List("component", s"${name.capitalize}.scala"),
+        pkgPath = List("component"),
+        imports = DataImports,
+        objects = Nil,
+        caseClasses = List(
+          Code.CaseClass(
+            name = name,
+            fields = fields,
+            companionObject = Some(Code.Object.schemaCompanion(name)),
+            mixins = Nil,
+          ),
+        ),
+        enums = Nil,
       ),
-      enums = Nil,
-    ))
+    )
   }
 
   private def unionToCode(name: String, union: Shape.UnionShape): Option[Code.File] = {
     val cases = union.members.toList.map { case (memberName, member) =>
       val fields = List(
-        Code.Field("value", shapeIdToType(member.target), Nil, config.fieldNamesNormalization)
+        Code.Field("value", shapeIdToType(member.target), Nil, config.fieldNamesNormalization),
       )
       Code.CaseClass(
         name = memberName.capitalize,
@@ -346,23 +394,25 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       )
     }
 
-    Some(Code.File(
-      path = List("component", s"${name.capitalize}.scala"),
-      pkgPath = List("component"),
-      imports = DataImports ++ List(Code.Import("zio.schema.annotation._")),
-      objects = Nil,
-      caseClasses = Nil,
-      enums = List(
-        Code.Enum(
-          name = name,
-          cases = cases,
-          caseNames = Nil,
-          discriminator = None,
-          noDiscriminator = true,
-          schema = true,
-        )
+    Some(
+      Code.File(
+        path = List("component", s"${name.capitalize}.scala"),
+        pkgPath = List("component"),
+        imports = DataImports ++ List(Code.Import("zio.schema.annotation._")),
+        objects = Nil,
+        caseClasses = Nil,
+        enums = List(
+          Code.Enum(
+            name = name,
+            cases = cases,
+            caseNames = Nil,
+            discriminator = None,
+            noDiscriminator = true,
+            schema = true,
+          ),
+        ),
       ),
-    ))
+    )
   }
 
   private def enumToCode(name: String, `enum`: Shape.EnumShape): Option[Code.File] = {
@@ -375,23 +425,25 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       )
     }
 
-    Some(Code.File(
-      path = List("component", s"${name.capitalize}.scala"),
-      pkgPath = List("component"),
-      imports = DataImports,
-      objects = Nil,
-      caseClasses = Nil,
-      enums = List(
-        Code.Enum(
-          name = name,
-          cases = cases,
-          caseNames = Nil,
-          discriminator = None,
-          noDiscriminator = false,
-          schema = true,
-        )
+    Some(
+      Code.File(
+        path = List("component", s"${name.capitalize}.scala"),
+        pkgPath = List("component"),
+        imports = DataImports,
+        objects = Nil,
+        caseClasses = Nil,
+        enums = List(
+          Code.Enum(
+            name = name,
+            cases = cases,
+            caseNames = Nil,
+            discriminator = None,
+            noDiscriminator = false,
+            schema = true,
+          ),
+        ),
       ),
-    ))
+    )
   }
 
   // ===========================================================================
@@ -411,35 +463,37 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
     if (endpoints.isEmpty) return Nil
 
     // Create a single Endpoints object
-    List(Code.File(
-      path = List("Endpoints.scala"),
-      pkgPath = Nil,
-      imports = EndpointImports ++ List(Code.Import.FromBase("component._")),
-      objects = List(
-        Code.Object(
-          name = "Endpoints",
-          extensions = Nil,
-          schema = None,
-          endpoints = endpoints.toMap,
-          objects = Nil,
-          caseClasses = Nil,
-          enums = Nil,
-        )
+    List(
+      Code.File(
+        path = List("Endpoints.scala"),
+        pkgPath = Nil,
+        imports = EndpointImports ++ List(Code.Import.FromBase("component._")),
+        objects = List(
+          Code.Object(
+            name = "Endpoints",
+            extensions = Nil,
+            schema = None,
+            endpoints = endpoints.toMap,
+            objects = Nil,
+            caseClasses = Nil,
+            enums = Nil,
+          ),
+        ),
+        caseClasses = Nil,
+        enums = Nil,
       ),
-      caseClasses = Nil,
-      enums = Nil,
-    ))
+    )
   }
 
   private def operationToEndpoint(name: String, op: Shape.OperationShape): Option[(Code.Field, Code.EndpointCode)] = {
     op.httpTrait.map { http =>
-      val method = httpMethodToMethod(http.method)
-      val inputShape = op.input.flatMap(id => model.getStructure(id.name))
+      val method      = httpMethodToMethod(http.method)
+      val inputShape  = op.input.flatMap(id => model.getStructure(id.name))
       val outputShape = op.output.flatMap(id => model.getStructure(id.name))
-      
+
       // Build path segments
       val segments = buildPathSegments(http.uri, inputShape)
-      
+
       // Extract query parameters (members with @httpQuery)
       val queryParams: Set[Code.QueryParamCode] = inputShape.toSet.flatMap { (struct: Shape.StructureShape) =>
         struct.members.values.flatMap { member =>
@@ -448,7 +502,7 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
           }
         }
       }
-      
+
       // Extract headers (members with @httpHeader)
       val headers = inputShape.toList.flatMap { struct =>
         struct.members.values.flatMap { member =>
@@ -457,26 +511,26 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
           }
         }.toList
       }
-      
+
       // Check for streaming on input
       val inputStreaming = isStreamingShape(op.input)
-      
-      // Check for streaming on output  
+
+      // Check for streaming on output
       val outputStreaming = isStreamingShape(op.output)
-      
+
       // Input type - the request body (member with @httpPayload or the whole input minus path/query/header)
       val inType = determineInputType(op, inputShape)
-      
+
       // Output type
       val outType = op.output.map(_.name).getOrElse("Unit")
-      
+
       // Get documentation from operation traits
       val opDoc = op.traits.collectFirst { case SmithyTrait.Documentation(doc) => doc }
-      
+
       // Determine media type
-      val inMediaType = determineMediaType(inputShape)
+      val inMediaType  = determineMediaType(inputShape)
       val outMediaType = determineMediaType(outputShape)
-      
+
       // Error types
       val errorCodes = op.errors.map { errorId =>
         // Check if error has @httpError trait
@@ -484,11 +538,11 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
         val statusCode = errorShape.flatMap { s =>
           s.traits.collectFirst { case SmithyTrait.HttpError(code) => code }
         }.getOrElse(500)
-        
+
         val errorDoc = errorShape.flatMap { s =>
           s.traits.collectFirst { case SmithyTrait.Documentation(doc) => doc }
         }
-        
+
         Code.OutCode(
           outType = errorId.name,
           status = zio.http.Status.fromInt(statusCode),
@@ -511,7 +565,7 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
             mediaType = outMediaType,
             doc = opDoc,
             streaming = outputStreaming,
-          )
+          ),
         ),
         errorsCode = errorCodes,
         authTypeCode = None,
@@ -520,23 +574,24 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       Code.Field(name, config.fieldNamesNormalization) -> endpointCode
     }
   }
-  
+
   /**
    * Check if a shape reference points to a streaming blob
    */
   private def isStreamingShape(shapeRef: Option[ShapeId]): Boolean = {
     shapeRef.exists { ref =>
       model.getShape(ref.name) match {
-        case Some(shape) => shape.traits.exists {
-          case SmithyTrait.Streaming => true
-          case SmithyTrait.EventStream => true
-          case _ => false
-        }
-        case None => false
+        case Some(shape) =>
+          shape.traits.exists {
+            case SmithyTrait.Streaming   => true
+            case SmithyTrait.EventStream => true
+            case _                       => false
+          }
+        case None        => false
       }
     }
   }
-  
+
   /**
    * Determine media type from shape traits
    */
@@ -560,17 +615,17 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
 
   private def buildPathSegments(
     uri: String,
-    inputShape: Option[Shape.StructureShape]
+    inputShape: Option[Shape.StructureShape],
   ): List[Code.PathSegmentCode] = {
     val segments = uri.stripPrefix("/").split("/").toList
-    
+
     segments.filter(_.nonEmpty).map { segment =>
       if (segment.startsWith("{") && segment.endsWith("}")) {
         val paramName = segment.tail.init
         val paramType = inputShape.flatMap { struct =>
           struct.members.get(paramName).map(m => shapeIdToCodecType(m.target))
         }.getOrElse(Code.CodecType.String)
-        
+
         Code.PathSegmentCode(paramName, paramType)
       } else {
         Code.PathSegmentCode(segment, Code.CodecType.Literal)
@@ -580,16 +635,16 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
 
   private def determineInputType(
     op: Shape.OperationShape,
-    inputShape: Option[Shape.StructureShape]
+    inputShape: Option[Shape.StructureShape],
   ): String = {
     inputShape match {
-      case None => "Unit"
+      case None         => "Unit"
       case Some(struct) =>
         // Check if there's a @httpPayload member
         val payloadMember = struct.members.values.find(_.httpPayload)
         payloadMember match {
           case Some(member) => shapeIdToTypeName(member.target)
-          case None =>
+          case None         =>
             // If no payload, check if there are non-path/query/header members
             val bodyMembers = struct.members.values.filterNot { m =>
               m.httpLabel || m.httpQuery.isDefined || m.httpHeader.isDefined
@@ -606,7 +661,7 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
 
   private def shapeIdToType(shapeId: ShapeId): Code.ScalaType = {
     val name = shapeId.name
-    
+
     // Check if it's a prelude type
     name match {
       case "String"     => Code.Primitive.ScalaString
@@ -623,21 +678,29 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       case "BigInteger" => Code.TypeRef("BigInt")
       case "BigDecimal" => Code.TypeRef("BigDecimal")
       case "Unit"       => Code.ScalaType.Unit
-      case _ =>
+      case _            =>
         // Check if it's a shape in our model
         model.shapes.get(name) match {
-          case Some(_: Shape.ListShape) =>
-            model.shapes.get(name).collect { case l: Shape.ListShape => l }.map { list =>
-              shapeIdToType(list.member).seq(nonEmpty = false)
-            }.getOrElse(Code.TypeRef(name))
-          case Some(_: Shape.MapShape) =>
-            model.shapes.get(name).collect { case m: Shape.MapShape => m }.map { map =>
-              Code.Collection.Map(shapeIdToType(map.value), Some(shapeIdToType(map.key)))
-            }.getOrElse(Code.TypeRef(name))
+          case Some(_: Shape.ListShape)   =>
+            model.shapes
+              .get(name)
+              .collect { case l: Shape.ListShape => l }
+              .map { list =>
+                shapeIdToType(list.member).seq(nonEmpty = false)
+              }
+              .getOrElse(Code.TypeRef(name))
+          case Some(_: Shape.MapShape)    =>
+            model.shapes
+              .get(name)
+              .collect { case m: Shape.MapShape => m }
+              .map { map =>
+                Code.Collection.Map(shapeIdToType(map.value), Some(shapeIdToType(map.key)))
+              }
+              .getOrElse(Code.TypeRef(name))
           case Some(_: Shape.SimpleShape) =>
             // Simple shapes are type aliases
             shapeIdToTypeForSimpleShape(name)
-          case _ =>
+          case _                          =>
             // Reference to a structure, union, etc.
             Code.TypeRef(name)
         }
@@ -692,7 +755,7 @@ final class SmithyEndpointGen(model: SmithyModel, config: SmithyConfig) {
       case "Long"      => Code.CodecType.Long
       case "Boolean"   => Code.CodecType.Boolean
       case "Timestamp" => Code.CodecType.Instant
-      case _ =>
+      case _           =>
         // Check if it's a simple shape alias
         model.shapes.get(name) match {
           case Some(_: Shape.StringShape)    => Code.CodecType.String

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyEndpointGen.scala
@@ -1,0 +1,423 @@
+package zio.http.gen.smithy
+
+import zio.http.Method
+import zio.http.gen.scala.Code
+import zio.http.gen.scala.Code._
+
+/**
+ * Generates zio-http Endpoint definitions from Smithy models.
+ * 
+ * This code generator reads a SmithyModel AST and produces:
+ * - Endpoint definitions for operations with @http traits
+ * - Case classes for structure shapes
+ * - Sealed traits for union shapes
+ * - Type aliases for simple shapes
+ */
+object SmithyEndpointGen {
+
+  private val DataImports = List(
+    Code.Import("zio.schema._"),
+  )
+
+  private val EndpointImports = List(
+    Code.Import("zio.http._"),
+    Code.Import("zio.http.endpoint._"),
+    Code.Import("zio.http.codec._"),
+  )
+
+  /**
+   * Generate Code.Files from a SmithyModel
+   */
+  def fromSmithyModel(model: SmithyModel): Code.Files = {
+    val gen = new SmithyEndpointGen(model)
+    gen.generate()
+  }
+}
+
+final class SmithyEndpointGen(model: SmithyModel) {
+  import SmithyEndpointGen._
+
+  def generate(): Code.Files = {
+    val componentFiles = generateComponents()
+    val endpointFiles = generateEndpoints()
+    Code.Files(componentFiles ++ endpointFiles)
+  }
+
+  // ===========================================================================
+  // Component Generation (structures, unions, enums, etc.)
+  // ===========================================================================
+
+  private def generateComponents(): List[Code.File] = {
+    model.shapes.toList.flatMap { case (name, shape) =>
+      shapeToCode(name, shape)
+    }
+  }
+
+  private def shapeToCode(name: String, shape: Shape): Option[Code.File] = {
+    shape match {
+      case s: Shape.StructureShape => structureToCode(name, s)
+      case s: Shape.UnionShape     => unionToCode(name, s)
+      case s: Shape.EnumShape      => enumToCode(name, s)
+      case _: Shape.ListShape      => None // Lists are inlined as Chunk[T]
+      case _: Shape.MapShape       => None // Maps are inlined as Map[K, V]
+      case _: Shape.SimpleShape    => None // Simple shapes are primitives
+      case _: Shape.ServiceShape   => None // Services don't generate types
+      case _: Shape.OperationShape => None // Operations generate endpoints
+      case _: Shape.ResourceShape  => None // Resources are organizational
+      case _                       => None
+    }
+  }
+
+  private def structureToCode(name: String, structure: Shape.StructureShape): Option[Code.File] = {
+    val fields = structure.members.toList.map { case (memberName, member) =>
+      val fieldType = shapeIdToType(member.target)
+      val finalType = if (member.isRequired) fieldType else fieldType.opt
+      Code.Field(memberName, finalType, Nil, zio.http.gen.openapi.Config.default.fieldNamesNormalization)
+    }
+
+    Some(Code.File(
+      path = List("component", s"${name.capitalize}.scala"),
+      pkgPath = List("component"),
+      imports = DataImports,
+      objects = Nil,
+      caseClasses = List(
+        Code.CaseClass(
+          name = name,
+          fields = fields,
+          companionObject = Some(Code.Object.schemaCompanion(name)),
+          mixins = Nil,
+        )
+      ),
+      enums = Nil,
+    ))
+  }
+
+  private def unionToCode(name: String, union: Shape.UnionShape): Option[Code.File] = {
+    val cases = union.members.toList.map { case (memberName, member) =>
+      val fields = List(
+        Code.Field("value", shapeIdToType(member.target), Nil, zio.http.gen.openapi.Config.default.fieldNamesNormalization)
+      )
+      Code.CaseClass(
+        name = memberName.capitalize,
+        fields = fields,
+        companionObject = None,
+        mixins = List(name),
+      )
+    }
+
+    Some(Code.File(
+      path = List("component", s"${name.capitalize}.scala"),
+      pkgPath = List("component"),
+      imports = DataImports ++ List(Code.Import("zio.schema.annotation._")),
+      objects = Nil,
+      caseClasses = Nil,
+      enums = List(
+        Code.Enum(
+          name = name,
+          cases = cases,
+          caseNames = Nil,
+          discriminator = None,
+          noDiscriminator = true,
+          schema = true,
+        )
+      ),
+    ))
+  }
+
+  private def enumToCode(name: String, `enum`: Shape.EnumShape): Option[Code.File] = {
+    val cases = `enum`.members.toList.map { case (memberName, _) =>
+      Code.CaseClass(
+        name = memberName,
+        fields = Nil,
+        companionObject = None,
+        mixins = List(name),
+      )
+    }
+
+    Some(Code.File(
+      path = List("component", s"${name.capitalize}.scala"),
+      pkgPath = List("component"),
+      imports = DataImports,
+      objects = Nil,
+      caseClasses = Nil,
+      enums = List(
+        Code.Enum(
+          name = name,
+          cases = cases,
+          caseNames = Nil,
+          discriminator = None,
+          noDiscriminator = false,
+          schema = true,
+        )
+      ),
+    ))
+  }
+
+  // ===========================================================================
+  // Endpoint Generation
+  // ===========================================================================
+
+  private def generateEndpoints(): List[Code.File] = {
+    val httpOperations = model.httpOperations
+
+    if (httpOperations.isEmpty) return Nil
+
+    // Group operations by service or just put them all in one file
+    val endpoints = httpOperations.toList.flatMap { case (opName, op) =>
+      operationToEndpoint(opName, op)
+    }
+
+    if (endpoints.isEmpty) return Nil
+
+    // Create a single Endpoints object
+    List(Code.File(
+      path = List("Endpoints.scala"),
+      pkgPath = Nil,
+      imports = EndpointImports ++ List(Code.Import.FromBase("component._")),
+      objects = List(
+        Code.Object(
+          name = "Endpoints",
+          extensions = Nil,
+          schema = None,
+          endpoints = endpoints.toMap,
+          objects = Nil,
+          caseClasses = Nil,
+          enums = Nil,
+        )
+      ),
+      caseClasses = Nil,
+      enums = Nil,
+    ))
+  }
+
+  private def operationToEndpoint(name: String, op: Shape.OperationShape): Option[(Code.Field, Code.EndpointCode)] = {
+    op.httpTrait.map { http =>
+      val method = httpMethodToMethod(http.method)
+      val inputShape = op.input.flatMap(id => model.getStructure(id.name))
+      
+      // Build path segments
+      val segments = buildPathSegments(http.uri, inputShape)
+      
+      // Extract query parameters (members with @httpQuery)
+      val queryParams: Set[Code.QueryParamCode] = inputShape.toSet.flatMap { (struct: Shape.StructureShape) =>
+        struct.members.values.flatMap { member =>
+          member.httpQuery.map { queryName =>
+            Code.QueryParamCode(queryName, shapeIdToCodecType(member.target))
+          }
+        }
+      }
+      
+      // Extract headers (members with @httpHeader)
+      val headers = inputShape.toList.flatMap { struct =>
+        struct.members.values.flatMap { member =>
+          member.httpHeader.map { headerName =>
+            Code.HeaderCode(headerName)
+          }
+        }.toList
+      }
+      
+      // Input type - the request body (member with @httpPayload or the whole input minus path/query/header)
+      val inType = determineInputType(op, inputShape)
+      
+      // Output type
+      val outType = op.output.map(_.name).getOrElse("Unit")
+      
+      // Error types
+      val errorCodes = op.errors.map { errorId =>
+        // Check if error has @httpError trait
+        val errorShape = model.getStructure(errorId.name)
+        val statusCode = errorShape.flatMap { s =>
+          s.traits.collectFirst { case SmithyTrait.HttpError(code) => code }
+        }.getOrElse(500)
+        
+        Code.OutCode(
+          outType = errorId.name,
+          status = zio.http.Status.fromInt(statusCode),
+          mediaType = Some("application/json"),
+          doc = None,
+          streaming = false,
+        )
+      }
+
+      val endpointCode = Code.EndpointCode(
+        method = method,
+        pathPatternCode = Code.PathPatternCode(segments),
+        queryParamsCode = queryParams,
+        headersCode = Code.HeadersCode(headers),
+        inCode = Code.InCode(inType),
+        outCodes = List(
+          Code.OutCode(
+            outType = outType,
+            status = zio.http.Status.fromInt(http.code),
+            mediaType = Some("application/json"),
+            doc = None,
+            streaming = false,
+          )
+        ),
+        errorsCode = errorCodes,
+        authTypeCode = None,
+      )
+
+      Code.Field(name, zio.http.gen.openapi.Config.default.fieldNamesNormalization) -> endpointCode
+    }
+  }
+
+  private def httpMethodToMethod(method: String): Method = method.toUpperCase match {
+    case "GET"     => Method.GET
+    case "POST"    => Method.POST
+    case "PUT"     => Method.PUT
+    case "DELETE"  => Method.DELETE
+    case "PATCH"   => Method.PATCH
+    case "HEAD"    => Method.HEAD
+    case "OPTIONS" => Method.OPTIONS
+    case "TRACE"   => Method.TRACE
+    case _         => Method.GET
+  }
+
+  private def buildPathSegments(
+    uri: String,
+    inputShape: Option[Shape.StructureShape]
+  ): List[Code.PathSegmentCode] = {
+    val segments = uri.stripPrefix("/").split("/").toList
+    
+    segments.filter(_.nonEmpty).map { segment =>
+      if (segment.startsWith("{") && segment.endsWith("}")) {
+        val paramName = segment.tail.init
+        val paramType = inputShape.flatMap { struct =>
+          struct.members.get(paramName).map(m => shapeIdToCodecType(m.target))
+        }.getOrElse(Code.CodecType.String)
+        
+        Code.PathSegmentCode(paramName, paramType)
+      } else {
+        Code.PathSegmentCode(segment, Code.CodecType.Literal)
+      }
+    }
+  }
+
+  private def determineInputType(
+    op: Shape.OperationShape,
+    inputShape: Option[Shape.StructureShape]
+  ): String = {
+    inputShape match {
+      case None => "Unit"
+      case Some(struct) =>
+        // Check if there's a @httpPayload member
+        val payloadMember = struct.members.values.find(_.httpPayload)
+        payloadMember match {
+          case Some(member) => shapeIdToTypeName(member.target)
+          case None =>
+            // If no payload, check if there are non-path/query/header members
+            val bodyMembers = struct.members.values.filterNot { m =>
+              m.httpLabel || m.httpQuery.isDefined || m.httpHeader.isDefined
+            }
+            if (bodyMembers.isEmpty) "Unit"
+            else op.input.map(_.name).getOrElse("Unit")
+        }
+    }
+  }
+
+  // ===========================================================================
+  // Type Mapping
+  // ===========================================================================
+
+  private def shapeIdToType(shapeId: ShapeId): Code.ScalaType = {
+    val name = shapeId.name
+    
+    // Check if it's a prelude type
+    name match {
+      case "String"     => Code.Primitive.ScalaString
+      case "Integer"    => Code.Primitive.ScalaInt
+      case "Long"       => Code.Primitive.ScalaLong
+      case "Short"      => Code.Primitive.ScalaShort
+      case "Byte"       => Code.Primitive.ScalaByte
+      case "Float"      => Code.Primitive.ScalaFloat
+      case "Double"     => Code.Primitive.ScalaDouble
+      case "Boolean"    => Code.Primitive.ScalaBoolean
+      case "Timestamp"  => Code.Primitive.ScalaInstant
+      case "Blob"       => Code.TypeRef("Chunk[Byte]")
+      case "Document"   => Code.ScalaType.JsonAST
+      case "BigInteger" => Code.TypeRef("BigInt")
+      case "BigDecimal" => Code.TypeRef("BigDecimal")
+      case "Unit"       => Code.ScalaType.Unit
+      case _ =>
+        // Check if it's a shape in our model
+        model.shapes.get(name) match {
+          case Some(_: Shape.ListShape) =>
+            model.shapes.get(name).collect { case l: Shape.ListShape => l }.map { list =>
+              shapeIdToType(list.member).seq(nonEmpty = false)
+            }.getOrElse(Code.TypeRef(name))
+          case Some(_: Shape.MapShape) =>
+            model.shapes.get(name).collect { case m: Shape.MapShape => m }.map { map =>
+              Code.Collection.Map(shapeIdToType(map.value), Some(shapeIdToType(map.key)))
+            }.getOrElse(Code.TypeRef(name))
+          case Some(_: Shape.SimpleShape) =>
+            // Simple shapes are type aliases
+            shapeIdToTypeForSimpleShape(name)
+          case _ =>
+            // Reference to a structure, union, etc.
+            Code.TypeRef(name)
+        }
+    }
+  }
+
+  private def shapeIdToTypeForSimpleShape(name: String): Code.ScalaType = {
+    model.shapes.get(name) match {
+      case Some(_: Shape.StringShape)     => Code.Primitive.ScalaString
+      case Some(_: Shape.IntegerShape)    => Code.Primitive.ScalaInt
+      case Some(_: Shape.LongShape)       => Code.Primitive.ScalaLong
+      case Some(_: Shape.ShortShape)      => Code.Primitive.ScalaShort
+      case Some(_: Shape.ByteShape)       => Code.Primitive.ScalaByte
+      case Some(_: Shape.FloatShape)      => Code.Primitive.ScalaFloat
+      case Some(_: Shape.DoubleShape)     => Code.Primitive.ScalaDouble
+      case Some(_: Shape.BooleanShape)    => Code.Primitive.ScalaBoolean
+      case Some(_: Shape.TimestampShape)  => Code.Primitive.ScalaInstant
+      case Some(_: Shape.BlobShape)       => Code.TypeRef("Chunk[Byte]")
+      case Some(_: Shape.DocumentShape)   => Code.ScalaType.JsonAST
+      case Some(_: Shape.BigIntegerShape) => Code.TypeRef("BigInt")
+      case Some(_: Shape.BigDecimalShape) => Code.TypeRef("BigDecimal")
+      case _                              => Code.TypeRef(name)
+    }
+  }
+
+  private def shapeIdToTypeName(shapeId: ShapeId): String = {
+    val name = shapeId.name
+    name match {
+      case "String"     => "String"
+      case "Integer"    => "Int"
+      case "Long"       => "Long"
+      case "Short"      => "Short"
+      case "Byte"       => "Byte"
+      case "Float"      => "Float"
+      case "Double"     => "Double"
+      case "Boolean"    => "Boolean"
+      case "Timestamp"  => "java.time.Instant"
+      case "Blob"       => "Chunk[Byte]"
+      case "Document"   => "zio.json.ast.Json"
+      case "BigInteger" => "BigInt"
+      case "BigDecimal" => "BigDecimal"
+      case "Unit"       => "Unit"
+      case _            => name
+    }
+  }
+
+  private def shapeIdToCodecType(shapeId: ShapeId): Code.CodecType = {
+    val name = shapeId.name
+    name match {
+      case "String"    => Code.CodecType.String
+      case "Integer"   => Code.CodecType.Int
+      case "Long"      => Code.CodecType.Long
+      case "Boolean"   => Code.CodecType.Boolean
+      case "Timestamp" => Code.CodecType.Instant
+      case _ =>
+        // Check if it's a simple shape alias
+        model.shapes.get(name) match {
+          case Some(_: Shape.StringShape)    => Code.CodecType.String
+          case Some(_: Shape.IntegerShape)   => Code.CodecType.Int
+          case Some(_: Shape.LongShape)      => Code.CodecType.Long
+          case Some(_: Shape.BooleanShape)   => Code.CodecType.Boolean
+          case Some(_: Shape.TimestampShape) => Code.CodecType.Instant
+          case _                             => Code.CodecType.String // fallback
+        }
+    }
+  }
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyValidation.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyValidation.scala
@@ -1,0 +1,725 @@
+package zio.http.gen.smithy
+
+/**
+ * Smithy Model Validation
+ * 
+ * Validates Smithy models according to the Smithy specification:
+ * https://smithy.io/2.0/spec/model-validation.html
+ * 
+ * Provides comprehensive validation with helpful error messages including:
+ * - Shape reference validation (undefined references)
+ * - HTTP trait validation (path parameters, methods, status codes)
+ * - Constraint trait validation (@length, @range, @pattern)
+ * - Structure validation (required members, duplicate members)
+ * - Operation validation (input/output/error shapes)
+ * - Service validation (referenced operations/resources exist)
+ */
+object SmithyValidation {
+
+  /**
+   * A validation error with context about where and what failed
+   */
+  final case class ValidationError(
+    shapeName: Option[String],
+    memberName: Option[String],
+    errorType: ErrorType,
+    message: String
+  ) {
+    def render: String = {
+      val location = (shapeName, memberName) match {
+        case (Some(shape), Some(member)) => s"$shape.$member"
+        case (Some(shape), None)         => shape
+        case (None, Some(member))        => s"<unknown>.$member"
+        case (None, None)                => "<model>"
+      }
+      s"$location: [${errorType.name}] $message"
+    }
+  }
+
+  sealed trait ErrorType {
+    def name: String
+  }
+  object ErrorType {
+    case object UndefinedShape extends ErrorType { def name = "UNDEFINED_SHAPE" }
+    case object UndefinedMember extends ErrorType { def name = "UNDEFINED_MEMBER" }
+    case object InvalidHttpMethod extends ErrorType { def name = "INVALID_HTTP_METHOD" }
+    case object InvalidHttpPath extends ErrorType { def name = "INVALID_HTTP_PATH" }
+    case object InvalidStatusCode extends ErrorType { def name = "INVALID_STATUS_CODE" }
+    case object PathParameterMismatch extends ErrorType { def name = "PATH_PARAMETER_MISMATCH" }
+    case object MissingPathParameter extends ErrorType { def name = "MISSING_PATH_PARAMETER" }
+    case object DuplicatePathParameter extends ErrorType { def name = "DUPLICATE_PATH_PARAMETER" }
+    case object InvalidConstraint extends ErrorType { def name = "INVALID_CONSTRAINT" }
+    case object InvalidPattern extends ErrorType { def name = "INVALID_PATTERN" }
+    case object IncompatibleTrait extends ErrorType { def name = "INCOMPATIBLE_TRAIT" }
+    case object MissingRequiredTrait extends ErrorType { def name = "MISSING_REQUIRED_TRAIT" }
+    case object InvalidOperation extends ErrorType { def name = "INVALID_OPERATION" }
+    case object InvalidService extends ErrorType { def name = "INVALID_SERVICE" }
+    case object InvalidEnum extends ErrorType { def name = "INVALID_ENUM" }
+    case object CyclicReference extends ErrorType { def name = "CYCLIC_REFERENCE" }
+    case object InvalidRange extends ErrorType { def name = "INVALID_RANGE" }
+    case object InvalidLength extends ErrorType { def name = "INVALID_LENGTH" }
+  }
+
+  /**
+   * Result of validation
+   */
+  final case class ValidationResult(
+    errors: List[ValidationError],
+    warnings: List[ValidationError]
+  ) {
+    def isValid: Boolean = errors.isEmpty
+    def hasWarnings: Boolean = warnings.nonEmpty
+    
+    def ++(other: ValidationResult): ValidationResult =
+      ValidationResult(errors ++ other.errors, warnings ++ other.warnings)
+      
+    def render: String = {
+      val errorMessages = if (errors.nonEmpty) {
+        s"Errors (${errors.size}):\n" + errors.map(e => s"  - ${e.render}").mkString("\n")
+      } else ""
+      
+      val warningMessages = if (warnings.nonEmpty) {
+        s"Warnings (${warnings.size}):\n" + warnings.map(w => s"  - ${w.render}").mkString("\n")
+      } else ""
+      
+      List(errorMessages, warningMessages).filter(_.nonEmpty).mkString("\n\n")
+    }
+  }
+
+  object ValidationResult {
+    val empty: ValidationResult = ValidationResult(Nil, Nil)
+    
+    def error(e: ValidationError): ValidationResult = ValidationResult(List(e), Nil)
+    def warning(w: ValidationError): ValidationResult = ValidationResult(Nil, List(w))
+    def errors(es: List[ValidationError]): ValidationResult = ValidationResult(es, Nil)
+    def warnings(ws: List[ValidationError]): ValidationResult = ValidationResult(Nil, ws)
+  }
+
+  // ===========================================================================
+  // Main validation entry point
+  // ===========================================================================
+
+  /**
+   * Validate a SmithyModel and return all errors and warnings
+   */
+  def validate(model: SmithyModel): ValidationResult = {
+    val validators: List[SmithyModel => ValidationResult] = List(
+      validateShapeReferences,
+      validateHttpTraits,
+      validateConstraintTraits,
+      validateOperations,
+      validateServices,
+      validateEnums,
+      validateUnions,
+    )
+    
+    validators.foldLeft(ValidationResult.empty) { (acc, validator) =>
+      acc ++ validator(model)
+    }
+  }
+
+  /**
+   * Validate and throw if there are errors
+   */
+  def validateOrThrow(model: SmithyModel): SmithyModel = {
+    val result = validate(model)
+    if (!result.isValid) {
+      throw new SmithyValidationException(result)
+    }
+    model
+  }
+
+  class SmithyValidationException(val result: ValidationResult) 
+    extends RuntimeException(s"Smithy validation failed:\n${result.render}")
+
+  // ===========================================================================
+  // Shape Reference Validation
+  // ===========================================================================
+
+  private val preludeShapes: Set[String] = Set(
+    "String", "Integer", "Long", "Short", "Byte", "Float", "Double", 
+    "Boolean", "Timestamp", "Blob", "Document", "BigInteger", "BigDecimal",
+    "Unit", "PrimitiveBoolean", "PrimitiveByte", "PrimitiveShort",
+    "PrimitiveInteger", "PrimitiveLong", "PrimitiveFloat", "PrimitiveDouble"
+  )
+
+  /**
+   * Validate that all shape references point to existing shapes
+   */
+  private def validateShapeReferences(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+    
+    def checkRef(ref: ShapeId, context: (Option[String], Option[String])): Unit = {
+      val name = ref.name
+      if (!preludeShapes.contains(name) && !model.shapes.contains(name)) {
+        errors += ValidationError(
+          context._1, context._2,
+          ErrorType.UndefinedShape,
+          s"Reference to undefined shape: $name"
+        )
+      }
+    }
+
+    model.shapes.foreach { case (shapeName, shape) =>
+      shape match {
+        case s: Shape.StructureShape =>
+          s.members.foreach { case (memberName, member) =>
+            checkRef(member.target, (Some(shapeName), Some(memberName)))
+          }
+          s.mixins.foreach(mixin => checkRef(mixin, (Some(shapeName), None)))
+          
+        case s: Shape.UnionShape =>
+          s.members.foreach { case (memberName, member) =>
+            checkRef(member.target, (Some(shapeName), Some(memberName)))
+          }
+          s.mixins.foreach(mixin => checkRef(mixin, (Some(shapeName), None)))
+          
+        case s: Shape.ListShape =>
+          checkRef(s.member, (Some(shapeName), Some("member")))
+          
+        case s: Shape.MapShape =>
+          checkRef(s.key, (Some(shapeName), Some("key")))
+          checkRef(s.value, (Some(shapeName), Some("value")))
+          
+        case s: Shape.OperationShape =>
+          s.input.foreach(i => checkRef(i, (Some(shapeName), Some("input"))))
+          s.output.foreach(o => checkRef(o, (Some(shapeName), Some("output"))))
+          s.errors.foreach(e => checkRef(e, (Some(shapeName), Some("errors"))))
+          
+        case s: Shape.ServiceShape =>
+          s.operations.foreach(op => checkRef(op, (Some(shapeName), Some("operations"))))
+          s.resources.foreach(r => checkRef(r, (Some(shapeName), Some("resources"))))
+          s.errors.foreach(e => checkRef(e, (Some(shapeName), Some("errors"))))
+          
+        case s: Shape.ResourceShape =>
+          s.identifiers.values.foreach(id => checkRef(id, (Some(shapeName), Some("identifiers"))))
+          s.properties.values.foreach(p => checkRef(p, (Some(shapeName), Some("properties"))))
+          s.create.foreach(c => checkRef(c, (Some(shapeName), Some("create"))))
+          s.put.foreach(p => checkRef(p, (Some(shapeName), Some("put"))))
+          s.read.foreach(r => checkRef(r, (Some(shapeName), Some("read"))))
+          s.update.foreach(u => checkRef(u, (Some(shapeName), Some("update"))))
+          s.delete.foreach(d => checkRef(d, (Some(shapeName), Some("delete"))))
+          s.list.foreach(l => checkRef(l, (Some(shapeName), Some("list"))))
+          s.operations.foreach(op => checkRef(op, (Some(shapeName), Some("operations"))))
+          s.collectionOperations.foreach(op => checkRef(op, (Some(shapeName), Some("collectionOperations"))))
+          s.resources.foreach(r => checkRef(r, (Some(shapeName), Some("resources"))))
+          
+        case _ => // Simple shapes don't have references
+      }
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // HTTP Trait Validation
+  // ===========================================================================
+
+  private val validHttpMethods: Set[String] = Set(
+    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "CONNECT"
+  )
+
+  /**
+   * Validate HTTP-related traits on operations
+   */
+  private def validateHttpTraits(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    model.allOperations.foreach { case (opName, op) =>
+      op.httpTrait.foreach { http =>
+        // Validate HTTP method
+        if (!validHttpMethods.contains(http.method.toUpperCase)) {
+          errors += ValidationError(
+            Some(opName), None,
+            ErrorType.InvalidHttpMethod,
+            s"Invalid HTTP method: '${http.method}'. Valid methods are: ${validHttpMethods.mkString(", ")}"
+          )
+        }
+
+        // Validate status code
+        if (http.code < 100 || http.code > 599) {
+          errors += ValidationError(
+            Some(opName), None,
+            ErrorType.InvalidStatusCode,
+            s"Invalid HTTP status code: ${http.code}. Must be between 100 and 599."
+          )
+        }
+
+        // Validate path format
+        val uri = http.uri
+        if (!uri.startsWith("/")) {
+          errors += ValidationError(
+            Some(opName), None,
+            ErrorType.InvalidHttpPath,
+            s"HTTP URI must start with '/': $uri"
+          )
+        }
+
+        // Extract path parameters from URI
+        val pathParamRegex = """\{(\w+)\}""".r
+        val pathParams = pathParamRegex.findAllMatchIn(uri).map(_.group(1)).toList
+
+        // Check for duplicate path parameters
+        val duplicates = pathParams.groupBy(identity).filter(_._2.size > 1).keys
+        duplicates.foreach { dup =>
+          errors += ValidationError(
+            Some(opName), None,
+            ErrorType.DuplicatePathParameter,
+            s"Duplicate path parameter: {$dup}"
+          )
+        }
+
+        // Validate that path parameters have corresponding @httpLabel members
+        op.input.foreach { inputId =>
+          model.getStructure(inputId.name).foreach { inputStruct =>
+            val labelMembers = inputStruct.members.filter { case (_, member) =>
+              member.httpLabel
+            }.keys.toSet
+
+            // Check all path params have @httpLabel members
+            pathParams.foreach { param =>
+              if (!labelMembers.contains(param)) {
+                // Check if the member exists at all
+                if (inputStruct.members.contains(param)) {
+                  errors += ValidationError(
+                    Some(inputId.name), Some(param),
+                    ErrorType.MissingRequiredTrait,
+                    s"Path parameter '$param' exists but is missing @httpLabel trait"
+                  )
+                } else {
+                  errors += ValidationError(
+                    Some(opName), None,
+                    ErrorType.MissingPathParameter,
+                    s"Path parameter '$param' in URI has no corresponding member in ${inputId.name}"
+                  )
+                }
+              }
+            }
+
+            // Check all @httpLabel members are in the path
+            labelMembers.foreach { label =>
+              if (!pathParams.contains(label)) {
+                errors += ValidationError(
+                  Some(inputId.name), Some(label),
+                  ErrorType.PathParameterMismatch,
+                  s"Member '$label' has @httpLabel but is not in the URI path: $uri"
+                )
+              }
+            }
+          }
+        }
+
+        // Validate @httpPayload is only on one member
+        op.input.foreach { inputId =>
+          model.getStructure(inputId.name).foreach { inputStruct =>
+            val payloadMembers = inputStruct.members.filter { case (_, member) =>
+              member.httpPayload
+            }.keys.toList
+
+            if (payloadMembers.size > 1) {
+              errors += ValidationError(
+                Some(inputId.name), None,
+                ErrorType.IncompatibleTrait,
+                s"Multiple @httpPayload members: ${payloadMembers.mkString(", ")}. Only one member can have @httpPayload."
+              )
+            }
+          }
+        }
+
+        // Validate that GET/DELETE/HEAD don't typically have body
+        // (warning, not error - as Smithy allows it)
+      }
+    }
+
+    // Validate @httpError trait values
+    model.shapes.foreach { case (shapeName, shape) =>
+      shape.traits.foreach {
+        case SmithyTrait.HttpError(code) if code < 400 || code > 599 =>
+          errors += ValidationError(
+            Some(shapeName), None,
+            ErrorType.InvalidStatusCode,
+            s"@httpError code must be 4xx or 5xx, got: $code"
+          )
+        case _ => // ok
+      }
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // Constraint Trait Validation
+  // ===========================================================================
+
+  /**
+   * Validate constraint traits like @length, @range, @pattern
+   */
+  private def validateConstraintTraits(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    def validateTraitsOnShape(shapeName: String, shape: Shape): Unit = {
+      shape.traits.foreach {
+        case SmithyTrait.Length(min, max) =>
+          // Length trait must have non-negative values
+          min.foreach { m =>
+            if (m < 0) {
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.InvalidLength,
+                s"@length min must be non-negative, got: $m"
+              )
+            }
+          }
+          max.foreach { m =>
+            if (m < 0) {
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.InvalidLength,
+                s"@length max must be non-negative, got: $m"
+              )
+            }
+          }
+          // min must be <= max
+          (min, max) match {
+            case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.InvalidLength,
+                s"@length min ($minVal) cannot be greater than max ($maxVal)"
+              )
+            case _ => // ok
+          }
+          
+          // Length can only be applied to strings, lists, maps, blobs
+          shape match {
+            case _: Shape.StringShape | _: Shape.ListShape | 
+                 _: Shape.MapShape | _: Shape.BlobShape => // ok
+            case _ =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.IncompatibleTrait,
+                "@length trait can only be applied to string, list, map, or blob shapes"
+              )
+          }
+
+        case SmithyTrait.Range(min, max) =>
+          // min must be <= max
+          (min, max) match {
+            case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.InvalidRange,
+                s"@range min ($minVal) cannot be greater than max ($maxVal)"
+              )
+            case _ => // ok
+          }
+          
+          // Range can only be applied to numeric shapes
+          shape match {
+            case _: Shape.ByteShape | _: Shape.ShortShape | _: Shape.IntegerShape |
+                 _: Shape.LongShape | _: Shape.FloatShape | _: Shape.DoubleShape |
+                 _: Shape.BigIntegerShape | _: Shape.BigDecimalShape => // ok
+            case _ =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.IncompatibleTrait,
+                "@range trait can only be applied to numeric shapes"
+              )
+          }
+
+        case SmithyTrait.Pattern(regex) =>
+          // Validate that the regex compiles
+          try {
+            regex.r
+          } catch {
+            case e: Exception =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.InvalidPattern,
+                s"@pattern contains invalid regex: ${e.getMessage}"
+              )
+          }
+          
+          // Pattern can only be applied to strings
+          shape match {
+            case _: Shape.StringShape => // ok
+            case _ =>
+              errors += ValidationError(
+                Some(shapeName), None,
+                ErrorType.IncompatibleTrait,
+                "@pattern trait can only be applied to string shapes"
+              )
+          }
+
+        case SmithyTrait.TimestampFormat(format) =>
+          val validFormats = Set("date-time", "http-date", "epoch-seconds")
+          if (!validFormats.contains(format)) {
+            errors += ValidationError(
+              Some(shapeName), None,
+              ErrorType.InvalidConstraint,
+              s"Invalid @timestampFormat: '$format'. Valid formats: ${validFormats.mkString(", ")}"
+            )
+          }
+
+        case _ => // other traits don't need validation here
+      }
+    }
+
+    // Validate traits on all shapes
+    model.shapes.foreach { case (shapeName, shape) =>
+      validateTraitsOnShape(shapeName, shape)
+      
+      // Also validate member traits
+      shape match {
+        case s: Shape.StructureShape =>
+          s.members.foreach { case (memberName, member) =>
+            member.traits.foreach {
+              case SmithyTrait.Pattern(regex) =>
+                try {
+                  regex.r
+                } catch {
+                  case e: Exception =>
+                    errors += ValidationError(
+                      Some(shapeName), Some(memberName),
+                      ErrorType.InvalidPattern,
+                      s"@pattern contains invalid regex: ${e.getMessage}"
+                    )
+                }
+              case SmithyTrait.Length(min, max) =>
+                (min, max) match {
+                  case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
+                    errors += ValidationError(
+                      Some(shapeName), Some(memberName),
+                      ErrorType.InvalidLength,
+                      s"@length min ($minVal) cannot be greater than max ($maxVal)"
+                    )
+                  case _ => // ok
+                }
+              case SmithyTrait.Range(min, max) =>
+                (min, max) match {
+                  case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
+                    errors += ValidationError(
+                      Some(shapeName), Some(memberName),
+                      ErrorType.InvalidRange,
+                      s"@range min ($minVal) cannot be greater than max ($maxVal)"
+                    )
+                  case _ => // ok
+                }
+              case _ => // ok
+            }
+          }
+        case _ => // ok
+      }
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // Operation Validation
+  // ===========================================================================
+
+  /**
+   * Validate operations have valid input/output types
+   */
+  private def validateOperations(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    model.allOperations.foreach { case (opName, op) =>
+      // Input must be a structure if specified
+      op.input.foreach { inputId =>
+        model.getShape(inputId.name) match {
+          case Some(_: Shape.StructureShape) => // ok
+          case Some(_) =>
+            errors += ValidationError(
+              Some(opName), Some("input"),
+              ErrorType.InvalidOperation,
+              s"Operation input must be a structure, but '${inputId.name}' is not"
+            )
+          case None =>
+            // Already caught by shape reference validation
+        }
+      }
+
+      // Output must be a structure if specified
+      op.output.foreach { outputId =>
+        model.getShape(outputId.name) match {
+          case Some(_: Shape.StructureShape) => // ok
+          case Some(_) =>
+            errors += ValidationError(
+              Some(opName), Some("output"),
+              ErrorType.InvalidOperation,
+              s"Operation output must be a structure, but '${outputId.name}' is not"
+            )
+          case None =>
+            // Already caught by shape reference validation
+        }
+      }
+
+      // Errors must be structures with @error trait
+      op.errors.foreach { errorId =>
+        model.getShape(errorId.name) match {
+          case Some(s: Shape.StructureShape) =>
+            val hasErrorTrait = s.traits.exists {
+              case SmithyTrait.Error | SmithyTrait.ErrorMessage(_) => true
+              case _ => false
+            }
+            if (!hasErrorTrait) {
+              errors += ValidationError(
+                Some(opName), Some("errors"),
+                ErrorType.MissingRequiredTrait,
+                s"Error structure '${errorId.name}' must have @error trait"
+              )
+            }
+          case Some(_) =>
+            errors += ValidationError(
+              Some(opName), Some("errors"),
+              ErrorType.InvalidOperation,
+              s"Operation error must be a structure, but '${errorId.name}' is not"
+            )
+          case None =>
+            // Already caught by shape reference validation
+        }
+      }
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // Service Validation
+  // ===========================================================================
+
+  /**
+   * Validate services reference valid operations and resources
+   */
+  private def validateServices(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    model.allServices.foreach { case (svcName, svc) =>
+      // Operations must be operation shapes
+      svc.operations.foreach { opId =>
+        model.getShape(opId.name) match {
+          case Some(_: Shape.OperationShape) => // ok
+          case Some(_) =>
+            errors += ValidationError(
+              Some(svcName), Some("operations"),
+              ErrorType.InvalidService,
+              s"'${opId.name}' is not an operation shape"
+            )
+          case None =>
+            // Already caught by shape reference validation
+        }
+      }
+
+      // Resources must be resource shapes
+      svc.resources.foreach { resId =>
+        model.getShape(resId.name) match {
+          case Some(_: Shape.ResourceShape) => // ok
+          case Some(_) =>
+            errors += ValidationError(
+              Some(svcName), Some("resources"),
+              ErrorType.InvalidService,
+              s"'${resId.name}' is not a resource shape"
+            )
+          case None =>
+            // Already caught by shape reference validation
+        }
+      }
+
+      // Service version should not be empty
+      if (svc.version.isEmpty) {
+        errors += ValidationError(
+          Some(svcName), None,
+          ErrorType.InvalidService,
+          "Service version should not be empty"
+        )
+      }
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // Enum Validation
+  // ===========================================================================
+
+  /**
+   * Validate enum shapes have at least one member
+   */
+  private def validateEnums(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    model.shapes.foreach {
+      case (name, e: Shape.EnumShape) =>
+        if (e.members.isEmpty) {
+          errors += ValidationError(
+            Some(name), None,
+            ErrorType.InvalidEnum,
+            "Enum must have at least one member"
+          )
+        }
+        
+        // Check for duplicate enum values
+        val values = e.members.values.flatMap(_.value).toList
+        val duplicateValues = values.groupBy(identity).filter(_._2.size > 1).keys
+        duplicateValues.foreach { dup =>
+          errors += ValidationError(
+            Some(name), None,
+            ErrorType.InvalidEnum,
+            s"Duplicate enum value: '$dup'"
+          )
+        }
+        
+      case (name, e: Shape.IntEnumShape) =>
+        if (e.members.isEmpty) {
+          errors += ValidationError(
+            Some(name), None,
+            ErrorType.InvalidEnum,
+            "IntEnum must have at least one member"
+          )
+        }
+        
+        // Check for duplicate int values
+        val values = e.members.values.map(_.value).toList
+        val duplicateValues = values.groupBy(identity).filter(_._2.size > 1).keys
+        duplicateValues.foreach { dup =>
+          errors += ValidationError(
+            Some(name), None,
+            ErrorType.InvalidEnum,
+            s"Duplicate intEnum value: $dup"
+          )
+        }
+        
+      case _ => // not an enum
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+
+  // ===========================================================================
+  // Union Validation
+  // ===========================================================================
+
+  /**
+   * Validate union shapes have at least one member
+   */
+  private def validateUnions(model: SmithyModel): ValidationResult = {
+    val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
+
+    model.shapes.foreach {
+      case (name, u: Shape.UnionShape) =>
+        if (u.members.isEmpty) {
+          errors += ValidationError(
+            Some(name), None,
+            ErrorType.InvalidOperation, // reusing error type
+            "Union must have at least one member"
+          )
+        }
+        
+      case _ => // not a union
+    }
+
+    ValidationResult.errors(errors.toList)
+  }
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyValidation.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/smithy/SmithyValidation.scala
@@ -2,17 +2,17 @@ package zio.http.gen.smithy
 
 /**
  * Smithy Model Validation
- * 
+ *
  * Validates Smithy models according to the Smithy specification:
  * https://smithy.io/2.0/spec/model-validation.html
- * 
+ *
  * Provides comprehensive validation with helpful error messages including:
- * - Shape reference validation (undefined references)
- * - HTTP trait validation (path parameters, methods, status codes)
- * - Constraint trait validation (@length, @range, @pattern)
- * - Structure validation (required members, duplicate members)
- * - Operation validation (input/output/error shapes)
- * - Service validation (referenced operations/resources exist)
+ *   - Shape reference validation (undefined references)
+ *   - HTTP trait validation (path parameters, methods, status codes)
+ *   - Constraint trait validation (@length, @range, @pattern)
+ *   - Structure validation (required members, duplicate members)
+ *   - Operation validation (input/output/error shapes)
+ *   - Service validation (referenced operations/resources exist)
  */
 object SmithyValidation {
 
@@ -23,7 +23,7 @@ object SmithyValidation {
     shapeName: Option[String],
     memberName: Option[String],
     errorType: ErrorType,
-    message: String
+    message: String,
   ) {
     def render: String = {
       val location = (shapeName, memberName) match {
@@ -39,25 +39,25 @@ object SmithyValidation {
   sealed trait ErrorType {
     def name: String
   }
-  object ErrorType {
-    case object UndefinedShape extends ErrorType { def name = "UNDEFINED_SHAPE" }
-    case object UndefinedMember extends ErrorType { def name = "UNDEFINED_MEMBER" }
-    case object InvalidHttpMethod extends ErrorType { def name = "INVALID_HTTP_METHOD" }
-    case object InvalidHttpPath extends ErrorType { def name = "INVALID_HTTP_PATH" }
-    case object InvalidStatusCode extends ErrorType { def name = "INVALID_STATUS_CODE" }
-    case object PathParameterMismatch extends ErrorType { def name = "PATH_PARAMETER_MISMATCH" }
-    case object MissingPathParameter extends ErrorType { def name = "MISSING_PATH_PARAMETER" }
+  object ErrorType       {
+    case object UndefinedShape         extends ErrorType { def name = "UNDEFINED_SHAPE"          }
+    case object UndefinedMember        extends ErrorType { def name = "UNDEFINED_MEMBER"         }
+    case object InvalidHttpMethod      extends ErrorType { def name = "INVALID_HTTP_METHOD"      }
+    case object InvalidHttpPath        extends ErrorType { def name = "INVALID_HTTP_PATH"        }
+    case object InvalidStatusCode      extends ErrorType { def name = "INVALID_STATUS_CODE"      }
+    case object PathParameterMismatch  extends ErrorType { def name = "PATH_PARAMETER_MISMATCH"  }
+    case object MissingPathParameter   extends ErrorType { def name = "MISSING_PATH_PARAMETER"   }
     case object DuplicatePathParameter extends ErrorType { def name = "DUPLICATE_PATH_PARAMETER" }
-    case object InvalidConstraint extends ErrorType { def name = "INVALID_CONSTRAINT" }
-    case object InvalidPattern extends ErrorType { def name = "INVALID_PATTERN" }
-    case object IncompatibleTrait extends ErrorType { def name = "INCOMPATIBLE_TRAIT" }
-    case object MissingRequiredTrait extends ErrorType { def name = "MISSING_REQUIRED_TRAIT" }
-    case object InvalidOperation extends ErrorType { def name = "INVALID_OPERATION" }
-    case object InvalidService extends ErrorType { def name = "INVALID_SERVICE" }
-    case object InvalidEnum extends ErrorType { def name = "INVALID_ENUM" }
-    case object CyclicReference extends ErrorType { def name = "CYCLIC_REFERENCE" }
-    case object InvalidRange extends ErrorType { def name = "INVALID_RANGE" }
-    case object InvalidLength extends ErrorType { def name = "INVALID_LENGTH" }
+    case object InvalidConstraint      extends ErrorType { def name = "INVALID_CONSTRAINT"       }
+    case object InvalidPattern         extends ErrorType { def name = "INVALID_PATTERN"          }
+    case object IncompatibleTrait      extends ErrorType { def name = "INCOMPATIBLE_TRAIT"       }
+    case object MissingRequiredTrait   extends ErrorType { def name = "MISSING_REQUIRED_TRAIT"   }
+    case object InvalidOperation       extends ErrorType { def name = "INVALID_OPERATION"        }
+    case object InvalidService         extends ErrorType { def name = "INVALID_SERVICE"          }
+    case object InvalidEnum            extends ErrorType { def name = "INVALID_ENUM"             }
+    case object CyclicReference        extends ErrorType { def name = "CYCLIC_REFERENCE"         }
+    case object InvalidRange           extends ErrorType { def name = "INVALID_RANGE"            }
+    case object InvalidLength          extends ErrorType { def name = "INVALID_LENGTH"           }
   }
 
   /**
@@ -65,33 +65,33 @@ object SmithyValidation {
    */
   final case class ValidationResult(
     errors: List[ValidationError],
-    warnings: List[ValidationError]
+    warnings: List[ValidationError],
   ) {
-    def isValid: Boolean = errors.isEmpty
+    def isValid: Boolean     = errors.isEmpty
     def hasWarnings: Boolean = warnings.nonEmpty
-    
+
     def ++(other: ValidationResult): ValidationResult =
       ValidationResult(errors ++ other.errors, warnings ++ other.warnings)
-      
+
     def render: String = {
       val errorMessages = if (errors.nonEmpty) {
         s"Errors (${errors.size}):\n" + errors.map(e => s"  - ${e.render}").mkString("\n")
       } else ""
-      
+
       val warningMessages = if (warnings.nonEmpty) {
         s"Warnings (${warnings.size}):\n" + warnings.map(w => s"  - ${w.render}").mkString("\n")
       } else ""
-      
+
       List(errorMessages, warningMessages).filter(_.nonEmpty).mkString("\n\n")
     }
   }
 
   object ValidationResult {
     val empty: ValidationResult = ValidationResult(Nil, Nil)
-    
-    def error(e: ValidationError): ValidationResult = ValidationResult(List(e), Nil)
-    def warning(w: ValidationError): ValidationResult = ValidationResult(Nil, List(w))
-    def errors(es: List[ValidationError]): ValidationResult = ValidationResult(es, Nil)
+
+    def error(e: ValidationError): ValidationResult           = ValidationResult(List(e), Nil)
+    def warning(w: ValidationError): ValidationResult         = ValidationResult(Nil, List(w))
+    def errors(es: List[ValidationError]): ValidationResult   = ValidationResult(es, Nil)
     def warnings(ws: List[ValidationError]): ValidationResult = ValidationResult(Nil, ws)
   }
 
@@ -112,7 +112,7 @@ object SmithyValidation {
       validateEnums,
       validateUnions,
     )
-    
+
     validators.foldLeft(ValidationResult.empty) { (acc, validator) =>
       acc ++ validator(model)
     }
@@ -129,18 +129,35 @@ object SmithyValidation {
     model
   }
 
-  class SmithyValidationException(val result: ValidationResult) 
-    extends RuntimeException(s"Smithy validation failed:\n${result.render}")
+  class SmithyValidationException(val result: ValidationResult)
+      extends RuntimeException(s"Smithy validation failed:\n${result.render}")
 
   // ===========================================================================
   // Shape Reference Validation
   // ===========================================================================
 
   private val preludeShapes: Set[String] = Set(
-    "String", "Integer", "Long", "Short", "Byte", "Float", "Double", 
-    "Boolean", "Timestamp", "Blob", "Document", "BigInteger", "BigDecimal",
-    "Unit", "PrimitiveBoolean", "PrimitiveByte", "PrimitiveShort",
-    "PrimitiveInteger", "PrimitiveLong", "PrimitiveFloat", "PrimitiveDouble"
+    "String",
+    "Integer",
+    "Long",
+    "Short",
+    "Byte",
+    "Float",
+    "Double",
+    "Boolean",
+    "Timestamp",
+    "Blob",
+    "Document",
+    "BigInteger",
+    "BigDecimal",
+    "Unit",
+    "PrimitiveBoolean",
+    "PrimitiveByte",
+    "PrimitiveShort",
+    "PrimitiveInteger",
+    "PrimitiveLong",
+    "PrimitiveFloat",
+    "PrimitiveDouble",
   )
 
   /**
@@ -148,14 +165,15 @@ object SmithyValidation {
    */
   private def validateShapeReferences(model: SmithyModel): ValidationResult = {
     val errors = scala.collection.mutable.ListBuffer.empty[ValidationError]
-    
+
     def checkRef(ref: ShapeId, context: (Option[String], Option[String])): Unit = {
       val name = ref.name
       if (!preludeShapes.contains(name) && !model.shapes.contains(name)) {
         errors += ValidationError(
-          context._1, context._2,
+          context._1,
+          context._2,
           ErrorType.UndefinedShape,
-          s"Reference to undefined shape: $name"
+          s"Reference to undefined shape: $name",
         )
       }
     }
@@ -167,30 +185,30 @@ object SmithyValidation {
             checkRef(member.target, (Some(shapeName), Some(memberName)))
           }
           s.mixins.foreach(mixin => checkRef(mixin, (Some(shapeName), None)))
-          
+
         case s: Shape.UnionShape =>
           s.members.foreach { case (memberName, member) =>
             checkRef(member.target, (Some(shapeName), Some(memberName)))
           }
           s.mixins.foreach(mixin => checkRef(mixin, (Some(shapeName), None)))
-          
+
         case s: Shape.ListShape =>
           checkRef(s.member, (Some(shapeName), Some("member")))
-          
+
         case s: Shape.MapShape =>
           checkRef(s.key, (Some(shapeName), Some("key")))
           checkRef(s.value, (Some(shapeName), Some("value")))
-          
+
         case s: Shape.OperationShape =>
           s.input.foreach(i => checkRef(i, (Some(shapeName), Some("input"))))
           s.output.foreach(o => checkRef(o, (Some(shapeName), Some("output"))))
           s.errors.foreach(e => checkRef(e, (Some(shapeName), Some("errors"))))
-          
+
         case s: Shape.ServiceShape =>
           s.operations.foreach(op => checkRef(op, (Some(shapeName), Some("operations"))))
           s.resources.foreach(r => checkRef(r, (Some(shapeName), Some("resources"))))
           s.errors.foreach(e => checkRef(e, (Some(shapeName), Some("errors"))))
-          
+
         case s: Shape.ResourceShape =>
           s.identifiers.values.foreach(id => checkRef(id, (Some(shapeName), Some("identifiers"))))
           s.properties.values.foreach(p => checkRef(p, (Some(shapeName), Some("properties"))))
@@ -203,7 +221,7 @@ object SmithyValidation {
           s.operations.foreach(op => checkRef(op, (Some(shapeName), Some("operations"))))
           s.collectionOperations.foreach(op => checkRef(op, (Some(shapeName), Some("collectionOperations"))))
           s.resources.foreach(r => checkRef(r, (Some(shapeName), Some("resources"))))
-          
+
         case _ => // Simple shapes don't have references
       }
     }
@@ -216,7 +234,15 @@ object SmithyValidation {
   // ===========================================================================
 
   private val validHttpMethods: Set[String] = Set(
-    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "CONNECT"
+    "GET",
+    "POST",
+    "PUT",
+    "DELETE",
+    "PATCH",
+    "HEAD",
+    "OPTIONS",
+    "TRACE",
+    "CONNECT",
   )
 
   /**
@@ -230,18 +256,20 @@ object SmithyValidation {
         // Validate HTTP method
         if (!validHttpMethods.contains(http.method.toUpperCase)) {
           errors += ValidationError(
-            Some(opName), None,
+            Some(opName),
+            None,
             ErrorType.InvalidHttpMethod,
-            s"Invalid HTTP method: '${http.method}'. Valid methods are: ${validHttpMethods.mkString(", ")}"
+            s"Invalid HTTP method: '${http.method}'. Valid methods are: ${validHttpMethods.mkString(", ")}",
           )
         }
 
         // Validate status code
         if (http.code < 100 || http.code > 599) {
           errors += ValidationError(
-            Some(opName), None,
+            Some(opName),
+            None,
             ErrorType.InvalidStatusCode,
-            s"Invalid HTTP status code: ${http.code}. Must be between 100 and 599."
+            s"Invalid HTTP status code: ${http.code}. Must be between 100 and 599.",
           )
         }
 
@@ -249,23 +277,25 @@ object SmithyValidation {
         val uri = http.uri
         if (!uri.startsWith("/")) {
           errors += ValidationError(
-            Some(opName), None,
+            Some(opName),
+            None,
             ErrorType.InvalidHttpPath,
-            s"HTTP URI must start with '/': $uri"
+            s"HTTP URI must start with '/': $uri",
           )
         }
 
         // Extract path parameters from URI
         val pathParamRegex = """\{(\w+)\}""".r
-        val pathParams = pathParamRegex.findAllMatchIn(uri).map(_.group(1)).toList
+        val pathParams     = pathParamRegex.findAllMatchIn(uri).map(_.group(1)).toList
 
         // Check for duplicate path parameters
         val duplicates = pathParams.groupBy(identity).filter(_._2.size > 1).keys
         duplicates.foreach { dup =>
           errors += ValidationError(
-            Some(opName), None,
+            Some(opName),
+            None,
             ErrorType.DuplicatePathParameter,
-            s"Duplicate path parameter: {$dup}"
+            s"Duplicate path parameter: {$dup}",
           )
         }
 
@@ -282,15 +312,17 @@ object SmithyValidation {
                 // Check if the member exists at all
                 if (inputStruct.members.contains(param)) {
                   errors += ValidationError(
-                    Some(inputId.name), Some(param),
+                    Some(inputId.name),
+                    Some(param),
                     ErrorType.MissingRequiredTrait,
-                    s"Path parameter '$param' exists but is missing @httpLabel trait"
+                    s"Path parameter '$param' exists but is missing @httpLabel trait",
                   )
                 } else {
                   errors += ValidationError(
-                    Some(opName), None,
+                    Some(opName),
+                    None,
                     ErrorType.MissingPathParameter,
-                    s"Path parameter '$param' in URI has no corresponding member in ${inputId.name}"
+                    s"Path parameter '$param' in URI has no corresponding member in ${inputId.name}",
                   )
                 }
               }
@@ -300,9 +332,10 @@ object SmithyValidation {
             labelMembers.foreach { label =>
               if (!pathParams.contains(label)) {
                 errors += ValidationError(
-                  Some(inputId.name), Some(label),
+                  Some(inputId.name),
+                  Some(label),
                   ErrorType.PathParameterMismatch,
-                  s"Member '$label' has @httpLabel but is not in the URI path: $uri"
+                  s"Member '$label' has @httpLabel but is not in the URI path: $uri",
                 )
               }
             }
@@ -318,9 +351,10 @@ object SmithyValidation {
 
             if (payloadMembers.size > 1) {
               errors += ValidationError(
-                Some(inputId.name), None,
+                Some(inputId.name),
+                None,
                 ErrorType.IncompatibleTrait,
-                s"Multiple @httpPayload members: ${payloadMembers.mkString(", ")}. Only one member can have @httpPayload."
+                s"Multiple @httpPayload members: ${payloadMembers.mkString(", ")}. Only one member can have @httpPayload.",
               )
             }
           }
@@ -336,11 +370,12 @@ object SmithyValidation {
       shape.traits.foreach {
         case SmithyTrait.HttpError(code) if code < 400 || code > 599 =>
           errors += ValidationError(
-            Some(shapeName), None,
+            Some(shapeName),
+            None,
             ErrorType.InvalidStatusCode,
-            s"@httpError code must be 4xx or 5xx, got: $code"
+            s"@httpError code must be 4xx or 5xx, got: $code",
           )
-        case _ => // ok
+        case _                                                       => // ok
       }
     }
 
@@ -364,18 +399,20 @@ object SmithyValidation {
           min.foreach { m =>
             if (m < 0) {
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.InvalidLength,
-                s"@length min must be non-negative, got: $m"
+                s"@length min must be non-negative, got: $m",
               )
             }
           }
           max.foreach { m =>
             if (m < 0) {
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.InvalidLength,
-                s"@length max must be non-negative, got: $m"
+                s"@length max must be non-negative, got: $m",
               )
             }
           }
@@ -383,22 +420,23 @@ object SmithyValidation {
           (min, max) match {
             case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.InvalidLength,
-                s"@length min ($minVal) cannot be greater than max ($maxVal)"
+                s"@length min ($minVal) cannot be greater than max ($maxVal)",
               )
-            case _ => // ok
+            case _                                               => // ok
           }
-          
+
           // Length can only be applied to strings, lists, maps, blobs
           shape match {
-            case _: Shape.StringShape | _: Shape.ListShape | 
-                 _: Shape.MapShape | _: Shape.BlobShape => // ok
-            case _ =>
+            case _: Shape.StringShape | _: Shape.ListShape | _: Shape.MapShape | _: Shape.BlobShape => // ok
+            case _                                                                                  =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.IncompatibleTrait,
-                "@length trait can only be applied to string, list, map, or blob shapes"
+                "@length trait can only be applied to string, list, map, or blob shapes",
               )
           }
 
@@ -407,23 +445,25 @@ object SmithyValidation {
           (min, max) match {
             case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.InvalidRange,
-                s"@range min ($minVal) cannot be greater than max ($maxVal)"
+                s"@range min ($minVal) cannot be greater than max ($maxVal)",
               )
-            case _ => // ok
+            case _                                               => // ok
           }
-          
+
           // Range can only be applied to numeric shapes
           shape match {
-            case _: Shape.ByteShape | _: Shape.ShortShape | _: Shape.IntegerShape |
-                 _: Shape.LongShape | _: Shape.FloatShape | _: Shape.DoubleShape |
-                 _: Shape.BigIntegerShape | _: Shape.BigDecimalShape => // ok
+            case _: Shape.ByteShape | _: Shape.ShortShape | _: Shape.IntegerShape | _: Shape.LongShape |
+                _: Shape.FloatShape | _: Shape.DoubleShape | _: Shape.BigIntegerShape |
+                _: Shape.BigDecimalShape => // ok
             case _ =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.IncompatibleTrait,
-                "@range trait can only be applied to numeric shapes"
+                "@range trait can only be applied to numeric shapes",
               )
           }
 
@@ -434,20 +474,22 @@ object SmithyValidation {
           } catch {
             case e: Exception =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.InvalidPattern,
-                s"@pattern contains invalid regex: ${e.getMessage}"
+                s"@pattern contains invalid regex: ${e.getMessage}",
               )
           }
-          
+
           // Pattern can only be applied to strings
           shape match {
             case _: Shape.StringShape => // ok
-            case _ =>
+            case _                    =>
               errors += ValidationError(
-                Some(shapeName), None,
+                Some(shapeName),
+                None,
                 ErrorType.IncompatibleTrait,
-                "@pattern trait can only be applied to string shapes"
+                "@pattern trait can only be applied to string shapes",
               )
           }
 
@@ -455,9 +497,10 @@ object SmithyValidation {
           val validFormats = Set("date-time", "http-date", "epoch-seconds")
           if (!validFormats.contains(format)) {
             errors += ValidationError(
-              Some(shapeName), None,
+              Some(shapeName),
+              None,
               ErrorType.InvalidConstraint,
-              s"Invalid @timestampFormat: '$format'. Valid formats: ${validFormats.mkString(", ")}"
+              s"Invalid @timestampFormat: '$format'. Valid formats: ${validFormats.mkString(", ")}",
             )
           }
 
@@ -468,47 +511,50 @@ object SmithyValidation {
     // Validate traits on all shapes
     model.shapes.foreach { case (shapeName, shape) =>
       validateTraitsOnShape(shapeName, shape)
-      
+
       // Also validate member traits
       shape match {
         case s: Shape.StructureShape =>
           s.members.foreach { case (memberName, member) =>
             member.traits.foreach {
-              case SmithyTrait.Pattern(regex) =>
+              case SmithyTrait.Pattern(regex)   =>
                 try {
                   regex.r
                 } catch {
                   case e: Exception =>
                     errors += ValidationError(
-                      Some(shapeName), Some(memberName),
+                      Some(shapeName),
+                      Some(memberName),
                       ErrorType.InvalidPattern,
-                      s"@pattern contains invalid regex: ${e.getMessage}"
+                      s"@pattern contains invalid regex: ${e.getMessage}",
                     )
                 }
               case SmithyTrait.Length(min, max) =>
                 (min, max) match {
                   case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
                     errors += ValidationError(
-                      Some(shapeName), Some(memberName),
+                      Some(shapeName),
+                      Some(memberName),
                       ErrorType.InvalidLength,
-                      s"@length min ($minVal) cannot be greater than max ($maxVal)"
+                      s"@length min ($minVal) cannot be greater than max ($maxVal)",
                     )
-                  case _ => // ok
+                  case _                                               => // ok
                 }
-              case SmithyTrait.Range(min, max) =>
+              case SmithyTrait.Range(min, max)  =>
                 (min, max) match {
                   case (Some(minVal), Some(maxVal)) if minVal > maxVal =>
                     errors += ValidationError(
-                      Some(shapeName), Some(memberName),
+                      Some(shapeName),
+                      Some(memberName),
                       ErrorType.InvalidRange,
-                      s"@range min ($minVal) cannot be greater than max ($maxVal)"
+                      s"@range min ($minVal) cannot be greater than max ($maxVal)",
                     )
-                  case _ => // ok
+                  case _                                               => // ok
                 }
-              case _ => // ok
+              case _                            => // ok
             }
           }
-        case _ => // ok
+        case _                       => // ok
       }
     }
 
@@ -530,14 +576,15 @@ object SmithyValidation {
       op.input.foreach { inputId =>
         model.getShape(inputId.name) match {
           case Some(_: Shape.StructureShape) => // ok
-          case Some(_) =>
+          case Some(_)                       =>
             errors += ValidationError(
-              Some(opName), Some("input"),
+              Some(opName),
+              Some("input"),
               ErrorType.InvalidOperation,
-              s"Operation input must be a structure, but '${inputId.name}' is not"
+              s"Operation input must be a structure, but '${inputId.name}' is not",
             )
-          case None =>
-            // Already caught by shape reference validation
+          case None                          =>
+          // Already caught by shape reference validation
         }
       }
 
@@ -545,14 +592,15 @@ object SmithyValidation {
       op.output.foreach { outputId =>
         model.getShape(outputId.name) match {
           case Some(_: Shape.StructureShape) => // ok
-          case Some(_) =>
+          case Some(_)                       =>
             errors += ValidationError(
-              Some(opName), Some("output"),
+              Some(opName),
+              Some("output"),
               ErrorType.InvalidOperation,
-              s"Operation output must be a structure, but '${outputId.name}' is not"
+              s"Operation output must be a structure, but '${outputId.name}' is not",
             )
-          case None =>
-            // Already caught by shape reference validation
+          case None                          =>
+          // Already caught by shape reference validation
         }
       }
 
@@ -562,23 +610,25 @@ object SmithyValidation {
           case Some(s: Shape.StructureShape) =>
             val hasErrorTrait = s.traits.exists {
               case SmithyTrait.Error | SmithyTrait.ErrorMessage(_) => true
-              case _ => false
+              case _                                               => false
             }
             if (!hasErrorTrait) {
               errors += ValidationError(
-                Some(opName), Some("errors"),
+                Some(opName),
+                Some("errors"),
                 ErrorType.MissingRequiredTrait,
-                s"Error structure '${errorId.name}' must have @error trait"
+                s"Error structure '${errorId.name}' must have @error trait",
               )
             }
-          case Some(_) =>
+          case Some(_)                       =>
             errors += ValidationError(
-              Some(opName), Some("errors"),
+              Some(opName),
+              Some("errors"),
               ErrorType.InvalidOperation,
-              s"Operation error must be a structure, but '${errorId.name}' is not"
+              s"Operation error must be a structure, but '${errorId.name}' is not",
             )
-          case None =>
-            // Already caught by shape reference validation
+          case None                          =>
+          // Already caught by shape reference validation
         }
       }
     }
@@ -601,14 +651,15 @@ object SmithyValidation {
       svc.operations.foreach { opId =>
         model.getShape(opId.name) match {
           case Some(_: Shape.OperationShape) => // ok
-          case Some(_) =>
+          case Some(_)                       =>
             errors += ValidationError(
-              Some(svcName), Some("operations"),
+              Some(svcName),
+              Some("operations"),
               ErrorType.InvalidService,
-              s"'${opId.name}' is not an operation shape"
+              s"'${opId.name}' is not an operation shape",
             )
-          case None =>
-            // Already caught by shape reference validation
+          case None                          =>
+          // Already caught by shape reference validation
         }
       }
 
@@ -616,23 +667,25 @@ object SmithyValidation {
       svc.resources.foreach { resId =>
         model.getShape(resId.name) match {
           case Some(_: Shape.ResourceShape) => // ok
-          case Some(_) =>
+          case Some(_)                      =>
             errors += ValidationError(
-              Some(svcName), Some("resources"),
+              Some(svcName),
+              Some("resources"),
               ErrorType.InvalidService,
-              s"'${resId.name}' is not a resource shape"
+              s"'${resId.name}' is not a resource shape",
             )
-          case None =>
-            // Already caught by shape reference validation
+          case None                         =>
+          // Already caught by shape reference validation
         }
       }
 
       // Service version should not be empty
       if (svc.version.isEmpty) {
         errors += ValidationError(
-          Some(svcName), None,
+          Some(svcName),
+          None,
           ErrorType.InvalidService,
-          "Service version should not be empty"
+          "Service version should not be empty",
         )
       }
     }
@@ -654,43 +707,47 @@ object SmithyValidation {
       case (name, e: Shape.EnumShape) =>
         if (e.members.isEmpty) {
           errors += ValidationError(
-            Some(name), None,
+            Some(name),
+            None,
             ErrorType.InvalidEnum,
-            "Enum must have at least one member"
+            "Enum must have at least one member",
           )
         }
-        
+
         // Check for duplicate enum values
-        val values = e.members.values.flatMap(_.value).toList
+        val values          = e.members.values.flatMap(_.value).toList
         val duplicateValues = values.groupBy(identity).filter(_._2.size > 1).keys
         duplicateValues.foreach { dup =>
           errors += ValidationError(
-            Some(name), None,
+            Some(name),
+            None,
             ErrorType.InvalidEnum,
-            s"Duplicate enum value: '$dup'"
+            s"Duplicate enum value: '$dup'",
           )
         }
-        
+
       case (name, e: Shape.IntEnumShape) =>
         if (e.members.isEmpty) {
           errors += ValidationError(
-            Some(name), None,
+            Some(name),
+            None,
             ErrorType.InvalidEnum,
-            "IntEnum must have at least one member"
+            "IntEnum must have at least one member",
           )
         }
-        
+
         // Check for duplicate int values
-        val values = e.members.values.map(_.value).toList
+        val values          = e.members.values.map(_.value).toList
         val duplicateValues = values.groupBy(identity).filter(_._2.size > 1).keys
         duplicateValues.foreach { dup =>
           errors += ValidationError(
-            Some(name), None,
+            Some(name),
+            None,
             ErrorType.InvalidEnum,
-            s"Duplicate intEnum value: $dup"
+            s"Duplicate intEnum value: $dup",
           )
         }
-        
+
       case _ => // not an enum
     }
 
@@ -711,12 +768,13 @@ object SmithyValidation {
       case (name, u: Shape.UnionShape) =>
         if (u.members.isEmpty) {
           errors += ValidationError(
-            Some(name), None,
+            Some(name),
+            None,
             ErrorType.InvalidOperation, // reusing error type
-            "Union must have at least one member"
+            "Union must have at least one member",
           )
         }
-        
+
       case _ => // not a union
     }
 

--- a/zio-http-gen/src/test/resources/smithy/auth_service.smithy
+++ b/zio-http-gen/src/test/resources/smithy/auth_service.smithy
@@ -1,0 +1,201 @@
+$version: "2"
+namespace example.auth
+
+use smithy.api#httpBearerAuth
+
+/// User authentication and authorization service
+@httpBearerAuth
+service AuthService {
+    version: "1.0.0"
+    operations: [Login, Logout, GetCurrentUser, RefreshToken]
+}
+
+/// Login with username and password
+@http(method: "POST", uri: "/auth/login")
+operation Login {
+    input: LoginInput
+    output: LoginOutput
+    errors: [InvalidCredentials, AccountLocked]
+}
+
+/// Logout the current user
+@http(method: "POST", uri: "/auth/logout")
+operation Logout {
+    input: LogoutInput
+    output: LogoutOutput
+}
+
+/// Get the currently authenticated user
+@http(method: "GET", uri: "/auth/me")
+@readonly
+@auth([httpBearerAuth])
+operation GetCurrentUser {
+    input: GetCurrentUserInput
+    output: GetCurrentUserOutput
+    errors: [Unauthorized]
+}
+
+/// Refresh an authentication token
+@http(method: "POST", uri: "/auth/refresh")
+operation RefreshToken {
+    input: RefreshTokenInput
+    output: RefreshTokenOutput
+    errors: [InvalidToken, TokenExpired]
+}
+
+structure LoginInput {
+    @required
+    @length(min: 3, max: 100)
+    username: String
+
+    @required
+    @length(min: 8, max: 128)
+    password: String
+
+    /// Remember the user for longer session
+    rememberMe: Boolean
+}
+
+structure LoginOutput {
+    @required
+    accessToken: AccessToken
+
+    @required
+    refreshToken: RefreshTokenValue
+
+    @required
+    expiresIn: Integer
+
+    @required
+    user: User
+}
+
+structure LogoutInput {
+    @httpHeader("Authorization")
+    authorization: String
+}
+
+structure LogoutOutput {}
+
+structure GetCurrentUserInput {
+    @httpHeader("Authorization")
+    @required
+    authorization: String
+}
+
+structure GetCurrentUserOutput {
+    @required
+    user: User
+}
+
+structure RefreshTokenInput {
+    @required
+    refreshToken: RefreshTokenValue
+}
+
+structure RefreshTokenOutput {
+    @required
+    accessToken: AccessToken
+
+    @required
+    expiresIn: Integer
+}
+
+/// User information
+structure User {
+    @required
+    id: UserId
+
+    @required
+    username: String
+
+    @required
+    email: Email
+
+    @required
+    roles: RoleList
+
+    @required
+    createdAt: Timestamp
+
+    lastLoginAt: Timestamp
+
+    @required
+    status: UserStatus
+}
+
+@pattern("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+string Email
+
+@length(min: 36, max: 36)
+string UserId
+
+@length(min: 100, max: 500)
+string AccessToken
+
+@length(min: 100, max: 500)
+string RefreshTokenValue
+
+list RoleList {
+    member: Role
+}
+
+enum Role {
+    USER
+    ADMIN
+    MODERATOR
+    GUEST
+}
+
+enum UserStatus {
+    ACTIVE
+    INACTIVE
+    PENDING
+    SUSPENDED
+}
+
+/// Invalid credentials error
+@error("client")
+@httpError(401)
+structure InvalidCredentials {
+    @required
+    message: String
+
+    remainingAttempts: Integer
+}
+
+/// Account is locked
+@error("client")
+@httpError(403)
+structure AccountLocked {
+    @required
+    message: String
+
+    lockedUntil: Timestamp
+}
+
+/// User is not authorized
+@error("client")
+@httpError(401)
+structure Unauthorized {
+    @required
+    message: String
+}
+
+/// Token is invalid
+@error("client")
+@httpError(401)
+structure InvalidToken {
+    @required
+    message: String
+}
+
+/// Token has expired
+@error("client")
+@httpError(401)
+structure TokenExpired {
+    @required
+    message: String
+
+    expiredAt: Timestamp
+}

--- a/zio-http-gen/src/test/resources/smithy/order_service.smithy
+++ b/zio-http-gen/src/test/resources/smithy/order_service.smithy
@@ -1,0 +1,441 @@
+$version: "2"
+namespace example.orders
+
+/// Order management service with resources
+service OrderService {
+    version: "2.0.0"
+    resources: [Order]
+    operations: [SearchOrders]
+}
+
+/// An order resource
+resource Order {
+    identifiers: { orderId: OrderId }
+    properties: { status: OrderStatus }
+    read: GetOrder
+    create: CreateOrder
+    update: UpdateOrder
+    delete: CancelOrder
+    list: ListOrders
+    operations: [AddOrderItem, RemoveOrderItem]
+}
+
+/// Search orders across all users
+@http(method: "POST", uri: "/orders/search")
+@readonly
+operation SearchOrders {
+    input: SearchOrdersInput
+    output: SearchOrdersOutput
+}
+
+/// Get order by ID
+@http(method: "GET", uri: "/orders/{orderId}")
+@readonly
+operation GetOrder {
+    input: GetOrderInput
+    output: GetOrderOutput
+    errors: [OrderNotFound]
+}
+
+/// Create a new order
+@http(method: "POST", uri: "/orders")
+operation CreateOrder {
+    input: CreateOrderInput
+    output: CreateOrderOutput
+    errors: [ValidationError, InsufficientInventory]
+}
+
+/// Update an existing order
+@http(method: "PUT", uri: "/orders/{orderId}")
+@idempotent
+operation UpdateOrder {
+    input: UpdateOrderInput
+    output: UpdateOrderOutput
+    errors: [OrderNotFound, OrderAlreadyShipped, ValidationError]
+}
+
+/// Cancel an order
+@http(method: "DELETE", uri: "/orders/{orderId}")
+@idempotent
+operation CancelOrder {
+    input: CancelOrderInput
+    output: CancelOrderOutput
+    errors: [OrderNotFound, OrderAlreadyShipped]
+}
+
+/// List orders with filtering
+@http(method: "GET", uri: "/orders")
+@readonly
+operation ListOrders {
+    input: ListOrdersInput
+    output: ListOrdersOutput
+}
+
+/// Add an item to an order
+@http(method: "POST", uri: "/orders/{orderId}/items")
+operation AddOrderItem {
+    input: AddOrderItemInput
+    output: AddOrderItemOutput
+    errors: [OrderNotFound, OrderAlreadyShipped, InsufficientInventory]
+}
+
+/// Remove an item from an order
+@http(method: "DELETE", uri: "/orders/{orderId}/items/{itemId}")
+@idempotent
+operation RemoveOrderItem {
+    input: RemoveOrderItemInput
+    output: RemoveOrderItemOutput
+    errors: [OrderNotFound, ItemNotFound, OrderAlreadyShipped]
+}
+
+@length(min: 36, max: 36)
+string OrderId
+
+@length(min: 36, max: 36)
+string ItemId
+
+@length(min: 36, max: 36)
+string ProductId
+
+structure GetOrderInput {
+    @required
+    @httpLabel
+    orderId: OrderId
+}
+
+structure GetOrderOutput {
+    @required
+    order: OrderData
+}
+
+structure CreateOrderInput {
+    @required
+    customerId: String
+
+    @required
+    items: OrderItemList
+
+    shippingAddress: Address
+
+    billingAddress: Address
+
+    notes: String
+}
+
+structure CreateOrderOutput {
+    @required
+    order: OrderData
+}
+
+structure UpdateOrderInput {
+    @required
+    @httpLabel
+    orderId: OrderId
+
+    shippingAddress: Address
+
+    billingAddress: Address
+
+    notes: String
+}
+
+structure UpdateOrderOutput {
+    @required
+    order: OrderData
+}
+
+structure CancelOrderInput {
+    @required
+    @httpLabel
+    orderId: OrderId
+
+    @httpQuery("reason")
+    reason: String
+}
+
+structure CancelOrderOutput {}
+
+structure ListOrdersInput {
+    @httpQuery("status")
+    status: OrderStatus
+
+    @httpQuery("customerId")
+    customerId: String
+
+    @httpQuery("fromDate")
+    fromDate: Timestamp
+
+    @httpQuery("toDate")
+    toDate: Timestamp
+
+    @httpQuery("limit")
+    @range(min: 1, max: 100)
+    limit: Integer
+
+    @httpQuery("offset")
+    @range(min: 0)
+    offset: Integer
+}
+
+structure ListOrdersOutput {
+    @required
+    orders: OrderList
+
+    @required
+    total: Long
+}
+
+structure SearchOrdersInput {
+    query: String
+
+    filters: OrderFilters
+
+    @range(min: 1, max: 100)
+    limit: Integer
+
+    offset: Integer
+}
+
+structure OrderFilters {
+    statuses: OrderStatusList
+
+    minTotal: Money
+
+    maxTotal: Money
+
+    dateRange: DateRange
+}
+
+structure DateRange {
+    from: Timestamp
+    to: Timestamp
+}
+
+structure SearchOrdersOutput {
+    @required
+    orders: OrderList
+
+    @required
+    total: Long
+}
+
+structure AddOrderItemInput {
+    @required
+    @httpLabel
+    orderId: OrderId
+
+    @required
+    productId: ProductId
+
+    @required
+    @range(min: 1)
+    quantity: Integer
+}
+
+structure AddOrderItemOutput {
+    @required
+    order: OrderData
+}
+
+structure RemoveOrderItemInput {
+    @required
+    @httpLabel
+    orderId: OrderId
+
+    @required
+    @httpLabel
+    itemId: ItemId
+}
+
+structure RemoveOrderItemOutput {
+    @required
+    order: OrderData
+}
+
+/// An order
+structure OrderData {
+    @required
+    id: OrderId
+
+    @required
+    customerId: String
+
+    @required
+    items: OrderItemList
+
+    @required
+    status: OrderStatus
+
+    @required
+    subtotal: Money
+
+    @required
+    tax: Money
+
+    @required
+    total: Money
+
+    shippingAddress: Address
+
+    billingAddress: Address
+
+    notes: String
+
+    @required
+    createdAt: Timestamp
+
+    updatedAt: Timestamp
+
+    shippedAt: Timestamp
+
+    deliveredAt: Timestamp
+}
+
+/// An item in an order
+structure OrderItem {
+    @required
+    id: ItemId
+
+    @required
+    productId: ProductId
+
+    @required
+    productName: String
+
+    @required
+    quantity: Integer
+
+    @required
+    unitPrice: Money
+
+    @required
+    totalPrice: Money
+}
+
+list OrderItemList {
+    member: OrderItem
+}
+
+list OrderList {
+    member: OrderData
+}
+
+list OrderStatusList {
+    member: OrderStatus
+}
+
+enum OrderStatus {
+    PENDING
+    CONFIRMED
+    PROCESSING
+    SHIPPED
+    DELIVERED
+    CANCELLED
+    REFUNDED
+}
+
+/// Monetary value in cents
+structure Money {
+    @required
+    amount: Long
+
+    @required
+    currency: Currency
+}
+
+enum Currency {
+    USD
+    EUR
+    GBP
+    JPY
+    CAD
+    AUD
+}
+
+/// Shipping/billing address
+structure Address {
+    @required
+    street1: String
+
+    street2: String
+
+    @required
+    city: String
+
+    @required
+    state: String
+
+    @required
+    postalCode: String
+
+    @required
+    country: String
+}
+
+/// Order not found
+@error("client")
+@httpError(404)
+structure OrderNotFound {
+    @required
+    message: String
+
+    orderId: OrderId
+}
+
+/// Item not found in order
+@error("client")
+@httpError(404)
+structure ItemNotFound {
+    @required
+    message: String
+
+    itemId: ItemId
+}
+
+/// Order has already been shipped
+@error("client")
+@httpError(409)
+structure OrderAlreadyShipped {
+    @required
+    message: String
+
+    orderId: OrderId
+
+    shippedAt: Timestamp
+}
+
+/// Insufficient inventory
+@error("client")
+@httpError(409)
+structure InsufficientInventory {
+    @required
+    message: String
+
+    productId: ProductId
+
+    requested: Integer
+
+    available: Integer
+}
+
+/// Validation error
+@error("client")
+@httpError(400)
+structure ValidationError {
+    @required
+    message: String
+
+    errors: ValidationErrorList
+}
+
+structure ValidationErrorDetail {
+    @required
+    field: String
+
+    @required
+    message: String
+}
+
+list ValidationErrorList {
+    member: ValidationErrorDetail
+}

--- a/zio-http-gen/src/test/resources/smithy/pet_store.smithy
+++ b/zio-http-gen/src/test/resources/smithy/pet_store.smithy
@@ -1,0 +1,175 @@
+$version: "2"
+namespace example.petstore
+
+/// A simple pet store service
+service PetStore {
+    version: "1.0.0"
+    operations: [GetPet, ListPets, CreatePet, DeletePet]
+}
+
+/// Get a pet by ID
+@http(method: "GET", uri: "/pets/{petId}")
+@readonly
+operation GetPet {
+    input: GetPetInput
+    output: GetPetOutput
+    errors: [PetNotFound]
+}
+
+/// List all pets with pagination
+@http(method: "GET", uri: "/pets")
+@readonly
+@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "maxResults", items: "pets")
+operation ListPets {
+    input: ListPetsInput
+    output: ListPetsOutput
+}
+
+/// Create a new pet
+@http(method: "POST", uri: "/pets")
+@idempotent
+operation CreatePet {
+    input: CreatePetInput
+    output: CreatePetOutput
+    errors: [ValidationError]
+}
+
+/// Delete a pet by ID
+@http(method: "DELETE", uri: "/pets/{petId}")
+@idempotent
+operation DeletePet {
+    input: DeletePetInput
+    output: DeletePetOutput
+    errors: [PetNotFound]
+}
+
+structure GetPetInput {
+    @required
+    @httpLabel
+    petId: String
+}
+
+structure GetPetOutput {
+    @required
+    pet: Pet
+}
+
+structure ListPetsInput {
+    @httpQuery("maxResults")
+    @range(min: 1, max: 100)
+    maxResults: Integer
+
+    @httpQuery("nextToken")
+    nextToken: String
+
+    @httpQuery("species")
+    species: Species
+}
+
+structure ListPetsOutput {
+    @required
+    pets: PetList
+
+    nextToken: String
+}
+
+structure CreatePetInput {
+    @required
+    name: PetName
+
+    @required
+    species: Species
+
+    age: Integer
+    
+    tags: TagList
+}
+
+structure CreatePetOutput {
+    @required
+    pet: Pet
+}
+
+structure DeletePetInput {
+    @required
+    @httpLabel
+    petId: String
+}
+
+structure DeletePetOutput {}
+
+/// A pet in the store
+structure Pet {
+    @required
+    id: String
+
+    @required
+    name: PetName
+
+    @required
+    species: Species
+
+    age: Integer
+
+    @required
+    createdAt: Timestamp
+
+    tags: TagList
+}
+
+/// Pet species
+enum Species {
+    DOG
+    CAT
+    BIRD
+    FISH
+    REPTILE
+    OTHER
+}
+
+/// Pet name with length validation
+@length(min: 1, max: 100)
+string PetName
+
+list PetList {
+    member: Pet
+}
+
+list TagList {
+    member: Tag
+}
+
+@length(min: 1, max: 50)
+string Tag
+
+/// Pet not found error
+@error("client")
+@httpError(404)
+structure PetNotFound {
+    @required
+    message: String
+
+    petId: String
+}
+
+/// Validation error
+@error("client")
+@httpError(400)
+structure ValidationError {
+    @required
+    message: String
+
+    fieldErrors: FieldErrorList
+}
+
+structure FieldError {
+    @required
+    field: String
+
+    @required
+    message: String
+}
+
+list FieldErrorList {
+    member: FieldError
+}

--- a/zio-http-gen/src/test/resources/smithy/weather_service.smithy
+++ b/zio-http-gen/src/test/resources/smithy/weather_service.smithy
@@ -1,0 +1,6 @@
+$version: "2"
+namespace example.weather
+
+service Weather {
+    version: "2006-03-01"
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -616,6 +616,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
         test("response and empty request") {
           val endpoint = Endpoint(Method.GET / "api" / "v1" / "users").out[User]
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
+          println(openAPI.toJsonPretty)
           val scala    = EndpointGen.fromOpenAPI(openAPI)
           val expected = Code.File(
             List("api", "v1", "Users.scala"),

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/OpenAPICodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/OpenAPICodeGenSpec.scala
@@ -29,7 +29,7 @@ import zio.http.gen.openapi.Config.NormalizeFields
 import zio.http.gen.openapi.{Config, EndpointGen}
 
 @nowarn("msg=missing interpolator")
-object CodeGenSpec extends ZIOSpecDefault {
+object OpenAPICodeGenSpec extends ZIOSpecDefault {
 
   case class ValidatedData(
     @validate(Validation.maxLength(10)) name: String,

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyCodecsSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyCodecsSpec.scala
@@ -1,0 +1,144 @@
+package zio.http.gen.smithy
+
+import zio.Scope
+import zio.test._
+
+object SmithyCodecsSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("SmithyCodecsSpec")(
+      suite("Identifier Codec")(
+        test("parses simple identifier") {
+          val result = SmithyCodecs.identifier.decode("myVar")
+          assertTrue(result == Right("myVar"))
+        },
+        test("parses identifier with underscore") {
+          val result = SmithyCodecs.identifier.decode("my_var")
+          assertTrue(result == Right("my_var"))
+        },
+        test("parses identifier starting with underscore") {
+          val result = SmithyCodecs.identifier.decode("_private")
+          assertTrue(result == Right("_private"))
+        },
+        test("parses identifier with numbers") {
+          val result = SmithyCodecs.identifier.decode("var123")
+          assertTrue(result == Right("var123"))
+        },
+        test("fails on identifier starting with digit") {
+          val result = SmithyCodecs.identifier.decode("123var")
+          assertTrue(result.isLeft)
+        },
+      ),
+      suite("Namespace Codec")(
+        test("parses simple namespace") {
+          val result = SmithyCodecs.namespace.decode("example")
+          assertTrue(result == Right("example"))
+        },
+        test("parses dotted namespace") {
+          val result = SmithyCodecs.namespace.decode("example.api")
+          assertTrue(result == Right("example.api"))
+        },
+        test("parses multi-part namespace") {
+          val result = SmithyCodecs.namespace.decode("com.example.weather")
+          assertTrue(result == Right("com.example.weather"))
+        },
+      ),
+      suite("QuotedString Codec")(
+        test("parses simple string") {
+          val result = SmithyCodecs.quotedString.decode("\"hello\"")
+          assertTrue(result == Right("hello"))
+        },
+        test("parses empty string") {
+          val result = SmithyCodecs.quotedString.decode("\"\"")
+          assertTrue(result == Right(""))
+        },
+        test("parses string with escape sequences") {
+          val result = SmithyCodecs.quotedString.decode("\"hello\\nworld\"")
+          assertTrue(result == Right("hello\nworld"))
+        },
+        test("parses string with escaped quote") {
+          val result = SmithyCodecs.quotedString.decode("\"say \\\"hello\\\"\"")
+          assertTrue(result == Right("say \"hello\""))
+        },
+      ),
+      suite("Number Codecs")(
+        test("parses positive integer") {
+          val result = SmithyCodecs.integerNumber.decode("42")
+          assertTrue(result == Right(42L))
+        },
+        test("parses negative integer") {
+          val result = SmithyCodecs.integerNumber.decode("-42")
+          assertTrue(result == Right(-42L))
+        },
+        test("parses zero") {
+          val result = SmithyCodecs.integerNumber.decode("0")
+          assertTrue(result == Right(0L))
+        },
+        test("parses decimal number") {
+          val result = SmithyCodecs.decimalNumber.decode("3.14")
+          assertTrue(result == Right(BigDecimal("3.14")))
+        },
+        test("parses negative decimal") {
+          val result = SmithyCodecs.decimalNumber.decode("-2.5")
+          assertTrue(result == Right(BigDecimal("-2.5")))
+        },
+      ),
+      suite("ShapeId Codec")(
+        test("parses simple shape name") {
+          val result = SmithyCodecs.shapeId.decode("String")
+          assertTrue(result == Right(ShapeId(None, "String", None)))
+        },
+        test("parses qualified shape id") {
+          val result = SmithyCodecs.shapeId.decode("example.api#MyShape")
+          assertTrue(result == Right(ShapeId(Some("example.api"), "MyShape", None)))
+        },
+        test("parses shape id with member") {
+          val result = SmithyCodecs.shapeId.decode("example.api#MyUnion$member1")
+          assertTrue(result == Right(ShapeId(Some("example.api"), "MyUnion", Some("member1"))))
+        },
+        test("parses shape id with member but no namespace") {
+          val result = SmithyCodecs.shapeId.decode("MyUnion$member1")
+          assertTrue(result == Right(ShapeId(None, "MyUnion", Some("member1"))))
+        },
+      ),
+      suite("NodeValue Codecs")(
+        test("parses string node") {
+          val result = SmithyCodecs.nodeString.decode("\"hello\"")
+          assertTrue(result == Right(NodeValue.Str("hello")))
+        },
+        test("parses number node") {
+          val result = SmithyCodecs.nodeNumber.decode("42")
+          assertTrue(result == Right(NodeValue.Num(BigDecimal(42))))
+        },
+        test("parses true boolean") {
+          val result = SmithyCodecs.nodeBool.decode("true")
+          assertTrue(result == Right(NodeValue.Bool(true)))
+        },
+        test("parses false boolean") {
+          val result = SmithyCodecs.nodeBool.decode("false")
+          assertTrue(result == Right(NodeValue.Bool(false)))
+        },
+        test("parses null") {
+          val result = SmithyCodecs.nodeNull.decode("null")
+          assertTrue(result == Right(NodeValue.Null))
+        },
+      ),
+      suite("Simple Shape Keywords")(
+        test("parses string keyword") {
+          val result = SmithyCodecs.simpleShapeKeyword.decode("string")
+          assertTrue(result == Right("string"))
+        },
+        test("parses integer keyword") {
+          val result = SmithyCodecs.simpleShapeKeyword.decode("integer")
+          assertTrue(result == Right("integer"))
+        },
+        test("parses boolean keyword") {
+          val result = SmithyCodecs.simpleShapeKeyword.decode("boolean")
+          assertTrue(result == Right("boolean"))
+        },
+        test("parses timestamp keyword") {
+          val result = SmithyCodecs.simpleShapeKeyword.decode("timestamp")
+          assertTrue(result == Right("timestamp"))
+        },
+      ),
+    )
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
@@ -19,13 +19,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    name: String
                                |    age: Integer
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             // Should have one file for the User structure
@@ -55,13 +55,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure BankAccount {
                                |    accountNumber: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             assertTrue(rendered.size == 3) && // Union + 2 structures
@@ -77,13 +77,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    ACTIVE
                                |    INACTIVE
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             assertTrue(rendered.size == 1) &&
@@ -134,13 +134,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    name: String
                                |    email: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             // Should have Endpoints.scala + component files
@@ -182,13 +182,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure User {
                                |    id: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
@@ -217,13 +217,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure ProtectedData {
                                |    data: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
@@ -247,15 +247,15 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    byteField: Byte
                                |    timestampField: Timestamp
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
-            val rendered = result.toOption.get
+            val rendered     = result.toOption.get
             val allTypesCode = rendered.find(_._1.contains("AllTypes.scala")).map(_._2).getOrElse("")
             assertTrue(allTypesCode.contains("String")) &&
             assertTrue(allTypesCode.contains("Int")) &&
@@ -362,17 +362,17 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |
                                |@pattern("^[A-Za-z0-9 ]+$")
                                |string CityId""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.weather")
           } yield (model, files, rendered)
-          
+
           assertTrue(result.isRight) && {
             val (model, files, rendered) = result.toOption.get
-            val endpointsCode = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
-            
+            val endpointsCode            = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
+
             assertTrue(
               model.namespace == "example.weather",
               model.shapes.contains("Weather"),
@@ -384,7 +384,7 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
               endpointsCode.contains("ListCities"),
               endpointsCode.contains("GetCurrentTime"),
               endpointsCode.contains("Method.GET"),
-              rendered.keys.exists(k => k.contains("GetCityOutput.scala") || k.contains("component"))
+              rendered.keys.exists(k => k.contains("GetCityOutput.scala") || k.contains("component")),
             )
           }
         },
@@ -397,9 +397,9 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure User {
                                |    id: String
                                |}""".stripMargin
-          
+
           val result = SmithyEndpointGen.fromString(smithyString)
-          
+
           assertTrue(result.isRight) && {
             val files = result.toOption.get
             assertTrue(files.files.nonEmpty)
@@ -407,9 +407,9 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
         },
         test("fromString returns empty files for text without shapes") {
           val textWithoutShapes = "this is not valid smithy"
-          
+
           val result = SmithyEndpointGen.fromString(textWithoutShapes)
-          
+
           // Parser is lenient, produces empty model for unrecognized text
           assertTrue(result.isRight) && {
             val files = result.toOption.get
@@ -423,22 +423,22 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                           |structure User {
                           |    id: String
                           |}""".stripMargin
-          
+
           val smithy2 = """$version: "2"
                           |namespace example.api
                           |
                           |structure Order {
                           |    orderId: String
                           |}""".stripMargin
-          
+
           val result1 = SmithyParser.parse(smithy1)
           val result2 = SmithyParser.parse(smithy2)
-          
+
           assertTrue(result1.isRight) &&
           assertTrue(result2.isRight) && {
             val model1 = result1.toOption.get
             val model2 = result2.toOption.get
-            
+
             // Both models should have their respective shapes
             assertTrue(model1.shapes.contains("User")) &&
             assertTrue(model2.shapes.contains("Order"))
@@ -457,16 +457,16 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    @httpPayload
                                |    data: StreamingBlob
                                |}""".stripMargin
-          
+
           val result = SmithyParser.parse(smithyString)
-          
+
           assertTrue(result.isRight) && {
             val model = result.toOption.get
             assertTrue(model.shapes.contains("StreamingBlob")) && {
               val blobShape = model.shapes("StreamingBlob")
               assertTrue(blobShape.traits.exists {
                 case SmithyTrait.Streaming => true
-                case _ => false
+                case _                     => false
               })
             }
           }
@@ -480,16 +480,16 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    /// The unique identifier
                                |    id: String
                                |}""".stripMargin
-          
+
           val result = SmithyParser.parse(smithyString)
-          
+
           assertTrue(result.isRight) && {
             val model = result.toOption.get
             assertTrue(model.shapes.contains("User")) && {
               val userShape = model.shapes("User").asInstanceOf[Shape.StructureShape]
-              val hasDoc = userShape.traits.exists {
+              val hasDoc    = userShape.traits.exists {
                 case SmithyTrait.Documentation(_) => true
-                case _ => false
+                case _                            => false
               }
               assertTrue(hasDoc)
             }
@@ -503,16 +503,16 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |service SecureService {
                                |    version: "1.0"
                                |}""".stripMargin
-          
+
           val result = SmithyParser.parse(smithyString)
-          
+
           assertTrue(result.isRight) && {
             val model = result.toOption.get
             assertTrue(model.shapes.contains("SecureService")) && {
               val svcShape = model.shapes("SecureService").asInstanceOf[Shape.ServiceShape]
-              val hasAuth = svcShape.traits.exists {
+              val hasAuth  = svcShape.traits.exists {
                 case SmithyTrait.HttpBearerAuth => true
-                case _ => false
+                case _                          => false
               }
               assertTrue(hasAuth)
             }
@@ -550,13 +550,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure Unauthorized {
                                |    message: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model)
+            files    = SmithyEndpointGen.fromSmithyModel(model)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
@@ -581,13 +581,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    first_name: String
                                |    last_name: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model, SmithyConfig.default)
+            files    = SmithyEndpointGen.fromSmithyModel(model, SmithyConfig.default)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             val userCode = rendered.find(_._1.contains("UserProfile.scala")).map(_._2).getOrElse("")
@@ -610,13 +610,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    user_id: String
                                |    first_name: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model, SmithyConfig.preserveFieldNames)
+            files    = SmithyEndpointGen.fromSmithyModel(model, SmithyConfig.preserveFieldNames)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             val userCode = rendered.find(_._1.contains("UserProfile.scala")).map(_._2).getOrElse("")
@@ -630,9 +630,9 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
             fieldNamesNormalization = NormalizeFields(
               enableAutomatic = true,
               manualOverrides = Map("user_id" -> "uid"),
-            )
+            ),
           )
-          
+
           val smithyString = """$version: "2"
                                |namespace example.api
                                |
@@ -641,13 +641,13 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |    user_id: String
                                |    first_name: String
                                |}""".stripMargin
-          
+
           val result = for {
             model <- SmithyParser.parse(smithyString)
-            files = SmithyEndpointGen.fromSmithyModel(model, config)
+            files    = SmithyEndpointGen.fromSmithyModel(model, config)
             rendered = CodeGen.renderedFiles(files, "example.api")
           } yield rendered
-          
+
           assertTrue(result.isRight) && {
             val rendered = result.toOption.get
             val userCode = rendered.find(_._1.contains("UserProfile.scala")).map(_._2).getOrElse("")
@@ -667,9 +667,9 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure User {
                                |    profile: UndefinedType
                                |}""".stripMargin
-          
+
           val result = SmithyEndpointGen.fromString(smithyString, SmithyConfig.default)
-          
+
           assertTrue(result.isLeft) &&
           assertTrue(result.swap.toOption.get.contains("validation failed"))
         },
@@ -680,9 +680,9 @@ object SmithyEndpointGenSpec extends ZIOSpecDefault {
                                |structure User {
                                |    profile: UndefinedType
                                |}""".stripMargin
-          
+
           val result = SmithyEndpointGen.fromString(smithyString, SmithyConfig.fast)
-          
+
           assertTrue(result.isRight)
         },
       ),

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
@@ -2,8 +2,9 @@ package zio.http.gen.smithy
 
 import zio.Scope
 import zio.test._
-import zio.http.gen.scala.CodeGen
+
 import zio.http.gen.openapi.Config.NormalizeFields
+import zio.http.gen.scala.CodeGen
 
 object SmithyEndpointGenSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyEndpointGenSpec.scala
@@ -1,0 +1,392 @@
+package zio.http.gen.smithy
+
+import zio.Scope
+import zio.test._
+import zio.http.gen.scala.CodeGen
+
+object SmithyEndpointGenSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("SmithyEndpointGenSpec")(
+      suite("Code Generation")(
+        test("generate case class from structure") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |structure User {
+                               |    @required
+                               |    id: String
+                               |    name: String
+                               |    age: Integer
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            // Should have one file for the User structure
+            assertTrue(rendered.size == 1) &&
+            assertTrue(rendered.keys.exists(_.contains("User.scala"))) && {
+              val userCode = rendered.values.head
+              assertTrue(userCode.contains("case class User")) &&
+              assertTrue(userCode.contains("id: String")) &&
+              assertTrue(userCode.contains("name: Option[String]")) &&
+              assertTrue(userCode.contains("age: Option[Int]"))
+            }
+          }
+        },
+        test("generate sealed trait from union") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |union PaymentMethod {
+                               |    creditCard: CreditCard
+                               |    bankAccount: BankAccount
+                               |}
+                               |
+                               |structure CreditCard {
+                               |    number: String
+                               |}
+                               |
+                               |structure BankAccount {
+                               |    accountNumber: String
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            assertTrue(rendered.size == 3) && // Union + 2 structures
+            assertTrue(rendered.keys.exists(_.contains("PaymentMethod.scala")))
+          }
+        },
+        test("generate enum from enum shape") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |enum Status {
+                               |    PENDING
+                               |    ACTIVE
+                               |    INACTIVE
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            assertTrue(rendered.size == 1) &&
+            assertTrue(rendered.keys.exists(_.contains("Status.scala"))) && {
+              val statusCode = rendered.values.head
+              assertTrue(statusCode.contains("sealed trait Status")) &&
+              assertTrue(statusCode.contains("PENDING")) &&
+              assertTrue(statusCode.contains("ACTIVE")) &&
+              assertTrue(statusCode.contains("INACTIVE"))
+            }
+          }
+        },
+        test("generate endpoint from operation with @http trait") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |service UserService {
+                               |    operations: [GetUser, CreateUser]
+                               |}
+                               |
+                               |@http(method: "GET", uri: "/users/{userId}")
+                               |operation GetUser {
+                               |    input: GetUserInput
+                               |    output: User
+                               |}
+                               |
+                               |@http(method: "POST", uri: "/users", code: 201)
+                               |operation CreateUser {
+                               |    input: CreateUserInput
+                               |    output: User
+                               |}
+                               |
+                               |structure GetUserInput {
+                               |    @required
+                               |    @httpLabel
+                               |    userId: String
+                               |}
+                               |
+                               |structure CreateUserInput {
+                               |    @required
+                               |    name: String
+                               |    email: String
+                               |}
+                               |
+                               |structure User {
+                               |    @required
+                               |    id: String
+                               |    name: String
+                               |    email: String
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            // Should have Endpoints.scala + component files
+            assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
+              val endpointsCode = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
+              assertTrue(endpointsCode.contains("object Endpoints")) &&
+              assertTrue(endpointsCode.contains("GetUser")) &&
+              assertTrue(endpointsCode.contains("CreateUser")) &&
+              assertTrue(endpointsCode.contains("Method.GET")) &&
+              assertTrue(endpointsCode.contains("Method.POST"))
+            }
+          }
+        },
+        test("generate endpoint with query parameters") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |@http(method: "GET", uri: "/users")
+                               |operation ListUsers {
+                               |    input: ListUsersInput
+                               |    output: UserList
+                               |}
+                               |
+                               |structure ListUsersInput {
+                               |    @httpQuery("limit")
+                               |    limit: Integer
+                               |    @httpQuery("offset")
+                               |    offset: Integer
+                               |}
+                               |
+                               |structure UserList {
+                               |    users: UserArray
+                               |}
+                               |
+                               |list UserArray {
+                               |    member: User
+                               |}
+                               |
+                               |structure User {
+                               |    id: String
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
+              val endpointsCode = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
+              assertTrue(endpointsCode.contains("query")) &&
+              assertTrue(endpointsCode.contains("limit") || endpointsCode.contains("offset"))
+            }
+          }
+        },
+        test("generate endpoint with headers") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |@http(method: "GET", uri: "/protected")
+                               |operation GetProtected {
+                               |    input: GetProtectedInput
+                               |    output: ProtectedData
+                               |}
+                               |
+                               |structure GetProtectedInput {
+                               |    @required
+                               |    @httpHeader("Authorization")
+                               |    authorization: String
+                               |}
+                               |
+                               |structure ProtectedData {
+                               |    data: String
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            assertTrue(rendered.keys.exists(_.contains("Endpoints.scala"))) && {
+              val endpointsCode = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
+              assertTrue(endpointsCode.contains("Authorization") || endpointsCode.contains("header"))
+            }
+          }
+        },
+        test("map Smithy types to Scala types correctly") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |structure AllTypes {
+                               |    stringField: String
+                               |    intField: Integer
+                               |    longField: Long
+                               |    boolField: Boolean
+                               |    doubleField: Double
+                               |    floatField: Float
+                               |    shortField: Short
+                               |    byteField: Byte
+                               |    timestampField: Timestamp
+                               |}""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.api")
+          } yield rendered
+          
+          assertTrue(result.isRight) && {
+            val rendered = result.toOption.get
+            val allTypesCode = rendered.find(_._1.contains("AllTypes.scala")).map(_._2).getOrElse("")
+            assertTrue(allTypesCode.contains("String")) &&
+            assertTrue(allTypesCode.contains("Int")) &&
+            assertTrue(allTypesCode.contains("Long")) &&
+            assertTrue(allTypesCode.contains("Boolean")) &&
+            assertTrue(allTypesCode.contains("Double"))
+          }
+        },
+      ),
+      suite("End-to-End")(
+        test("parse and generate from weather service example") {
+          val smithyString = """$version: "2"
+                               |namespace example.weather
+                               |
+                               |/// Provides weather forecasts.
+                               |service Weather {
+                               |    version: "2006-03-01"
+                               |    resources: [City]
+                               |    operations: [GetCurrentTime]
+                               |}
+                               |
+                               |resource City {
+                               |    identifiers: { cityId: CityId }
+                               |    read: GetCity
+                               |    list: ListCities
+                               |}
+                               |
+                               |@http(method: "GET", uri: "/cities/{cityId}")
+                               |@readonly
+                               |operation GetCity {
+                               |    input: GetCityInput
+                               |    output: GetCityOutput
+                               |    errors: [NoSuchResource]
+                               |}
+                               |
+                               |structure GetCityInput {
+                               |    @required
+                               |    @httpLabel
+                               |    cityId: CityId
+                               |}
+                               |
+                               |structure GetCityOutput {
+                               |    @required
+                               |    name: String
+                               |    coordinates: CityCoordinates
+                               |}
+                               |
+                               |structure CityCoordinates {
+                               |    @required
+                               |    latitude: Float
+                               |    @required
+                               |    longitude: Float
+                               |}
+                               |
+                               |@http(method: "GET", uri: "/cities")
+                               |@readonly
+                               |@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
+                               |operation ListCities {
+                               |    input: ListCitiesInput
+                               |    output: ListCitiesOutput
+                               |}
+                               |
+                               |structure ListCitiesInput {
+                               |    @httpQuery("nextToken")
+                               |    nextToken: String
+                               |    @httpQuery("pageSize")
+                               |    pageSize: Integer
+                               |}
+                               |
+                               |structure ListCitiesOutput {
+                               |    nextToken: String
+                               |    @required
+                               |    items: CitySummaries
+                               |}
+                               |
+                               |list CitySummaries {
+                               |    member: CitySummary
+                               |}
+                               |
+                               |structure CitySummary {
+                               |    @required
+                               |    cityId: CityId
+                               |    @required
+                               |    name: String
+                               |}
+                               |
+                               |@http(method: "GET", uri: "/time")
+                               |@readonly
+                               |operation GetCurrentTime {
+                               |    output: GetCurrentTimeOutput
+                               |}
+                               |
+                               |structure GetCurrentTimeOutput {
+                               |    @required
+                               |    time: Timestamp
+                               |}
+                               |
+                               |@error("client")
+                               |@httpError(404)
+                               |structure NoSuchResource {
+                               |    @required
+                               |    resourceType: String
+                               |}
+                               |
+                               |@pattern("^[A-Za-z0-9 ]+$")
+                               |string CityId""".stripMargin
+          
+          val result = for {
+            model <- SmithyParser.parse(smithyString)
+            files = SmithyEndpointGen.fromSmithyModel(model)
+            rendered = CodeGen.renderedFiles(files, "example.weather")
+          } yield (model, files, rendered)
+          
+          assertTrue(result.isRight) && {
+            val (model, files, rendered) = result.toOption.get
+            val endpointsCode = rendered.find(_._1.contains("Endpoints.scala")).map(_._2).getOrElse("")
+            
+            assertTrue(
+              model.namespace == "example.weather",
+              model.shapes.contains("Weather"),
+              model.shapes.contains("GetCity"),
+              model.shapes.contains("ListCities"),
+              files.files.nonEmpty,
+              rendered.keys.exists(_.contains("Endpoints.scala")),
+              endpointsCode.contains("GetCity"),
+              endpointsCode.contains("ListCities"),
+              endpointsCode.contains("GetCurrentTime"),
+              endpointsCode.contains("Method.GET"),
+              rendered.keys.exists(k => k.contains("GetCityOutput.scala") || k.contains("component"))
+            )
+          }
+        },
+      ),
+    )
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
@@ -1,12 +1,12 @@
 package zio.http.gen.smithy
 
+import scala.io.Source
+
 import zio.Scope
 import zio.test._
 
-import scala.io.Source
-
 object SmithyParsingSpec extends ZIOSpecDefault {
-  private def loadResource(name: String): String = {
+  private def loadResource(name: String): String           = {
     val stream = getClass.getResourceAsStream(s"/smithy/$name")
     Source.fromInputStream(stream).mkString
   }
@@ -338,7 +338,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
             assertTrue(model.getOperation("SearchOrders").isDefined) &&
             assertTrue(model.getOperation("AddOrderItem").isDefined) &&
             assertTrue(model.getOperation("RemoveOrderItem").isDefined) &&
-            assertTrue(model.getOperation("RemoveOrderItem").get.httpTrait.get.uri == "/orders/{orderId}/items/{itemId}") &&
+            assertTrue(
+              model.getOperation("RemoveOrderItem").get.httpTrait.get.uri == "/orders/{orderId}/items/{itemId}",
+            ) &&
             assertTrue(model.getStructure("OrderData").isDefined) &&
             assertTrue(model.getStructure("OrderData").get.members.size == 14) &&
             assertTrue(model.getStructure("Money").isDefined) &&

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
@@ -6,41 +6,318 @@ import zio.test._
 object SmithyParsingSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("SmithyParsingSpec")(
-      test("parse service") {
-        val smithyString = """$version: "2"
-                             |namespace example.weather
-                             |
-                             |service Weather {
-                             |    version: "2006-03-01"
-                             |}""".stripMargin
-        val parsed = Smithy.parse(smithyString)
-        val expected = Smithy(Map("Weather" -> Smithy.Service("2006-03-01", Nil, Nil, Nil, Map.empty)))
-        assertCompletes
-      },
-      test("parse service and resource"){
-        val smithyString =  """$version: "2"
-                              |namespace example.weather
-                              |
-                              |/// Provides weather forecasts.
-                              |service Weather {
-                              |    version: "2006-03-01"
-                              |    resources: [
-                              |        City
-                              |    ]
-                              |}
-                              |
-                              |resource City {
-                              |    identifiers: { cityId: CityId }
-                              |    read: GetCity
-                              |    list: ListCities
-                              |}
-                              |
-                              |// "pattern" is a trait.
-                              |@pattern("^[A-Za-z0-9 ]+$")
-                              |string CityId""".stripMargin
-        val parsed = Smithy.parse(smithyString)
-        //val expected = Smithy(Map("Weather" -> Smithy.Service("2006-03-01", Nil, Nil, Nil, Map("City" -> Smithy.Resource(Map("cityId" -> "CityId"), "GetCity", "ListCities")))))
-        assertCompletes
-      }
+      suite("Full IDL Parsing")(
+        test("parse simple service") {
+          val smithyString = """$version: "2"
+                               |namespace example.weather
+                               |
+                               |service Weather {
+                               |    version: "2006-03-01"
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) &&
+          assertTrue(result.toOption.get.namespace == "example.weather") &&
+          assertTrue(result.toOption.get.version == "2") &&
+          assertTrue(result.toOption.get.shapes.contains("Weather"))
+        },
+        test("parse service with resource") {
+          val smithyString = """$version: "2"
+                               |namespace example.weather
+                               |
+                               |/// Provides weather forecasts.
+                               |service Weather {
+                               |    version: "2006-03-01"
+                               |    resources: [
+                               |        City
+                               |    ]
+                               |}
+                               |
+                               |resource City {
+                               |    identifiers: { cityId: CityId }
+                               |    read: GetCity
+                               |    list: ListCities
+                               |}
+                               |
+                               |@pattern("^[A-Za-z0-9 ]+$")
+                               |string CityId""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) &&
+          assertTrue(result.toOption.get.shapes.contains("Weather")) &&
+          assertTrue(result.toOption.get.shapes.contains("City")) &&
+          assertTrue(result.toOption.get.shapes.contains("CityId"))
+        },
+        test("parse operation with HTTP trait") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |@http(method: "GET", uri: "/users/{userId}")
+                               |operation GetUser {
+                               |    input: GetUserInput
+                               |    output: GetUserOutput
+                               |}
+                               |
+                               |structure GetUserInput {
+                               |    @required
+                               |    @httpLabel
+                               |    userId: String
+                               |}
+                               |
+                               |structure GetUserOutput {
+                               |    name: String
+                               |    email: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val op = model.getOperation("GetUser")
+            assertTrue(op.isDefined) &&
+            assertTrue(op.get.httpTrait.isDefined) &&
+            assertTrue(op.get.httpTrait.get.method == "GET") &&
+            assertTrue(op.get.httpTrait.get.uri == "/users/{userId}")
+          }
+        },
+        test("parse structure with members") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |structure Person {
+                               |    @required
+                               |    name: String
+                               |    age: Integer
+                               |    @httpHeader("X-Request-Id")
+                               |    requestId: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val struct = model.getStructure("Person")
+            assertTrue(struct.isDefined) &&
+            assertTrue(struct.get.members.contains("name")) &&
+            assertTrue(struct.get.members("name").isRequired) &&
+            assertTrue(struct.get.members.contains("age")) &&
+            assertTrue(struct.get.members.contains("requestId")) &&
+            assertTrue(struct.get.members("requestId").httpHeader == Some("X-Request-Id"))
+          }
+        },
+        test("parse list shape") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |list StringList {
+                               |    member: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val listShape = model.shapes.get("StringList")
+            assertTrue(listShape.isDefined) &&
+            assertTrue(listShape.get.isInstanceOf[Shape.ListShape]) &&
+            assertTrue(listShape.get.asInstanceOf[Shape.ListShape].member.name == "String")
+          }
+        },
+        test("parse map shape") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |map StringMap {
+                               |    key: String
+                               |    value: Integer
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val mapShape = model.shapes.get("StringMap")
+            assertTrue(mapShape.isDefined) &&
+            assertTrue(mapShape.get.isInstanceOf[Shape.MapShape]) &&
+            assertTrue(mapShape.get.asInstanceOf[Shape.MapShape].key.name == "String") &&
+            assertTrue(mapShape.get.asInstanceOf[Shape.MapShape].value.name == "Integer")
+          }
+        },
+        test("parse union shape") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |union IntOrString {
+                               |    intValue: Integer
+                               |    stringValue: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val unionShape = model.shapes.get("IntOrString")
+            assertTrue(unionShape.isDefined) &&
+            assertTrue(unionShape.get.isInstanceOf[Shape.UnionShape]) &&
+            assertTrue(unionShape.get.asInstanceOf[Shape.UnionShape].members.contains("intValue")) &&
+            assertTrue(unionShape.get.asInstanceOf[Shape.UnionShape].members.contains("stringValue"))
+          }
+        },
+        test("parse enum shape") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |enum Status {
+                               |    PENDING
+                               |    ACTIVE = "active"
+                               |    COMPLETED
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val enumShape = model.shapes.get("Status")
+            assertTrue(enumShape.isDefined) &&
+            assertTrue(enumShape.get.isInstanceOf[Shape.EnumShape])
+          }
+        },
+        test("parse simple shapes") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |string MyString
+                               |integer MyInteger
+                               |long MyLong
+                               |boolean MyBoolean
+                               |timestamp MyTimestamp
+                               |blob MyBlob""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            assertTrue(model.shapes.get("MyString").exists(_.isInstanceOf[Shape.StringShape])) &&
+            assertTrue(model.shapes.get("MyInteger").exists(_.isInstanceOf[Shape.IntegerShape])) &&
+            assertTrue(model.shapes.get("MyLong").exists(_.isInstanceOf[Shape.LongShape])) &&
+            assertTrue(model.shapes.get("MyBoolean").exists(_.isInstanceOf[Shape.BooleanShape])) &&
+            assertTrue(model.shapes.get("MyTimestamp").exists(_.isInstanceOf[Shape.TimestampShape])) &&
+            assertTrue(model.shapes.get("MyBlob").exists(_.isInstanceOf[Shape.BlobShape]))
+          }
+        },
+        test("parse operation with errors") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |@http(method: "DELETE", uri: "/items/{itemId}")
+                               |operation DeleteItem {
+                               |    input: DeleteItemInput
+                               |    output: DeleteItemOutput
+                               |    errors: [NotFoundError, ValidationError]
+                               |}
+                               |
+                               |structure DeleteItemInput {
+                               |    @required
+                               |    @httpLabel
+                               |    itemId: String
+                               |}
+                               |
+                               |structure DeleteItemOutput {}
+                               |
+                               |@error("client")
+                               |structure NotFoundError {
+                               |    message: String
+                               |}
+                               |
+                               |@error("client")
+                               |structure ValidationError {
+                               |    message: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val op = model.getOperation("DeleteItem")
+            assertTrue(op.isDefined) &&
+            assertTrue(op.get.errors.length == 2) &&
+            assertTrue(op.get.errors.exists(_.name == "NotFoundError")) &&
+            assertTrue(op.get.errors.exists(_.name == "ValidationError"))
+          }
+        },
+        test("parse http traits on members") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |structure SearchRequest {
+                               |    @httpQuery("q")
+                               |    query: String
+                               |    
+                               |    @httpQuery("limit")
+                               |    limit: Integer
+                               |    
+                               |    @httpHeader("X-Api-Key")
+                               |    apiKey: String
+                               |    
+                               |    @httpPayload
+                               |    body: String
+                               |}""".stripMargin
+          val result = SmithyParser.parse(smithyString)
+          assertTrue(result.isRight) && {
+            val model = result.toOption.get
+            val struct = model.getStructure("SearchRequest")
+            assertTrue(struct.isDefined) && {
+              val members = struct.get.members
+              assertTrue(members("query").httpQuery == Some("q")) &&
+              assertTrue(members("limit").httpQuery == Some("limit")) &&
+              assertTrue(members("apiKey").httpHeader == Some("X-Api-Key")) &&
+              assertTrue(members("body").httpPayload)
+            }
+          }
+        }
+      ),
+      suite("Legacy API Compatibility")(
+        test("parse service via legacy API") {
+          val smithyString = """$version: "2"
+                               |namespace example.weather
+                               |
+                               |service Weather {
+                               |    version: "2006-03-01"
+                               |}""".stripMargin
+          val parsed = Smithy.parse(smithyString)
+          assertTrue(parsed.services.contains("Weather")) &&
+          assertTrue(parsed.services("Weather").version == "2006-03-01")
+        },
+        test("parse service and resource via legacy API") {
+          val smithyString = """$version: "2"
+                               |namespace example.weather
+                               |
+                               |/// Provides weather forecasts.
+                               |service Weather {
+                               |    version: "2006-03-01"
+                               |    resources: [
+                               |        City
+                               |    ]
+                               |}
+                               |
+                               |resource City {
+                               |    identifiers: { cityId: CityId }
+                               |    read: GetCity
+                               |    list: ListCities
+                               |}
+                               |
+                               |@pattern("^[A-Za-z0-9 ]+$")
+                               |string CityId""".stripMargin
+          val parsed = Smithy.parse(smithyString)
+          assertTrue(parsed.services.contains("Weather")) &&
+          assertTrue(parsed.resources.contains("City"))
+        },
+        test("parse operation via legacy API") {
+          val smithyString = """$version: "2"
+                               |namespace example.api
+                               |
+                               |@http(method: "GET", uri: "/users/{userId}")
+                               |operation GetUser {
+                               |    input: GetUserInput
+                               |    output: GetUserOutput
+                               |}
+                               |
+                               |structure GetUserInput {
+                               |    @required
+                               |    @httpLabel
+                               |    userId: String
+                               |}
+                               |
+                               |structure GetUserOutput {
+                               |    name: String
+                               |}""".stripMargin
+          val parsed = Smithy.parse(smithyString)
+          assertTrue(parsed.operations.contains("GetUser")) &&
+          assertTrue(parsed.operations("GetUser").input == "GetUserInput") &&
+          assertTrue(parsed.operations("GetUser").output == "GetUserOutput")
+        }
+      )
     )
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
@@ -14,7 +14,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |service Weather {
                                |    version: "2006-03-01"
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) &&
           assertTrue(result.toOption.get.namespace == "example.weather") &&
           assertTrue(result.toOption.get.version == "2") &&
@@ -40,7 +40,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |
                                |@pattern("^[A-Za-z0-9 ]+$")
                                |string CityId""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) &&
           assertTrue(result.toOption.get.shapes.contains("Weather")) &&
           assertTrue(result.toOption.get.shapes.contains("City")) &&
@@ -66,10 +66,10 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    name: String
                                |    email: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
             val model = result.toOption.get
-            val op = model.getOperation("GetUser")
+            val op    = model.getOperation("GetUser")
             assertTrue(op.isDefined) &&
             assertTrue(op.get.httpTrait.isDefined) &&
             assertTrue(op.get.httpTrait.get.method == "GET") &&
@@ -87,9 +87,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    @httpHeader("X-Request-Id")
                                |    requestId: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model  = result.toOption.get
             val struct = model.getStructure("Person")
             assertTrue(struct.isDefined) &&
             assertTrue(struct.get.members.contains("name")) &&
@@ -106,9 +106,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |list StringList {
                                |    member: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model     = result.toOption.get
             val listShape = model.shapes.get("StringList")
             assertTrue(listShape.isDefined) &&
             assertTrue(listShape.get.isInstanceOf[Shape.ListShape]) &&
@@ -123,9 +123,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    key: String
                                |    value: Integer
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model    = result.toOption.get
             val mapShape = model.shapes.get("StringMap")
             assertTrue(mapShape.isDefined) &&
             assertTrue(mapShape.get.isInstanceOf[Shape.MapShape]) &&
@@ -141,9 +141,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    intValue: Integer
                                |    stringValue: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model      = result.toOption.get
             val unionShape = model.shapes.get("IntOrString")
             assertTrue(unionShape.isDefined) &&
             assertTrue(unionShape.get.isInstanceOf[Shape.UnionShape]) &&
@@ -160,9 +160,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    ACTIVE = "active"
                                |    COMPLETED
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model     = result.toOption.get
             val enumShape = model.shapes.get("Status")
             assertTrue(enumShape.isDefined) &&
             assertTrue(enumShape.get.isInstanceOf[Shape.EnumShape])
@@ -178,7 +178,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |boolean MyBoolean
                                |timestamp MyTimestamp
                                |blob MyBlob""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
             val model = result.toOption.get
             assertTrue(model.shapes.get("MyString").exists(_.isInstanceOf[Shape.StringShape])) &&
@@ -217,10 +217,10 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |structure ValidationError {
                                |    message: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
             val model = result.toOption.get
-            val op = model.getOperation("DeleteItem")
+            val op    = model.getOperation("DeleteItem")
             assertTrue(op.isDefined) &&
             assertTrue(op.get.errors.length == 2) &&
             assertTrue(op.get.errors.exists(_.name == "NotFoundError")) &&
@@ -244,9 +244,9 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |    @httpPayload
                                |    body: String
                                |}""".stripMargin
-          val result = SmithyParser.parse(smithyString)
+          val result       = SmithyParser.parse(smithyString)
           assertTrue(result.isRight) && {
-            val model = result.toOption.get
+            val model  = result.toOption.get
             val struct = model.getStructure("SearchRequest")
             assertTrue(struct.isDefined) && {
               val members = struct.get.members
@@ -256,7 +256,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
               assertTrue(members("body").httpPayload)
             }
           }
-        }
+        },
       ),
       suite("Legacy API Compatibility")(
         test("parse service via legacy API") {
@@ -266,7 +266,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |service Weather {
                                |    version: "2006-03-01"
                                |}""".stripMargin
-          val parsed = Smithy.parse(smithyString)
+          val parsed       = Smithy.parse(smithyString)
           assertTrue(parsed.services.contains("Weather")) &&
           assertTrue(parsed.services("Weather").version == "2006-03-01")
         },
@@ -290,7 +290,7 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |
                                |@pattern("^[A-Za-z0-9 ]+$")
                                |string CityId""".stripMargin
-          val parsed = Smithy.parse(smithyString)
+          val parsed       = Smithy.parse(smithyString)
           assertTrue(parsed.services.contains("Weather")) &&
           assertTrue(parsed.resources.contains("City"))
         },
@@ -313,11 +313,11 @@ object SmithyParsingSpec extends ZIOSpecDefault {
                                |structure GetUserOutput {
                                |    name: String
                                |}""".stripMargin
-          val parsed = Smithy.parse(smithyString)
+          val parsed       = Smithy.parse(smithyString)
           assertTrue(parsed.operations.contains("GetUser")) &&
           assertTrue(parsed.operations("GetUser").input == "GetUserInput") &&
           assertTrue(parsed.operations("GetUser").output == "GetUserOutput")
-        }
-      )
+        },
+      ),
     )
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyParsingSpec.scala
@@ -1,0 +1,46 @@
+package zio.http.gen.smithy
+
+import zio.Scope
+import zio.test._
+
+object SmithyParsingSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("SmithyParsingSpec")(
+      test("parse service") {
+        val smithyString = """$version: "2"
+                             |namespace example.weather
+                             |
+                             |service Weather {
+                             |    version: "2006-03-01"
+                             |}""".stripMargin
+        val parsed = Smithy.parse(smithyString)
+        val expected = Smithy(Map("Weather" -> Smithy.Service("2006-03-01", Nil, Nil, Nil, Map.empty)))
+        assertCompletes
+      },
+      test("parse service and resource"){
+        val smithyString =  """$version: "2"
+                              |namespace example.weather
+                              |
+                              |/// Provides weather forecasts.
+                              |service Weather {
+                              |    version: "2006-03-01"
+                              |    resources: [
+                              |        City
+                              |    ]
+                              |}
+                              |
+                              |resource City {
+                              |    identifiers: { cityId: CityId }
+                              |    read: GetCity
+                              |    list: ListCities
+                              |}
+                              |
+                              |// "pattern" is a trait.
+                              |@pattern("^[A-Za-z0-9 ]+$")
+                              |string CityId""".stripMargin
+        val parsed = Smithy.parse(smithyString)
+        //val expected = Smithy(Map("Weather" -> Smithy.Service("2006-03-01", Nil, Nil, Nil, Map("City" -> Smithy.Resource(Map("cityId" -> "CityId"), "GetCity", "ListCities")))))
+        assertCompletes
+      }
+    )
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyValidationSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyValidationSpec.scala
@@ -9,13 +9,13 @@ object SmithyValidationSpec extends ZIOSpecDefault {
     suite("Shape Reference Validation")(
       test("detects undefined shape references in structure members") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |structure User {
-          |    id: String
-          |    profile: NonExistentProfile
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |structure User {
+                       |    id: String
+                       |    profile: NonExistentProfile
+                       |}
         """.stripMargin
 
         val result = for {
@@ -24,20 +24,21 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.UndefinedShape &&
-          e.message.contains("NonExistentProfile")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.UndefinedShape &&
+              e.message.contains("NonExistentProfile"),
+          ),
+        )
       },
-      
       test("detects undefined shape references in list members") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |list Items {
-          |    member: NonExistentItem
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |list Items {
+                       |    member: NonExistentItem
+                       |}
         """.stripMargin
 
         val result = for {
@@ -48,16 +49,15 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.UndefinedShape))
       },
-      
       test("detects undefined shape references in map shapes") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |map UserMap {
-          |    key: String
-          |    value: NonExistentUser
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |map UserMap {
+                       |    key: String
+                       |    value: NonExistentUser
+                       |}
         """.stripMargin
 
         val result = for {
@@ -68,19 +68,18 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.UndefinedShape))
       },
-      
       test("allows prelude types") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |structure User {
-          |    id: String
-          |    age: Integer
-          |    active: Boolean
-          |    score: Double
-          |    created: Timestamp
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |structure User {
+                       |    id: String
+                       |    age: Integer
+                       |    active: Boolean
+                       |    score: Double
+                       |    created: Timestamp
+                       |}
         """.stripMargin
 
         val result = for {
@@ -90,16 +89,15 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(result.isRight) &&
         assertTrue(result.toOption.get.isValid)
       },
-      
       test("detects undefined operation input/output") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |operation GetUser {
-          |    input: NonExistentInput
-          |    output: NonExistentOutput
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |operation GetUser {
+                       |    input: NonExistentInput
+                       |    output: NonExistentOutput
+                       |}
         """.stripMargin
 
         val result = for {
@@ -111,19 +109,18 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(result.toOption.get.errors.count(_.errorType == SmithyValidation.ErrorType.UndefinedShape) >= 2)
       },
     ),
-    
     suite("HTTP Trait Validation")(
       test("detects invalid HTTP methods") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "INVALID", uri: "/users")
-          |operation ListUsers {
-          |    output: ListUsersOutput
-          |}
-          |
-          |structure ListUsersOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "INVALID", uri: "/users")
+                       |operation ListUsers {
+                       |    output: ListUsersOutput
+                       |}
+                       |
+                       |structure ListUsersOutput {}
         """.stripMargin
 
         val result = for {
@@ -132,23 +129,24 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidHttpMethod &&
-          e.message.contains("INVALID")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidHttpMethod &&
+              e.message.contains("INVALID"),
+          ),
+        )
       },
-      
       test("detects invalid HTTP status codes") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users", code: 999)
-          |operation ListUsers {
-          |    output: ListUsersOutput
-          |}
-          |
-          |structure ListUsersOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users", code: 999)
+                       |operation ListUsers {
+                       |    output: ListUsersOutput
+                       |}
+                       |
+                       |structure ListUsersOutput {}
         """.stripMargin
 
         val result = for {
@@ -159,17 +157,16 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidStatusCode))
       },
-      
       test("detects invalid @httpError status codes") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@error("client")
-          |@httpError(200)
-          |structure MyError {
-          |    message: String
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@error("client")
+                       |@httpError(200)
+                       |structure MyError {
+                       |    message: String
+                       |}
         """.stripMargin
 
         val result = for {
@@ -178,23 +175,24 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidStatusCode &&
-          e.message.contains("4xx or 5xx")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidStatusCode &&
+              e.message.contains("4xx or 5xx"),
+          ),
+        )
       },
-      
       test("detects URI not starting with /") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "users")
-          |operation ListUsers {
-          |    output: ListUsersOutput
-          |}
-          |
-          |structure ListUsersOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "users")
+                       |operation ListUsers {
+                       |    output: ListUsersOutput
+                       |}
+                       |
+                       |structure ListUsersOutput {}
         """.stripMargin
 
         val result = for {
@@ -205,23 +203,22 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidHttpPath))
       },
-      
       test("detects missing @httpLabel for path parameters") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users/{userId}")
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: GetUserOutput
-          |}
-          |
-          |structure GetUserInput {
-          |    userId: String
-          |}
-          |
-          |structure GetUserOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users/{userId}")
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: GetUserOutput
+                       |}
+                       |
+                       |structure GetUserInput {
+                       |    userId: String
+                       |}
+                       |
+                       |structure GetUserOutput {}
         """.stripMargin
 
         val result = for {
@@ -232,23 +229,22 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.MissingRequiredTrait))
       },
-      
       test("detects missing path parameter member") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users/{userId}")
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: GetUserOutput
-          |}
-          |
-          |structure GetUserInput {
-          |    name: String
-          |}
-          |
-          |structure GetUserOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users/{userId}")
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: GetUserOutput
+                       |}
+                       |
+                       |structure GetUserInput {
+                       |    name: String
+                       |}
+                       |
+                       |structure GetUserOutput {}
         """.stripMargin
 
         val result = for {
@@ -259,25 +255,24 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.MissingPathParameter))
       },
-      
       test("detects @httpLabel member not in path") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users")
-          |operation ListUsers {
-          |    input: ListUsersInput
-          |    output: ListUsersOutput
-          |}
-          |
-          |structure ListUsersInput {
-          |    @httpLabel
-          |    @required
-          |    userId: String
-          |}
-          |
-          |structure ListUsersOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users")
+                       |operation ListUsers {
+                       |    input: ListUsersInput
+                       |    output: ListUsersOutput
+                       |}
+                       |
+                       |structure ListUsersInput {
+                       |    @httpLabel
+                       |    @required
+                       |    userId: String
+                       |}
+                       |
+                       |structure ListUsersOutput {}
         """.stripMargin
 
         val result = for {
@@ -288,25 +283,24 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.PathParameterMismatch))
       },
-      
       test("detects duplicate path parameters") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users/{id}/posts/{id}")
-          |operation GetUserPost {
-          |    input: GetUserPostInput
-          |    output: GetUserPostOutput
-          |}
-          |
-          |structure GetUserPostInput {
-          |    @httpLabel
-          |    @required
-          |    id: String
-          |}
-          |
-          |structure GetUserPostOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users/{id}/posts/{id}")
+                       |operation GetUserPost {
+                       |    input: GetUserPostInput
+                       |    output: GetUserPostOutput
+                       |}
+                       |
+                       |structure GetUserPostInput {
+                       |    @httpLabel
+                       |    @required
+                       |    id: String
+                       |}
+                       |
+                       |structure GetUserPostOutput {}
         """.stripMargin
 
         val result = for {
@@ -317,26 +311,25 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.DuplicatePathParameter))
       },
-      
       test("detects multiple @httpPayload members") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "POST", uri: "/users")
-          |operation CreateUser {
-          |    input: CreateUserInput
-          |    output: CreateUserOutput
-          |}
-          |
-          |structure CreateUserInput {
-          |    @httpPayload
-          |    body1: String
-          |    @httpPayload
-          |    body2: String
-          |}
-          |
-          |structure CreateUserOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "POST", uri: "/users")
+                       |operation CreateUser {
+                       |    input: CreateUserInput
+                       |    output: CreateUserOutput
+                       |}
+                       |
+                       |structure CreateUserInput {
+                       |    @httpPayload
+                       |    body1: String
+                       |    @httpPayload
+                       |    body2: String
+                       |}
+                       |
+                       |structure CreateUserOutput {}
         """.stripMargin
 
         val result = for {
@@ -345,35 +338,36 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
-          e.message.contains("httpPayload")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+              e.message.contains("httpPayload"),
+          ),
+        )
       },
-      
       test("valid HTTP operation passes validation") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@http(method: "GET", uri: "/users/{userId}")
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: GetUserOutput
-          |}
-          |
-          |structure GetUserInput {
-          |    @httpLabel
-          |    @required
-          |    userId: String
-          |    
-          |    @httpQuery("expand")
-          |    expand: Boolean
-          |}
-          |
-          |structure GetUserOutput {
-          |    name: String
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@http(method: "GET", uri: "/users/{userId}")
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: GetUserOutput
+                       |}
+                       |
+                       |structure GetUserInput {
+                       |    @httpLabel
+                       |    @required
+                       |    userId: String
+                       |    
+                       |    @httpQuery("expand")
+                       |    expand: Boolean
+                       |}
+                       |
+                       |structure GetUserOutput {
+                       |    name: String
+                       |}
         """.stripMargin
 
         val result = for {
@@ -384,15 +378,14 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(result.toOption.get.isValid)
       },
     ),
-    
     suite("Constraint Trait Validation")(
       test("detects invalid @length with min > max") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@length(min: 10, max: 5)
-          |string Username
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@length(min: 10, max: 5)
+                       |string Username
         """.stripMargin
 
         val result = for {
@@ -401,19 +394,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidLength &&
-          e.message.contains("min") && e.message.contains("max")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidLength &&
+              e.message.contains("min") && e.message.contains("max"),
+          ),
+        )
       },
-      
       test("detects negative @length values") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@length(min: -5)
-          |string Username
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@length(min: -5)
+                       |string Username
         """.stripMargin
 
         val result = for {
@@ -422,19 +416,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidLength &&
-          e.message.contains("non-negative")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidLength &&
+              e.message.contains("non-negative"),
+          ),
+        )
       },
-      
       test("detects @length on incompatible shape") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@length(min: 1)
-          |integer Age
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@length(min: 1)
+                       |integer Age
         """.stripMargin
 
         val result = for {
@@ -443,19 +438,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
-          e.message.contains("length")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+              e.message.contains("length"),
+          ),
+        )
       },
-      
       test("detects invalid @range with min > max") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@range(min: 100, max: 0)
-          |integer Age
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@range(min: 100, max: 0)
+                       |integer Age
         """.stripMargin
 
         val result = for {
@@ -466,14 +462,13 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(!result.toOption.get.isValid) &&
         assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidRange))
       },
-      
       test("detects @range on incompatible shape") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@range(min: 1, max: 100)
-          |string Username
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@range(min: 1, max: 100)
+                       |string Username
         """.stripMargin
 
         val result = for {
@@ -482,19 +477,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
-          e.message.contains("range")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+              e.message.contains("range"),
+          ),
+        )
       },
-      
       test("detects invalid regex in @pattern") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@pattern("[invalid")
-          |string Username
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@pattern("[invalid")
+                       |string Username
         """.stripMargin
 
         val result = for {
@@ -503,19 +499,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidPattern &&
-          e.message.contains("invalid regex")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidPattern &&
+              e.message.contains("invalid regex"),
+          ),
+        )
       },
-      
       test("detects @pattern on incompatible shape") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@pattern("^[a-z]+$")
-          |integer Count
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@pattern("^[a-z]+$")
+                       |integer Count
         """.stripMargin
 
         val result = for {
@@ -524,19 +521,20 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
-          e.message.contains("pattern")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+              e.message.contains("pattern"),
+          ),
+        )
       },
-      
       test("detects invalid @timestampFormat") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@timestampFormat("invalid-format")
-          |timestamp MyTimestamp
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@timestampFormat("invalid-format")
+                       |timestamp MyTimestamp
         """.stripMargin
 
         val result = for {
@@ -545,26 +543,27 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidConstraint &&
-          e.message.contains("timestampFormat")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidConstraint &&
+              e.message.contains("timestampFormat"),
+          ),
+        )
       },
-      
       test("valid constraint traits pass validation") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |@length(min: 1, max: 100)
-          |@pattern("^[a-zA-Z0-9]+$")
-          |string Username
-          |
-          |@range(min: 0, max: 150)
-          |integer Age
-          |
-          |@timestampFormat("date-time")
-          |timestamp CreatedAt
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |@length(min: 1, max: 100)
+                       |@pattern("^[a-zA-Z0-9]+$")
+                       |string Username
+                       |
+                       |@range(min: 0, max: 150)
+                       |integer Age
+                       |
+                       |@timestampFormat("date-time")
+                       |timestamp CreatedAt
         """.stripMargin
 
         val result = for {
@@ -575,20 +574,19 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(result.toOption.get.isValid)
       },
     ),
-    
     suite("Operation Validation")(
       test("detects non-structure operation input") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |operation GetUser {
-          |    input: Username
-          |    output: GetUserOutput
-          |}
-          |
-          |string Username
-          |structure GetUserOutput {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |operation GetUser {
+                       |    input: Username
+                       |    output: GetUserOutput
+                       |}
+                       |
+                       |string Username
+                       |structure GetUserOutput {}
         """.stripMargin
 
         val result = for {
@@ -597,24 +595,25 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
-          e.message.contains("input must be a structure")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
+              e.message.contains("input must be a structure"),
+          ),
+        )
       },
-      
       test("detects non-structure operation output") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: Username
-          |}
-          |
-          |structure GetUserInput {}
-          |string Username
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: Username
+                       |}
+                       |
+                       |structure GetUserInput {}
+                       |string Username
         """.stripMargin
 
         val result = for {
@@ -623,28 +622,29 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
-          e.message.contains("output must be a structure")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
+              e.message.contains("output must be a structure"),
+          ),
+        )
       },
-      
       test("detects error structure without @error trait") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: GetUserOutput
-          |    errors: [NotFoundError]
-          |}
-          |
-          |structure GetUserInput {}
-          |structure GetUserOutput {}
-          |structure NotFoundError {
-          |    message: String
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: GetUserOutput
+                       |    errors: [NotFoundError]
+                       |}
+                       |
+                       |structure GetUserInput {}
+                       |structure GetUserOutput {}
+                       |structure NotFoundError {
+                       |    message: String
+                       |}
         """.stripMargin
 
         val result = for {
@@ -653,30 +653,31 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.MissingRequiredTrait &&
-          e.message.contains("@error trait")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.MissingRequiredTrait &&
+              e.message.contains("@error trait"),
+          ),
+        )
       },
-      
       test("valid operation with error trait passes validation") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: GetUserOutput
-          |    errors: [NotFoundError]
-          |}
-          |
-          |structure GetUserInput {}
-          |structure GetUserOutput {}
-          |
-          |@error("client")
-          |structure NotFoundError {
-          |    message: String
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: GetUserOutput
+                       |    errors: [NotFoundError]
+                       |}
+                       |
+                       |structure GetUserInput {}
+                       |structure GetUserOutput {}
+                       |
+                       |@error("client")
+                       |structure NotFoundError {
+                       |    message: String
+                       |}
         """.stripMargin
 
         val result = for {
@@ -687,19 +688,18 @@ object SmithyValidationSpec extends ZIOSpecDefault {
         assertTrue(result.toOption.get.isValid)
       },
     ),
-    
     suite("Service Validation")(
       test("detects non-operation in service operations") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |service MyService {
-          |    version: "1.0"
-          |    operations: [NotAnOperation]
-          |}
-          |
-          |structure NotAnOperation {}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |service MyService {
+                       |    version: "1.0"
+                       |    operations: [NotAnOperation]
+                       |}
+                       |
+                       |structure NotAnOperation {}
         """.stripMargin
 
         val result = for {
@@ -708,20 +708,21 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidService &&
-          e.message.contains("not an operation shape")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidService &&
+              e.message.contains("not an operation shape"),
+          ),
+        )
       },
-      
       test("detects empty service version") {
         val smithy = """
-          |$version: "2"
-          |namespace test
-          |
-          |service MyService {
-          |    version: ""
-          |}
+                       |$version: "2"
+                       |namespace test
+                       |
+                       |service MyService {
+                       |    version: ""
+                       |}
         """.stripMargin
 
         val result = for {
@@ -730,208 +731,212 @@ object SmithyValidationSpec extends ZIOSpecDefault {
 
         assertTrue(result.isRight) &&
         assertTrue(!result.toOption.get.isValid) &&
-        assertTrue(result.toOption.get.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidService &&
-          e.message.contains("version should not be empty")
-        ))
+        assertTrue(
+          result.toOption.get.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidService &&
+              e.message.contains("version should not be empty"),
+          ),
+        )
       },
     ),
-    
     suite("Enum Validation")(
       test("detects empty enum") {
         val model = SmithyModel(
           version = "2",
           namespace = "test",
-          shapes = Map("EmptyEnum" -> Shape.EnumShape(Map.empty))
+          shapes = Map("EmptyEnum" -> Shape.EnumShape(Map.empty)),
         )
-        
+
         val validation = SmithyValidation.validate(model)
-        
+
         assertTrue(!validation.isValid) &&
-        assertTrue(validation.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
-          e.message.contains("at least one member")
-        ))
+        assertTrue(
+          validation.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
+              e.message.contains("at least one member"),
+          ),
+        )
       },
-      
       test("detects duplicate enum values") {
         val model = SmithyModel(
           version = "2",
           namespace = "test",
-          shapes = Map("Status" -> Shape.EnumShape(Map(
-            "ACTIVE" -> Shape.EnumMember(Some("active")),
-            "ENABLED" -> Shape.EnumMember(Some("active")),
-            "DISABLED" -> Shape.EnumMember(Some("disabled"))
-          )))
+          shapes = Map(
+            "Status" -> Shape.EnumShape(
+              Map(
+                "ACTIVE"   -> Shape.EnumMember(Some("active")),
+                "ENABLED"  -> Shape.EnumMember(Some("active")),
+                "DISABLED" -> Shape.EnumMember(Some("disabled")),
+              ),
+            ),
+          ),
         )
-        
+
         val validation = SmithyValidation.validate(model)
-        
+
         assertTrue(!validation.isValid) &&
-        assertTrue(validation.errors.exists(e => 
-          e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
-          e.message.contains("Duplicate enum value")
-        ))
+        assertTrue(
+          validation.errors.exists(e =>
+            e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
+              e.message.contains("Duplicate enum value"),
+          ),
+        )
       },
     ),
-    
     suite("Union Validation")(
       test("detects empty union") {
         val model = SmithyModel(
           version = "2",
           namespace = "test",
-          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty))
+          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty)),
         )
-        
+
         val validation = SmithyValidation.validate(model)
-        
+
         assertTrue(!validation.isValid) &&
         assertTrue(validation.errors.exists(_.message.contains("at least one member")))
       },
     ),
-    
     suite("ValidationResult")(
       test("render produces readable output") {
         val result = SmithyValidation.ValidationResult(
           errors = List(
             SmithyValidation.ValidationError(
-              Some("User"), Some("profile"),
+              Some("User"),
+              Some("profile"),
               SmithyValidation.ErrorType.UndefinedShape,
-              "Reference to undefined shape: Profile"
-            )
+              "Reference to undefined shape: Profile",
+            ),
           ),
-          warnings = Nil
+          warnings = Nil,
         )
-        
+
         val rendered = result.render
         assertTrue(
           rendered.contains("User.profile") &&
-          rendered.contains("UNDEFINED_SHAPE") &&
-          rendered.contains("Profile")
+            rendered.contains("UNDEFINED_SHAPE") &&
+            rendered.contains("Profile"),
         )
       },
-      
       test("isValid returns true for empty errors") {
         val result = SmithyValidation.ValidationResult(Nil, Nil)
         assertTrue(result.isValid)
       },
-      
       test("isValid returns false when errors present") {
         val result = SmithyValidation.ValidationResult(
           errors = List(
-            SmithyValidation.ValidationError(None, None, SmithyValidation.ErrorType.UndefinedShape, "test")
+            SmithyValidation.ValidationError(None, None, SmithyValidation.ErrorType.UndefinedShape, "test"),
           ),
-          warnings = Nil
+          warnings = Nil,
         )
         assertTrue(!result.isValid)
       },
-      
       test("++ combines results correctly") {
         val r1 = SmithyValidation.ValidationResult.error(
-          SmithyValidation.ValidationError(Some("A"), None, SmithyValidation.ErrorType.UndefinedShape, "error1")
+          SmithyValidation.ValidationError(Some("A"), None, SmithyValidation.ErrorType.UndefinedShape, "error1"),
         )
         val r2 = SmithyValidation.ValidationResult.warning(
-          SmithyValidation.ValidationError(Some("B"), None, SmithyValidation.ErrorType.InvalidConstraint, "warning1")
+          SmithyValidation.ValidationError(Some("B"), None, SmithyValidation.ErrorType.InvalidConstraint, "warning1"),
         )
-        
+
         val combined = r1 ++ r2
         assertTrue(
           combined.errors.size == 1 &&
-          combined.warnings.size == 1 &&
-          !combined.isValid &&
-          combined.hasWarnings
+            combined.warnings.size == 1 &&
+            !combined.isValid &&
+            combined.hasWarnings,
         )
       },
     ),
-    
     suite("validateOrThrow")(
       test("throws exception on invalid model") {
         val model = SmithyModel(
           version = "2",
           namespace = "test",
-          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty))
+          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty)),
         )
-        
-        val threw = try {
-          SmithyValidation.validateOrThrow(model)
-          false
-        } catch {
-          case _: SmithyValidation.SmithyValidationException => true
-          case _: Throwable => false
-        }
-        
+
+        val threw =
+          try {
+            SmithyValidation.validateOrThrow(model)
+            false
+          } catch {
+            case _: SmithyValidation.SmithyValidationException => true
+            case _: Throwable                                  => false
+          }
+
         assertTrue(threw)
       },
-      
       test("returns model on valid model") {
         val model = SmithyModel(
           version = "2",
           namespace = "test",
-          shapes = Map("User" -> Shape.StructureShape(
-            members = Map("id" -> Member("id", ShapeId("String")))
-          ))
+          shapes = Map(
+            "User" -> Shape.StructureShape(
+              members = Map("id" -> Member("id", ShapeId("String"))),
+            ),
+          ),
         )
-        
+
         val result = SmithyValidation.validateOrThrow(model)
         assertTrue(result == model)
       },
     ),
-    
     suite("Full Model Validation")(
       test("validates a complete valid model") {
         val smithy = """
-          |$version: "2"
-          |namespace example.api
-          |
-          |service UserService {
-          |    version: "1.0"
-          |    operations: [GetUser, CreateUser]
-          |}
-          |
-          |@http(method: "GET", uri: "/users/{userId}")
-          |operation GetUser {
-          |    input: GetUserInput
-          |    output: User
-          |    errors: [NotFoundError]
-          |}
-          |
-          |@http(method: "POST", uri: "/users")
-          |operation CreateUser {
-          |    input: CreateUserInput
-          |    output: User
-          |}
-          |
-          |structure GetUserInput {
-          |    @httpLabel
-          |    @required
-          |    userId: String
-          |}
-          |
-          |structure CreateUserInput {
-          |    @required
-          |    name: String
-          |    
-          |    @length(min: 5, max: 100)
-          |    email: String
-          |    
-          |    @range(min: 0, max: 150)
-          |    age: Integer
-          |}
-          |
-          |structure User {
-          |    @required
-          |    id: String
-          |    name: String
-          |    email: String
-          |    age: Integer
-          |}
-          |
-          |@error("client")
-          |@httpError(404)
-          |structure NotFoundError {
-          |    @required
-          |    message: String
-          |}
+                       |$version: "2"
+                       |namespace example.api
+                       |
+                       |service UserService {
+                       |    version: "1.0"
+                       |    operations: [GetUser, CreateUser]
+                       |}
+                       |
+                       |@http(method: "GET", uri: "/users/{userId}")
+                       |operation GetUser {
+                       |    input: GetUserInput
+                       |    output: User
+                       |    errors: [NotFoundError]
+                       |}
+                       |
+                       |@http(method: "POST", uri: "/users")
+                       |operation CreateUser {
+                       |    input: CreateUserInput
+                       |    output: User
+                       |}
+                       |
+                       |structure GetUserInput {
+                       |    @httpLabel
+                       |    @required
+                       |    userId: String
+                       |}
+                       |
+                       |structure CreateUserInput {
+                       |    @required
+                       |    name: String
+                       |    
+                       |    @length(min: 5, max: 100)
+                       |    email: String
+                       |    
+                       |    @range(min: 0, max: 150)
+                       |    age: Integer
+                       |}
+                       |
+                       |structure User {
+                       |    @required
+                       |    id: String
+                       |    name: String
+                       |    email: String
+                       |    age: Integer
+                       |}
+                       |
+                       |@error("client")
+                       |@httpError(404)
+                       |structure NotFoundError {
+                       |    @required
+                       |    message: String
+                       |}
         """.stripMargin
 
         val result = for {

--- a/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyValidationSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/smithy/SmithyValidationSpec.scala
@@ -1,0 +1,946 @@
+package zio.http.gen.smithy
+
+import zio.Scope
+import zio.test._
+
+object SmithyValidationSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("SmithyValidationSpec")(
+    suite("Shape Reference Validation")(
+      test("detects undefined shape references in structure members") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |structure User {
+          |    id: String
+          |    profile: NonExistentProfile
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.UndefinedShape &&
+          e.message.contains("NonExistentProfile")
+        ))
+      },
+      
+      test("detects undefined shape references in list members") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |list Items {
+          |    member: NonExistentItem
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.UndefinedShape))
+      },
+      
+      test("detects undefined shape references in map shapes") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |map UserMap {
+          |    key: String
+          |    value: NonExistentUser
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.UndefinedShape))
+      },
+      
+      test("allows prelude types") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |structure User {
+          |    id: String
+          |    age: Integer
+          |    active: Boolean
+          |    score: Double
+          |    created: Timestamp
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(result.toOption.get.isValid)
+      },
+      
+      test("detects undefined operation input/output") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |operation GetUser {
+          |    input: NonExistentInput
+          |    output: NonExistentOutput
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.count(_.errorType == SmithyValidation.ErrorType.UndefinedShape) >= 2)
+      },
+    ),
+    
+    suite("HTTP Trait Validation")(
+      test("detects invalid HTTP methods") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "INVALID", uri: "/users")
+          |operation ListUsers {
+          |    output: ListUsersOutput
+          |}
+          |
+          |structure ListUsersOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidHttpMethod &&
+          e.message.contains("INVALID")
+        ))
+      },
+      
+      test("detects invalid HTTP status codes") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users", code: 999)
+          |operation ListUsers {
+          |    output: ListUsersOutput
+          |}
+          |
+          |structure ListUsersOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidStatusCode))
+      },
+      
+      test("detects invalid @httpError status codes") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@error("client")
+          |@httpError(200)
+          |structure MyError {
+          |    message: String
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidStatusCode &&
+          e.message.contains("4xx or 5xx")
+        ))
+      },
+      
+      test("detects URI not starting with /") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "users")
+          |operation ListUsers {
+          |    output: ListUsersOutput
+          |}
+          |
+          |structure ListUsersOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidHttpPath))
+      },
+      
+      test("detects missing @httpLabel for path parameters") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users/{userId}")
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: GetUserOutput
+          |}
+          |
+          |structure GetUserInput {
+          |    userId: String
+          |}
+          |
+          |structure GetUserOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.MissingRequiredTrait))
+      },
+      
+      test("detects missing path parameter member") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users/{userId}")
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: GetUserOutput
+          |}
+          |
+          |structure GetUserInput {
+          |    name: String
+          |}
+          |
+          |structure GetUserOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.MissingPathParameter))
+      },
+      
+      test("detects @httpLabel member not in path") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users")
+          |operation ListUsers {
+          |    input: ListUsersInput
+          |    output: ListUsersOutput
+          |}
+          |
+          |structure ListUsersInput {
+          |    @httpLabel
+          |    @required
+          |    userId: String
+          |}
+          |
+          |structure ListUsersOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.PathParameterMismatch))
+      },
+      
+      test("detects duplicate path parameters") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users/{id}/posts/{id}")
+          |operation GetUserPost {
+          |    input: GetUserPostInput
+          |    output: GetUserPostOutput
+          |}
+          |
+          |structure GetUserPostInput {
+          |    @httpLabel
+          |    @required
+          |    id: String
+          |}
+          |
+          |structure GetUserPostOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.DuplicatePathParameter))
+      },
+      
+      test("detects multiple @httpPayload members") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "POST", uri: "/users")
+          |operation CreateUser {
+          |    input: CreateUserInput
+          |    output: CreateUserOutput
+          |}
+          |
+          |structure CreateUserInput {
+          |    @httpPayload
+          |    body1: String
+          |    @httpPayload
+          |    body2: String
+          |}
+          |
+          |structure CreateUserOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+          e.message.contains("httpPayload")
+        ))
+      },
+      
+      test("valid HTTP operation passes validation") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@http(method: "GET", uri: "/users/{userId}")
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: GetUserOutput
+          |}
+          |
+          |structure GetUserInput {
+          |    @httpLabel
+          |    @required
+          |    userId: String
+          |    
+          |    @httpQuery("expand")
+          |    expand: Boolean
+          |}
+          |
+          |structure GetUserOutput {
+          |    name: String
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(result.toOption.get.isValid)
+      },
+    ),
+    
+    suite("Constraint Trait Validation")(
+      test("detects invalid @length with min > max") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@length(min: 10, max: 5)
+          |string Username
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidLength &&
+          e.message.contains("min") && e.message.contains("max")
+        ))
+      },
+      
+      test("detects negative @length values") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@length(min: -5)
+          |string Username
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidLength &&
+          e.message.contains("non-negative")
+        ))
+      },
+      
+      test("detects @length on incompatible shape") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@length(min: 1)
+          |integer Age
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+          e.message.contains("length")
+        ))
+      },
+      
+      test("detects invalid @range with min > max") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@range(min: 100, max: 0)
+          |integer Age
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(_.errorType == SmithyValidation.ErrorType.InvalidRange))
+      },
+      
+      test("detects @range on incompatible shape") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@range(min: 1, max: 100)
+          |string Username
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+          e.message.contains("range")
+        ))
+      },
+      
+      test("detects invalid regex in @pattern") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@pattern("[invalid")
+          |string Username
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidPattern &&
+          e.message.contains("invalid regex")
+        ))
+      },
+      
+      test("detects @pattern on incompatible shape") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@pattern("^[a-z]+$")
+          |integer Count
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.IncompatibleTrait &&
+          e.message.contains("pattern")
+        ))
+      },
+      
+      test("detects invalid @timestampFormat") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@timestampFormat("invalid-format")
+          |timestamp MyTimestamp
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidConstraint &&
+          e.message.contains("timestampFormat")
+        ))
+      },
+      
+      test("valid constraint traits pass validation") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |@length(min: 1, max: 100)
+          |@pattern("^[a-zA-Z0-9]+$")
+          |string Username
+          |
+          |@range(min: 0, max: 150)
+          |integer Age
+          |
+          |@timestampFormat("date-time")
+          |timestamp CreatedAt
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(result.toOption.get.isValid)
+      },
+    ),
+    
+    suite("Operation Validation")(
+      test("detects non-structure operation input") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |operation GetUser {
+          |    input: Username
+          |    output: GetUserOutput
+          |}
+          |
+          |string Username
+          |structure GetUserOutput {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
+          e.message.contains("input must be a structure")
+        ))
+      },
+      
+      test("detects non-structure operation output") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: Username
+          |}
+          |
+          |structure GetUserInput {}
+          |string Username
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidOperation &&
+          e.message.contains("output must be a structure")
+        ))
+      },
+      
+      test("detects error structure without @error trait") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: GetUserOutput
+          |    errors: [NotFoundError]
+          |}
+          |
+          |structure GetUserInput {}
+          |structure GetUserOutput {}
+          |structure NotFoundError {
+          |    message: String
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.MissingRequiredTrait &&
+          e.message.contains("@error trait")
+        ))
+      },
+      
+      test("valid operation with error trait passes validation") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: GetUserOutput
+          |    errors: [NotFoundError]
+          |}
+          |
+          |structure GetUserInput {}
+          |structure GetUserOutput {}
+          |
+          |@error("client")
+          |structure NotFoundError {
+          |    message: String
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(result.toOption.get.isValid)
+      },
+    ),
+    
+    suite("Service Validation")(
+      test("detects non-operation in service operations") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |service MyService {
+          |    version: "1.0"
+          |    operations: [NotAnOperation]
+          |}
+          |
+          |structure NotAnOperation {}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidService &&
+          e.message.contains("not an operation shape")
+        ))
+      },
+      
+      test("detects empty service version") {
+        val smithy = """
+          |$version: "2"
+          |namespace test
+          |
+          |service MyService {
+          |    version: ""
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(!result.toOption.get.isValid) &&
+        assertTrue(result.toOption.get.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidService &&
+          e.message.contains("version should not be empty")
+        ))
+      },
+    ),
+    
+    suite("Enum Validation")(
+      test("detects empty enum") {
+        val model = SmithyModel(
+          version = "2",
+          namespace = "test",
+          shapes = Map("EmptyEnum" -> Shape.EnumShape(Map.empty))
+        )
+        
+        val validation = SmithyValidation.validate(model)
+        
+        assertTrue(!validation.isValid) &&
+        assertTrue(validation.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
+          e.message.contains("at least one member")
+        ))
+      },
+      
+      test("detects duplicate enum values") {
+        val model = SmithyModel(
+          version = "2",
+          namespace = "test",
+          shapes = Map("Status" -> Shape.EnumShape(Map(
+            "ACTIVE" -> Shape.EnumMember(Some("active")),
+            "ENABLED" -> Shape.EnumMember(Some("active")),
+            "DISABLED" -> Shape.EnumMember(Some("disabled"))
+          )))
+        )
+        
+        val validation = SmithyValidation.validate(model)
+        
+        assertTrue(!validation.isValid) &&
+        assertTrue(validation.errors.exists(e => 
+          e.errorType == SmithyValidation.ErrorType.InvalidEnum &&
+          e.message.contains("Duplicate enum value")
+        ))
+      },
+    ),
+    
+    suite("Union Validation")(
+      test("detects empty union") {
+        val model = SmithyModel(
+          version = "2",
+          namespace = "test",
+          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty))
+        )
+        
+        val validation = SmithyValidation.validate(model)
+        
+        assertTrue(!validation.isValid) &&
+        assertTrue(validation.errors.exists(_.message.contains("at least one member")))
+      },
+    ),
+    
+    suite("ValidationResult")(
+      test("render produces readable output") {
+        val result = SmithyValidation.ValidationResult(
+          errors = List(
+            SmithyValidation.ValidationError(
+              Some("User"), Some("profile"),
+              SmithyValidation.ErrorType.UndefinedShape,
+              "Reference to undefined shape: Profile"
+            )
+          ),
+          warnings = Nil
+        )
+        
+        val rendered = result.render
+        assertTrue(
+          rendered.contains("User.profile") &&
+          rendered.contains("UNDEFINED_SHAPE") &&
+          rendered.contains("Profile")
+        )
+      },
+      
+      test("isValid returns true for empty errors") {
+        val result = SmithyValidation.ValidationResult(Nil, Nil)
+        assertTrue(result.isValid)
+      },
+      
+      test("isValid returns false when errors present") {
+        val result = SmithyValidation.ValidationResult(
+          errors = List(
+            SmithyValidation.ValidationError(None, None, SmithyValidation.ErrorType.UndefinedShape, "test")
+          ),
+          warnings = Nil
+        )
+        assertTrue(!result.isValid)
+      },
+      
+      test("++ combines results correctly") {
+        val r1 = SmithyValidation.ValidationResult.error(
+          SmithyValidation.ValidationError(Some("A"), None, SmithyValidation.ErrorType.UndefinedShape, "error1")
+        )
+        val r2 = SmithyValidation.ValidationResult.warning(
+          SmithyValidation.ValidationError(Some("B"), None, SmithyValidation.ErrorType.InvalidConstraint, "warning1")
+        )
+        
+        val combined = r1 ++ r2
+        assertTrue(
+          combined.errors.size == 1 &&
+          combined.warnings.size == 1 &&
+          !combined.isValid &&
+          combined.hasWarnings
+        )
+      },
+    ),
+    
+    suite("validateOrThrow")(
+      test("throws exception on invalid model") {
+        val model = SmithyModel(
+          version = "2",
+          namespace = "test",
+          shapes = Map("EmptyUnion" -> Shape.UnionShape(Map.empty))
+        )
+        
+        val threw = try {
+          SmithyValidation.validateOrThrow(model)
+          false
+        } catch {
+          case _: SmithyValidation.SmithyValidationException => true
+          case _: Throwable => false
+        }
+        
+        assertTrue(threw)
+      },
+      
+      test("returns model on valid model") {
+        val model = SmithyModel(
+          version = "2",
+          namespace = "test",
+          shapes = Map("User" -> Shape.StructureShape(
+            members = Map("id" -> Member("id", ShapeId("String")))
+          ))
+        )
+        
+        val result = SmithyValidation.validateOrThrow(model)
+        assertTrue(result == model)
+      },
+    ),
+    
+    suite("Full Model Validation")(
+      test("validates a complete valid model") {
+        val smithy = """
+          |$version: "2"
+          |namespace example.api
+          |
+          |service UserService {
+          |    version: "1.0"
+          |    operations: [GetUser, CreateUser]
+          |}
+          |
+          |@http(method: "GET", uri: "/users/{userId}")
+          |operation GetUser {
+          |    input: GetUserInput
+          |    output: User
+          |    errors: [NotFoundError]
+          |}
+          |
+          |@http(method: "POST", uri: "/users")
+          |operation CreateUser {
+          |    input: CreateUserInput
+          |    output: User
+          |}
+          |
+          |structure GetUserInput {
+          |    @httpLabel
+          |    @required
+          |    userId: String
+          |}
+          |
+          |structure CreateUserInput {
+          |    @required
+          |    name: String
+          |    
+          |    @length(min: 5, max: 100)
+          |    email: String
+          |    
+          |    @range(min: 0, max: 150)
+          |    age: Integer
+          |}
+          |
+          |structure User {
+          |    @required
+          |    id: String
+          |    name: String
+          |    email: String
+          |    age: Integer
+          |}
+          |
+          |@error("client")
+          |@httpError(404)
+          |structure NotFoundError {
+          |    @required
+          |    message: String
+          |}
+        """.stripMargin
+
+        val result = for {
+          model <- SmithyParser.parse(smithy)
+        } yield SmithyValidation.validate(model)
+
+        assertTrue(result.isRight) &&
+        assertTrue(result.toOption.get.isValid)
+      },
+    ),
+  )
+}

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -2791,10 +2791,7 @@ object Header {
         case value if MediaType.mainTypeMap.contains(value) => value
       }
       val type1x       = (RichTextCodec.literalCI("x-") ~ tokenString).transform[String](in => s"${in._1}${in._2}")(in => ("x-", s"${in.substring(2)}"))
-      val codecType1   = (type1 | type1x).transform[String](_.merge) {
-        case x if x.startsWith("x-") => Right(x)
-        case x                       => Left(x)
-      }
+      val codecType1   = type1 | type1x
       val forwardSlash = RichTextCodec.char('/').const('/')
       val codecType    = (codecType1 <~ forwardSlash) ~ tokenString
       val quote        = RichTextCodec.char('"')

--- a/zio-http/shared/src/main/scala/zio/http/codec/RichTextCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/RichTextCodec.scala
@@ -81,7 +81,7 @@ sealed abstract class RichTextCodec[A] { self =>
   ): RichTextCodec[alternator.Out] =
     RichTextCodec
       .Alt(self, RichTextCodec.defer(that))
-      .transform[alternator.Out](either => either.fold(alternator.left, alternator.right))(value =>
+      .transform[alternator.Out](either => either.fold(l => alternator.left(l), r => alternator.right(r)))(value =>
         alternator
           .unleft(value)
           .map(Left(_))

--- a/zio-http/shared/src/main/scala/zio/http/codec/RichTextCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/RichTextCodec.scala
@@ -136,10 +136,9 @@ sealed abstract class RichTextCodec[A] { self =>
     RichTextCodec.Repeated(self)
 
   final lazy val repeatNonEmpty: RichTextCodec[NonEmptyChunk[A]] =
-    self.repeat.transformOrFailLeft[NonEmptyChunk[A]](
-      chunk =>
-        if (chunk.isEmpty) Left("Expected at least one element")
-      else Right(NonEmptyChunk.fromIterable(chunk.head, chunk.tail))
+    self.repeat.transformOrFailLeft[NonEmptyChunk[A]](chunk =>
+      if (chunk.isEmpty) Left("Expected at least one element")
+      else Right(NonEmptyChunk.fromIterable(chunk.head, chunk.tail)),
     )(chunk => chunk.toChunk)
 
   final def singleton: RichTextCodec[NonEmptyChunk[A]] =
@@ -268,15 +267,15 @@ object RichTextCodec {
     literalUnit(lit).as(lit)
 
   def literalUnit(lit: String): RichTextCodec[Unit] = {
-     def loop(list: List[Char]): RichTextCodec[Unit] =
-       list match {
-         case head :: tail =>
-           char(head).const(head) ~> loop(tail)
-         case Nil          => empty
-       }
+    def loop(list: List[Char]): RichTextCodec[Unit] =
+      list match {
+        case head :: tail =>
+          char(head).const(head) ~> loop(tail)
+        case Nil          => empty
+      }
 
-     loop(lit.toList)
-   }
+    loop(lit.toList)
+  }
 
   /**
    * A codec that describes a literal character sequence, ignoring case.


### PR DESCRIPTION
## Summary

Implements Smithy IDL support for zio-http code generation, resolving #1522.

- Hand-written Smithy IDL 2.0 parser (no external dependencies)
- Code generator producing `Endpoint` definitions from Smithy specs
- Model validation with 16 error types and helpful messages
- Field name normalization (snake_case → camelCase) enabled by default
- 76 tests covering parsing, generation, and validation

/claim #1522