### PR TITLE
Fix URL double encoding when parsing from URI

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/StaticServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticServerSpec.scala
@@ -28,10 +28,10 @@ import zio.http.internal.{DynamicServer, HttpGen, RoutesRunnableSpec, serverTest
 object StaticServerSpec extends RoutesRunnableSpec {
 
   private val staticApp = Routes(
-    Method.GET / "success"       -> handler(Response.ok),
-    Method.GET / "failure"       -> handler(ZIO.fail(new RuntimeException("FAILURE"))),
-    Method.GET / "die"           -> handler(ZIO.die(new RuntimeException("DIE"))),
-    Method.GET / "get%2Fsuccess" -> handler(Response.ok),
+    Method.GET / "success"     -> handler(Response.ok),
+    Method.GET / "failure"     -> handler(ZIO.fail(new RuntimeException("FAILURE"))),
+    Method.GET / "die"         -> handler(ZIO.die(new RuntimeException("DIE"))),
+    Method.GET / "get success" -> handler(Response.ok),
   ).sandbox
 
   // Use this route to test anything that doesn't require ZIO related computations.
@@ -127,7 +127,7 @@ object StaticServerSpec extends RoutesRunnableSpec {
         assertZIO(actual)(equalTo(Status.NotFound))
       },
       test("200 response with encoded path") {
-        val actual = status(path = Path.root / "get%2Fsuccess")
+        val actual = status(path = Path.root / "get%20success")
         assertZIO(actual)(equalTo(Status.Ok))
       },
       test("Multiple 200 response") {

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -99,6 +99,20 @@ object URLSpec extends ZIOHttpSpec {
           val expected     = urlWithSpace.encode
           assertTrue(expected == "/my%20folder/file.txt")
         },
+        test("url with already encoded path should not double encode") {
+          val originalUrl = "http://testsample.com/file/test%20hotel.pdf"
+          val decoded     = URL.decode(originalUrl)
+          val reEncoded   = decoded.map(_.encode)
+          assertTrue(reEncoded == Right(originalUrl))
+        },
+        test("url fromURI should not double encode path") {
+          val uri = new java.net.URI("http://testsample.com/file/test%20hotel.pdf")
+          val url = URL.fromURI(uri)
+          assertTrue(
+            url.isDefined,
+            url.get.encode == "http://testsample.com/file/test%20hotel.pdf",
+          )
+        },
         test("auto-gen") {
           check(HttpGen.url) { url =>
             val expected        = url.copy(path = url.path.addLeadingSlash)

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -406,7 +406,7 @@ object URL {
     for {
       scheme <- Scheme.decode(uri.getScheme)
       host   <- Option(uri.getHost)
-      path   <- Option(uri.getRawPath)
+      path   <- Option(uri.getPath)
       port       = Option(uri.getPort).filter(_ != -1)
       connection = URL.Location.Absolute(scheme, host, port)
       path2      = Path.decode(path)
@@ -415,7 +415,7 @@ object URL {
   }
 
   private[http] def fromRelativeURI(uri: URI): Option[URL] = for {
-    path <- Option(uri.getRawPath)
+    path <- Option(uri.getPath)
   } yield URL(Path.decode(path), Location.Relative, QueryParams.decode(uri.getRawQuery), Fragment.fromURI(uri))
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -393,7 +393,7 @@ object URL {
     val prefix = if (!url.path.hasLeadingSlash) "/" else ""
 
     prefix + (if (url.queryParams.isEmpty) {
-                url.path.encode
+                url.path.encodeBuilder.toString
               } else {
                 // this branch could be more efficient with something like QueryParamEncoding.appendNonEmpty(pathBuf, qparams, Charsets.Http)
                 // that directly filtered the keys/values and appended to the buffer
@@ -406,16 +406,16 @@ object URL {
     for {
       scheme <- Scheme.decode(uri.getScheme)
       host   <- Option(uri.getHost)
-      path   <- Option(uri.getPath)
+      path   <- Option(uri.getRawPath)
       port       = Option(uri.getPort).filter(_ != -1)
       connection = URL.Location.Absolute(scheme, host, port)
-      path2      = Path.decode(path)
+      path2      = Path.decodeRaw(path)
       path3      = if (path.nonEmpty) path2.addLeadingSlash else path2
     } yield URL(path3, connection, QueryParams.decode(uri.getRawQuery), Fragment.fromURI(uri))
   }
 
   private[http] def fromRelativeURI(uri: URI): Option[URL] = for {
-    path <- Option(uri.getPath)
-  } yield URL(Path.decode(path), Location.Relative, QueryParams.decode(uri.getRawQuery), Fragment.fromURI(uri))
+    path <- Option(uri.getRawPath)
+  } yield URL(Path.decodeRaw(path), Location.Relative, QueryParams.decode(uri.getRawQuery), Fragment.fromURI(uri))
 
 }


### PR DESCRIPTION
## Summary

- Fix URL double encoding issue where `%20` becomes `%2520` when parsing URLs from `java.net.URI`
- Use `getPath()` (decoded) instead of `getRawPath()` (already-encoded) in `fromAbsoluteURI` and `fromRelativeURI`
- Add tests to verify encode-decode symmetry with percent-encoded paths

## Problem

When creating a URL from a `java.net.URI` (via `URL.decode` or `URL.fromURI`), the path was obtained using `uri.getRawPath()` which returns an already percent-encoded path. Later when `URL.encode()` is called, `Path.encodeBuilder` percent-encodes the segments again, causing:
- `%20` → `%2520`
- `%2F` → `%252F`
- etc.

## Solution

Use `uri.getPath()` which returns the decoded path. This way the path segments are stored in decoded form, and encoding happens only once when `URL.encode()` is called.

Fixes #3887