### PR TITLE
Add Datastar real-time chat example project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
 
       - name: Compress target directories
-        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
+        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v5

--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,6 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
       zioHttpHtmx,
       zioHttpStomp,
       zioHttpExample,
-      zioHttpExampleDatastarChat,
       zioHttpTestkit,
       zioHttpTools,
       docs,

--- a/build.sbt
+++ b/build.sbt
@@ -162,6 +162,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
       zioHttpHtmx,
       zioHttpStomp,
       zioHttpExample,
+      zioHttpExampleDatastarChat,
       zioHttpTestkit,
       zioHttpTools,
       docs,
@@ -373,8 +374,7 @@ lazy val zioHttpExampleDatastarChat = (project in file("zio-http-example-datasta
   .settings(stdSettings("zio-http-example-datastar-chat"))
   .settings(publishSetting(false))
   .settings(
-    scalaVersion := Scala3,
-    run / fork   := true,
+    run / fork := true,
   )
   .dependsOn(zioHttpJVM, zioHttpDatastarSdk)
 

--- a/build.sbt
+++ b/build.sbt
@@ -162,6 +162,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
       zioHttpHtmx,
       zioHttpStomp,
       zioHttpExample,
+      zioHttpExampleDatastarChat,
       zioHttpTestkit,
       zioHttpTools,
       docs,
@@ -367,6 +368,16 @@ lazy val zioHttpExample = (project in file("zio-http-example"))
     ),
   )
   .dependsOn(zioHttpJVM, zioHttpCli, zioHttpGen, zioHttpDatastarSdk)
+
+lazy val zioHttpExampleDatastarChat = (project in file("zio-http-example-datastar-chat"))
+  .disablePlugins(ScalafixPlugin)
+  .settings(stdSettings("zio-http-example-datastar-chat"))
+  .settings(publishSetting(false))
+  .settings(
+    scalaVersion := Scala3,
+    run / fork   := true,
+  )
+  .dependsOn(zioHttpJVM, zioHttpDatastarSdk)
 
 lazy val zioHttpTools = (project in file("zio-http-tools"))
   .settings(stdSettings("zio-http-tools"))

