### PR TITLE
Fix hardcoded Scala 2.13.10 in CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10]
+        scala: [2.13.18]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -983,7 +983,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10]
+        scala: [2.13.18]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ ThisBuild / githubWorkflowAddedJobs :=
         coursierSetup,
       ) ++ WorkflowStep.SetupJava(List(JavaSpec.temurin("21"))) :+ WorkflowStep.Sbt(List("mimaChecks")),
       cond = Option("${{ github.event_name == 'pull_request' }}"),
+      scalas = List(Scala213),
       javas = List(JavaSpec.temurin("21")),
     ),
   ) ++ ScoverageWorkFlow(50, 60) ++ JmhBenchmarkWorkflow(1) ++ BenchmarkWorkFlow()

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -77,6 +77,7 @@ object JmhBenchmarkWorkflow {
     WorkflowJob(
       id = "Jmh_cache",
       name = "Cache Jmh benchmarks",
+      scalas = List(Scala213),
       javas = List(JavaSpec.temurin("17")),
       cond = Some(
         "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",


### PR DESCRIPTION
## Summary
- The `mima_check` and `Jmh_cache` jobs did not specify the `scalas` parameter
- This caused sbt-github-actions to use a default outdated version (`2.13.10`) instead of the current `2.13.18`
- Added `scalas = List(Scala213)` to both jobs so they use the current Scala version consistently

## Test plan
- [ ] CI workflow should now show `2.13.18` for all jobs instead of `2.13.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)