### PR TITLE
Fix compiler warnings

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
@@ -186,7 +186,7 @@ trait DatastarPackageBase extends Attributes {
     ((patchElementsCodec | executeScriptCodec).transform(_.merge) {
       case e: DatastarEvent.PatchElements => Left(e)
       case e: DatastarEvent.ExecuteScript => Right(e)
-      case e: DatastarEvent.PatchSignals  => throw new Exception("Unreachable")
+      case _: DatastarEvent.PatchSignals  => throw new Exception("Unreachable")
     } | patchSignalsCodec).transform(_.merge) {
       case e: DatastarEvent.PatchElements => Left(e)
       case e: DatastarEvent.ExecuteScript => Left(e)

--- a/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
@@ -228,6 +228,7 @@ private[netty] object AsyncBodyReader {
   }
 
   // For Scala 2.12. In Scala 2.13+, the methods directly implemented on ArrayBuilder[Byte] are selected over syntax.
+  @scala.annotation.nowarn("msg=never used")
   private implicit class ByteArrayBuilderOps[A](private val self: mutable.ArrayBuilder[Byte]) extends AnyVal {
     def addAll(as: Array[Byte]): Unit = self ++= as
     def knownSize: Int                = -1

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
@@ -34,7 +34,7 @@ private[netty] object ClientSSLConverter {
   private def keyManagerTrustManagerToSslContext(
     keyManagerInfo: Option[(String, InputStream, Option[Secret])],
     trustManagerInfo: Option[(String, InputStream, Option[Secret])],
-    sslContextBuilder: SslContextBuilder,
+    @scala.annotation.unused sslContextBuilder: SslContextBuilder,
   ): SslContextBuilder = {
     val mkeyManagerFactory =
       keyManagerInfo.map { case (keyStoreType, inputStream, maybePassword) =>

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
@@ -48,6 +48,7 @@ object ClientSSLConfig {
       serverCertConfig.zipWith(clientCertConfig)(FromClientAndServerCert(_, _))
     }
 
+    @scala.annotation.nowarn("msg=never used")
     val fromJavaxNetSsl = {
       keyManagerKeyStoreType.optional
         .zip(keyManagerFile.optional)

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -1235,7 +1235,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   def notFound(message: => String): Handler[Any, Nothing, Any, Response] =
     error(Status.NotFound, message)
 
-  def notFound(routes: Routes[_, _]): Handler[Any, Nothing, Request, Response] =
+  def notFound(@scala.annotation.unused routes: Routes[_, _]): Handler[Any, Nothing, Request, Response] =
     Handler
       .fromFunctionHandler[Request] { request =>
         error(Status.NotFound, request.url.path.encode)

--- a/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
@@ -102,7 +102,7 @@ final case class HandlerAspect[-Env, +CtxOut](
         Handler.scoped[Env1] {
           for {
             tuple <- protocol.incomingHandler
-            (state, (request, ctxOut)) = tuple
+            (state, (request, _)) = tuple
             either   <- Handler.fromZIO(handler(request)).either
             response <- Handler.fromZIO(protocol.outgoingHandler((state, either.merge)))
             response <- if (either.isLeft) Handler.fail(response) else Handler.succeed(response)
@@ -138,7 +138,7 @@ final case class HandlerAspect[-Env, +CtxOut](
       Handler.scoped[Env1] {
         for {
           tuple <- protocol.incomingHandler
-          (state, (request, ctxOut)) = tuple
+          (state, (request, _)) = tuple
           either   <- Handler.fromZIO(handler(request)).either
           response <- Handler.fromZIO(protocol.outgoingHandler((state, either.merge)))
           response <- if (either.isLeft) Handler.fail(response) else Handler.succeed(response)

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -210,7 +210,7 @@ private[codec] object EncoderDecoder {
         },
       )
 
-    private def decodeQuery(config: CodecConfig, queryParams: QueryParams, inputs: Array[Any]): Unit =
+    private def decodeQuery(@scala.annotation.unused config: CodecConfig, queryParams: QueryParams, inputs: Array[Any]): Unit =
       genericDecode[QueryParams, HttpCodec.Query[_]](
         queryParams,
         flattened.query,
@@ -345,7 +345,7 @@ private[codec] object EncoderDecoder {
         },
       )
 
-    private def encodeQuery(config: CodecConfig, inputs: Array[Any]): QueryParams =
+    private def encodeQuery(@scala.annotation.unused config: CodecConfig, inputs: Array[Any]): QueryParams =
       genericEncode[QueryParams, HttpCodec.Query[_]](
         flattened.query,
         inputs,

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -135,7 +135,7 @@ object HttpGen {
       )
     }
 
-  def queryVariables(config: CodecConfig, inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
+  def queryVariables(@scala.annotation.unused config: CodecConfig, inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
     inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(codec, _), _) =>
       val recordSchema = (codec.schema match {
         case value if value.isInstanceOf[Schema.Optional[_]] => value.asInstanceOf[Schema.Optional[Any]].schema

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -973,7 +973,7 @@ object OpenAPIGen {
 
     def httpSecuritySchemes(
       endpoint: Endpoint[_, _, _, _, _],
-      params: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]],
+      @scala.annotation.unused params: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]],
     ): ListMap[Key, ReferenceOr[SecurityScheme]] =
       endpoint.authType match {
         case AuthType.Basic | AuthType.Bearer | AuthType.Digest =>


### PR DESCRIPTION
## Summary
Fixes all compiler warnings to ensure clean CI builds (which has `-Xfatal-warnings` enabled).

### Fixes
- **AsyncBodyReader**: Add `@nowarn` for Scala 2.12 compatibility class (unused in 2.13+)
- **ClientSSLConverter**: Mark unused `sslContextBuilder` parameter with `@unused`
- **ClientSSLConfig**: Add `@nowarn` for unused `fromJavaxNetSsl` val
- **Handler**: Mark unused `routes` parameter with `@unused`
- **HandlerAspect**: Replace unused `ctxOut` pattern variable with `_`
- **EncoderDecoder**: Mark unused `config` parameters with `@unused`
- **HttpGen**: Mark unused `config` parameter with `@unused`
- **OpenAPIGen**: Mark unused `params` parameter with `@unused`
- **DatastarPackageBase**: Replace unused `e` pattern variable with `_`

### Notes
CI already has `-Xfatal-warnings` configured, so these fixes ensure builds pass in CI.