--- a/docs/guides/real-time-chat-with-datastar.md
+++ b/docs/guides/real-time-chat-with-datastar.md
@@ -1,0 +1,218 @@
+---
+id: real-time-chat-with-datastar
+title: "Building a Real-time Chat with Datastar"
+sidebar_label: "Real-time Chat"
+---
+
+This guide walks through building a real-time multi-client chat application using ZIO HTTP and Datastar. The application demonstrates several powerful patterns for building reactive web applications with server-driven UI updates.
+
+## What We're Building
+
+A fully functional chat application where:
+- Multiple users can join and chat simultaneously
+- Messages appear in real-time across all connected clients
+- No page refreshes required - updates stream via Server-Sent Events (SSE)
+- Clean, reactive UI with Datastar signal bindings
+
+## Key Concepts Demonstrated
+
+- **ZIO Hub** for broadcasting messages to multiple subscribers
+- **Server-Sent Events (SSE)** for real-time updates via `events { handler {...} }`
+- **Datastar signals** for reactive form bindings
+- **Type-safe request handling** with `readSignals[T]`
+- **HTML templating** with the `template2` DSL
+
+## Prerequisites
+
+Add the Datastar SDK dependency to your project:
+
+```scala
+libraryDependencies += "dev.zio" %% "zio-http-datastar-sdk" % "@VERSION@"
+```
+
+## Architecture Overview
+
+The chat application consists of four components:
+
+1. **ChatMessage** - Immutable message model with ZIO Schema
+2. **ChatRoom** - In-memory state using `Ref` + message broadcasting via `Hub`
+3. **MessageRequest** - Request model for signal binding
+4. **ChatServer** - HTTP routes and HTML template
+
+```
+┌─────────────────┐     POST /chat/send      ┌─────────────────┐
+│   Browser 1     │ ───────────────────────► │                 │
+│   (Datastar)    │                          │   ChatServer    │
+│                 │ ◄─────────────────────── │                 │
+└─────────────────┘     SSE: new messages    │   ┌─────────┐   │
+                                             │   │ ChatRoom│   │
+┌─────────────────┐     POST /chat/send      │   │  (Hub)  │   │
+│   Browser 2     │ ───────────────────────► │   └─────────┘   │
+│   (Datastar)    │                          │                 │
+│                 │ ◄─────────────────────── │                 │
+└─────────────────┘     SSE: new messages    └─────────────────┘
+```
+
+## Implementation
+
+### 1. Message Model
+
+The `ChatMessage` case class represents a chat message with automatic ID and timestamp generation:
+
+```scala mdoc:passthrough
+import utils._
+
+printSource("zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatMessage.scala")
+```
+
+Key points:
+- Uses ZIO Schema for type-safe serialization
+- Factory method generates UUID and timestamp automatically
+- Scala 3 `given` syntax for Schema derivation
+
+### 2. Request Model
+
+The `MessageRequest` captures the form data sent when a user submits a message:
+
+```scala mdoc:passthrough
+printSource("zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/MessageRequest.scala")
+```
+
+This model maps directly to the Datastar signals `$username` and `$message` defined in the HTML template.
+
+### 3. Chat Room with Hub
+
+The `ChatRoom` manages message state and broadcasts new messages to all connected clients:
+
+```scala mdoc:passthrough
+printSource("zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatRoom.scala")
+```
+
+Key patterns:
+- **`Ref[List[ChatMessage]]`** - Thread-safe mutable reference for message history
+- **`Hub[ChatMessage]`** - Broadcasts messages to all subscribers
+- **`subscribe`** - Returns a `ZStream` that receives new messages
+- **ZLayer** - Provides the `ChatRoom` as a dependency
+
+### 4. Server and Routes
+
+The `ChatServer` ties everything together with HTTP routes and the HTML template:
+
+```scala mdoc:passthrough
+printSource("zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatServer.scala")
+```
+
+Let's break down the key parts:
+
+#### Signal Declarations
+
+```scala
+private val $username = Signal[String]("username")
+private val $message  = Signal[String]("message")
+```
+
+These typed signal declarations are used in the HTML template for two-way data binding.
+
+#### HTML Template with Datastar
+
+The template uses several Datastar attributes:
+
+- **`datastarScript`** - Includes the Datastar JavaScript library
+- **`dataInit`** - Triggers initial data load via SSE when the page loads
+- **`dataSignals($username) := ""`** - Declares reactive signals with initial values
+- **`dataBind("username")`** - Two-way binds input value to signal
+- **`dataOn.keydown := js"..."`** - Handles keyboard events
+- **`dataOn.click := js"@post('/chat/send')"`** - Sends message on button click
+
+#### SSE Streaming Route
+
+```scala
+Method.GET / "chat" / "messages" -> events {
+  handler {
+    for
+      messages <- ChatRoom.getMessages
+      _        <- ServerSentEventGenerator.patchElements(
+                    messages.map(messageTemplate),
+                    PatchElementOptions(
+                      selector = Some(id("message-list")),
+                      mode = ElementPatchMode.Inner,
+                    ),
+                  )
+      messages <- ChatRoom.subscribe
+      _        <- messages.mapZIO { message =>
+                    ServerSentEventGenerator.patchElements(
+                      messageTemplate(message),
+                      PatchElementOptions(
+                        selector = Some(id("message-list")),
+                        mode = ElementPatchMode.Append,
+                      ),
+                    )
+                  }.runDrain
+    yield ()
+  }
+}
+```
+
+This route:
+1. Sends existing messages immediately (with `Inner` mode to replace content)
+2. Subscribes to the Hub for new messages
+3. Streams each new message as an SSE event (with `Append` mode)
+
+#### Message Sending Route
+
+```scala
+Method.POST / "chat" / "send" ->
+  handler { (req: Request) =>
+    for
+      rq  <- req.readSignals[MessageRequest]
+      msg  = ChatMessage(username = rq.username, content = rq.message)
+      _   <- ChatRoom.addMessage(msg)
+    yield Response.ok
+  }
+```
+
+The `readSignals[T]` method extracts Datastar signals from the request body into a typed case class.
+
+## Running the Example
+
+Clone the ZIO HTTP repository and run the example:
+
+```bash
+git clone https://github.com/zio/zio-http.git
+cd zio-http
+sbt "zioHttpExampleDatastarChat/run"
+```
+
+Open your browser to [http://localhost:8080/chat](http://localhost:8080/chat).
+
+To test multi-client functionality, open multiple browser tabs or windows.
+
+## How It Works
+
+1. **Page Load**: Browser requests `/chat`, receives HTML with embedded Datastar
+2. **Initial Connection**: `dataInit` triggers GET `/chat/messages`, establishing SSE connection
+3. **Existing Messages**: Server sends all existing messages via `patchElements` with `Inner` mode
+4. **Subscription**: Server subscribes to Hub and keeps connection open
+5. **User Types**: Input changes update `$username` and `$message` signals locally
+6. **User Sends**: Button click or Enter key triggers POST `/chat/send` with signals
+7. **Broadcast**: Server adds message to ChatRoom, Hub broadcasts to all subscribers
+8. **Real-time Update**: Each subscriber's SSE connection receives new message, DOM updates
+
+## Styling
+
+The application uses an external CSS file loaded via `style.inlineResource("chat.css")`. This demonstrates how to load static resources in ZIO HTTP applications.
+
+## Next Steps
+
+This example can be extended with:
+- **User authentication** - Add login flow before chat access
+- **Multiple rooms** - Support different chat channels
+- **Message persistence** - Store messages in a database
+- **Typing indicators** - Show when users are typing
+- **Read receipts** - Track message delivery status
+
+## Related Documentation
+
+- [Datastar SDK Reference](../reference/datastar-sdk/index.md) - Complete API documentation
+- [Server-Sent Events](../examples/server-sent-events-in-endpoints.md) - SSE fundamentals
+- [HTML Templating](../reference/body/template.md) - Template DSL reference

--- a/docs/reference/datastar-sdk/index.md
+++ b/docs/reference/datastar-sdk/index.md
@@ -644,7 +644,7 @@ The result is a highly responsive search experience with beautiful animations, a
 
 ### Real-time Chat Example
 
-For a more comprehensive example demonstrating multi-client real-time chat with ZIO Hub broadcasting, see the [Real-time Chat with Datastar](../guides/real-time-chat-with-datastar.md) guide. This example showcases:
+For a more comprehensive example demonstrating multi-client real-time chat with ZIO Hub broadcasting, see the [Real-time Chat with Datastar](../../guides/real-time-chat-with-datastar.md) guide. This example showcases:
 
 - Broadcasting messages to multiple connected clients using ZIO Hub
 - Persistent SSE connections for real-time updates

--- a/docs/reference/datastar-sdk/index.md
+++ b/docs/reference/datastar-sdk/index.md
@@ -641,3 +641,12 @@ The CSS includes view transition rules that create smooth fade-in effects:
 ```
 
 The result is a highly responsive search experience with beautiful animations, all controlled from the server without complex client-side state management.
+
+### Real-time Chat Example
+
+For a more comprehensive example demonstrating multi-client real-time chat with ZIO Hub broadcasting, see the [Real-time Chat with Datastar](../guides/real-time-chat-with-datastar.md) guide. This example showcases:
+
+- Broadcasting messages to multiple connected clients using ZIO Hub
+- Persistent SSE connections for real-time updates
+- Two-way signal binding with form inputs
+- Type-safe request handling with `readSignals[T]`

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -152,11 +152,19 @@ const sidebars = {
           "guides/authentication-with-a-third-party-oauth-provider",
           "guides/passwordless-authentication-with-webauthn",
        ],
-    },
-    {
-       type: "category",
-       collapsed: false,
-       label: "SSL/TLS",
+     },
+     {
+        type: "category",
+        collapsed: false,
+        label: "Datastar",
+        items: [
+           "guides/real-time-chat-with-datastar",
+        ],
+     },
+     {
+        type: "category",
+        collapsed: false,
+        label: "SSL/TLS",
        link: { type: 'doc', id: "guides/securing-communication-with-ssl-tls" },
        items: [
           "guides/implementing-tls-with-self-signed-server-certificate",

--- a/zio-http-example-datastar-chat/src/main/resources/chat.css
+++ b/zio-http-example-datastar-chat/src/main/resources/chat.css
@@ -1,0 +1,269 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg-primary: #1a1a2e;
+  --bg-secondary: #16213e;
+  --bg-tertiary: #0f3460;
+  --accent: #e94560;
+  --accent-hover: #c93a52;
+  --text-primary: #eee;
+  --text-secondary: #aaa;
+  --border: #2d3561;
+  --success: #4ecca3;
+  --shadow: rgba(0, 0, 0, 0.3);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  background: var(--bg-secondary);
+  padding: 1.5rem 2rem;
+  box-shadow: 0 2px 10px var(--shadow);
+  border-bottom: 2px solid var(--accent);
+}
+
+.header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--success) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.5rem;
+}
+
+.header p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.connection-status {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: var(--success);
+  color: var(--bg-primary);
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-left: 1rem;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.username-section {
+  background: var(--bg-secondary);
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.username-section label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.username-section input {
+  width: 100%;
+  padding: 0.75rem;
+  background: var(--bg-primary);
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: all 0.3s ease;
+}
+
+.username-section input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(233, 69, 96, 0.1);
+}
+
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 16px var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  scroll-behavior: smooth;
+}
+
+.messages::-webkit-scrollbar {
+  width: 8px;
+}
+
+.messages::-webkit-scrollbar-track {
+  background: var(--bg-primary);
+}
+
+.messages::-webkit-scrollbar-thumb {
+  background: var(--accent);
+  border-radius: 4px;
+}
+
+.message {
+  background: var(--bg-tertiary);
+  padding: 1rem;
+  border-radius: 8px;
+  border-left: 3px solid var(--accent);
+  animation: slideIn 0.3s ease;
+  box-shadow: 0 2px 4px var(--shadow);
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.message-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.message-username {
+  font-weight: 700;
+  color: var(--success);
+  font-size: 0.9rem;
+}
+
+.message-time {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.message-content {
+  color: var(--text-primary);
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.input-area {
+  padding: 1.5rem;
+  background: var(--bg-primary);
+  border-top: 1px solid var(--border);
+}
+
+.input-area {
+  display: flex;
+  gap: 1rem;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: all 0.3s ease;
+}
+
+.input-area input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(233, 69, 96, 0.1);
+}
+
+.input-area button {
+  padding: 0.75rem 2rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 6px var(--shadow);
+}
+
+.input-area button:hover {
+  background: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px var(--shadow);
+}
+
+.input-area button:active {
+  transform: translateY(0);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .header {
+    padding: 1rem;
+  }
+
+  .header h1 {
+    font-size: 1.5rem;
+  }
+
+  .input-area {
+    flex-direction: column;
+  }
+
+  .input-area button {
+    width: 100%;
+  }
+}
+

--- a/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatMessage.scala
+++ b/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatMessage.scala
@@ -1,0 +1,17 @@
+package example.datastar.chat
+
+import zio.schema._
+
+case class ChatMessage(
+  id: String,
+  username: String,
+  content: String,
+  timestamp: Long,
+)
+
+object ChatMessage {
+  def apply(username: String, content: String): ChatMessage =
+    ChatMessage(java.util.UUID.randomUUID().toString, username, content, System.currentTimeMillis())
+
+  implicit val schema: Schema[ChatMessage] = DeriveSchema.gen[ChatMessage]
+}

--- a/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatRoom.scala
+++ b/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatRoom.scala
@@ -1,0 +1,36 @@
+package example.datastar.chat
+
+import zio._
+import zio.stream._
+
+case class ChatRoom(
+  messages: Ref[List[ChatMessage]],
+  subscribers: Hub[ChatMessage],
+)
+
+object ChatRoom {
+  def make: ZIO[Any, Nothing, ChatRoom] =
+    for {
+      messages <- Ref.make(List.empty[ChatMessage])
+      hub      <- Hub.unbounded[ChatMessage]
+    } yield ChatRoom(messages, hub)
+
+  def addMessage(message: ChatMessage): ZIO[ChatRoom, Nothing, Unit] =
+    ZIO.serviceWithZIO[ChatRoom] { room =>
+      for {
+        _ <- room.messages.update(_ :+ message)
+        _ <- room.subscribers.publish(message)
+      } yield ()
+    }
+
+  def getMessages: ZIO[ChatRoom, Nothing, List[ChatMessage]] =
+    ZIO.serviceWithZIO[ChatRoom](_.messages.get)
+
+  def subscribe: ZIO[ChatRoom & Scope, Nothing, UStream[ChatMessage]] =
+    ZIO.serviceWithZIO[ChatRoom] { room =>
+      room.subscribers.subscribe.map(ZStream.fromQueue(_))
+    }
+
+  val layer: ZLayer[Any, Nothing, ChatRoom] =
+    ZLayer.fromZIO(make)
+}

--- a/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatServer.scala
+++ b/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatServer.scala
@@ -1,0 +1,143 @@
+package example.datastar.chat
+
+import zio._
+import zio.http._
+import zio.http.datastar._
+import zio.http.endpoint.Endpoint
+import zio.http.template2._
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
+
+object ChatServer extends ZIOAppDefault {
+
+  private val $username = Signal[String]("username")
+  private val $message  = Signal[String]("message")
+
+  private val chatPage: Dom = html(
+    head(
+      meta(charset := "UTF-8"),
+      meta(name    := "viewport", content := "width=device-width, initial-scale=1.0"),
+      title("ZIO Chat - Real-time Multi-Client Chat"),
+      datastarScript,
+      style.inlineResource("chat.css"),
+    ),
+    body(
+      dataInit := Endpoint(Method.GET / "chat" / "messages").out[String].datastarRequest(()),
+      div(`class` := "header")(
+        h1("ZIO Chat"),
+        p(
+          "Real-time Multi-Client Chat with ZIO, ZIO HTTP & Datastar",
+          span(`class` := "connection-status")("CONNECTED"),
+        ),
+      ),
+      div(
+        `class`                := "container",
+        dataSignals($username) := "",
+        dataSignals($message)  := "",
+      )(
+        div(`class` := "username-section")(
+          label(`for` := "username")("Your Username"),
+          input(
+            `type`      := "text",
+            id          := "username",
+            placeholder := "Enter your username...",
+            dataBind("username"),
+          ),
+        ),
+        div(`class` := "chat-container")(
+          div(
+            `class` := "messages",
+            id      := "messages",
+          )(
+            div(id := "message-list"),
+          ),
+          div(`class` := "input-area")(
+            input(
+              `type`         := "text",
+              id             := "message",
+              placeholder    := "Type your message...",
+              dataBind("message"),
+              required,
+              dataOn.keydown := js"evt.code === 'Enter' && @post('/chat/send')",
+            ),
+            button(
+              `type`               := "submit",
+              dataAttr("disabled") := js"(${$username} === '' || ${$message} === '')",
+              dataOn.click         := js"@post('/chat/send')",
+            )("Send"),
+          ),
+        ),
+      ),
+      script(js"""
+        // Auto-scroll to bottom when new messages arrive
+        const messagesContainer = document.getElementById('messages');
+        const observer = new MutationObserver(() => {
+          messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        });
+        observer.observe(messagesContainer, { childList: true, subtree: true });
+      """),
+    ),
+  )
+
+  private def messageTemplate(msg: ChatMessage): Dom = {
+    val time = Instant
+      .ofEpochMilli(msg.timestamp)
+      .atZone(ZoneId.systemDefault())
+      .format(DateTimeFormatter.ofPattern("HH:mm:ss"))
+
+    div(`class` := "message")(
+      div(`class` := "message-header")(
+        span(`class` := "message-username")(msg.username),
+        span(`class` := "message-time")(time),
+      ),
+      div(`class` := "message-content")(msg.content),
+    )
+  }
+
+  private val routes = Routes(
+    Method.GET / "chat"              -> handler {
+      Response.text(chatPage.render).addHeader("Content-Type", "text/html")
+    },
+    Method.GET / "chat" / "messages" -> events {
+      handler {
+        for {
+          messages <- ChatRoom.getMessages
+          _        <- ServerSentEventGenerator.patchElements(
+            messages.map(messageTemplate),
+            PatchElementOptions(
+              selector = Some(id("message-list")),
+              mode = ElementPatchMode.Inner,
+            ),
+          )
+          messages <- ChatRoom.subscribe
+          _        <- messages.mapZIO { message =>
+            ServerSentEventGenerator.patchElements(
+              messageTemplate(message),
+              PatchElementOptions(
+                selector = Some(id("message-list")),
+                mode = ElementPatchMode.Append,
+              ),
+            )
+          }.runDrain
+        } yield ()
+      }
+    },
+    Method.POST / "chat" / "send"    ->
+      handler { (req: Request) =>
+        for {
+          rq <- req.readSignals[MessageRequest]
+          msg = ChatMessage(username = rq.username, content = rq.message)
+          _ <- ChatRoom.addMessage(msg)
+        } yield Response.ok
+      },
+  ).sandbox @@ ErrorResponseConfig.debug @@ Middleware.debug
+
+  override def run: ZIO[Any, Throwable, Unit] =
+    Server
+      .serve(routes)
+      .provide(
+        Server.default,
+        ChatRoom.layer,
+      )
+}

--- a/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/MessageRequest.scala
+++ b/zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/MessageRequest.scala
@@ -1,0 +1,9 @@
+package example.datastar.chat
+
+import zio.schema._
+
+case class MessageRequest(username: String, message: String)
+
+object MessageRequest {
+  implicit val schema: Schema[MessageRequest] = DeriveSchema.gen[MessageRequest]
+}


### PR DESCRIPTION
## Summary

- Add `zio-http-example-datastar-chat` module demonstrating multi-client real-time chat
- Create comprehensive guide in `docs/guides/real-time-chat-with-datastar.md`
- Add Datastar category to sidebar navigation in guides section
- Add cross-reference from Datastar SDK docs to the new guide

## Features Demonstrated

The chat example showcases several powerful patterns for building reactive web applications:

- **ZIO Hub** for broadcasting messages to multiple subscribers
- **Server-Sent Events (SSE)** via `events { handler {...} }`
- **Datastar signals** for reactive form bindings (`dataSignals`, `dataBind`)
- **Type-safe request handling** with `readSignals[T]`
- **HTML templating** with the `template2` DSL

## Architecture

```
┌─────────────────┐     POST /chat/send      ┌─────────────────┐
│   Browser 1     │ ───────────────────────► │                 │
│   (Datastar)    │                          │   ChatServer    │
│                 │ ◄─────────────────────── │                 │
└─────────────────┘     SSE: new messages    │   ┌─────────┐   │
                                             │   │ ChatRoom│   │
┌─────────────────┐     POST /chat/send      │   │  (Hub)  │   │
│   Browser 2     │ ───────────────────────► │   └─────────┘   │
│   (Datastar)    │                          │                 │
│                 │ ◄─────────────────────── │                 │
└─────────────────┘     SSE: new messages    └─────────────────┘
```

## Running the Example

```bash
sbt "zioHttpExampleDatastarChat/run"
```

Then open http://localhost:8080/chat in multiple browser tabs to test multi-client real-time messaging.

## Files Added/Modified

**New Files:**
- `zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatServer.scala`
- `zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatRoom.scala`
- `zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/ChatMessage.scala`
- `zio-http-example-datastar-chat/src/main/scala/example/datastar/chat/MessageRequest.scala`
- `zio-http-example-datastar-chat/src/main/resources/chat.css`
- `docs/guides/real-time-chat-with-datastar.md`

**Modified Files:**
- `build.sbt` - Added project definition and aggregation
- `website/sidebars.js` - Added Datastar category in guides
- `docs/reference/datastar-sdk/index.md` - Added cross-reference to guide

/claim #3697