### PR TITLE
fix: Add discriminator property to case schemas in OpenAPI generation

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -3049,7 +3049,18 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |        {
             |        "type" :
             |          "object",
-            |        "properties" : {}
+            |        "properties" : {
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "One"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type"
+            |        ]
             |      },
             |      "SealedTraitCustomDiscriminator" :
             |        {
@@ -3081,9 +3092,17 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "name" : {
             |            "type" :
             |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "three"
+            |            ]
             |          }
             |        },
             |        "required" : [
+            |          "type",
             |          "name"
             |        ]
             |      },
@@ -3095,9 +3114,17 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "name" : {
             |            "type" :
             |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "Two"
+            |            ]
             |          }
             |        },
             |        "required" : [
+            |          "type",
             |          "name"
             |        ]
             |      }
@@ -3975,7 +4002,18 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |        {
             |        "type" :
             |          "object",
-            |        "properties" : {}
+            |        "properties" : {
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "One"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type"
+            |        ]
             |      },
             |      "SealedTraitCustomDiscriminator" :
             |        {
@@ -3999,6 +4037,50 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          }
             |        }
             |      },
+            |      "Three" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "name" : {
+            |            "type" :
+            |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "three"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type",
+            |          "name"
+            |        ]
+            |      },
+            |      "Two" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "name" : {
+            |            "type" :
+            |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "Two"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type",
+            |          "name"
+            |        ]
+            |      },
             |      "WithOptionalAdtPayload" :
             |        {
             |        "type" :
@@ -4011,34 +4093,6 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |            ]
             |          }
             |        }
-            |      },
-            |      "Two" :
-            |        {
-            |        "type" :
-            |          "object",
-            |        "properties" : {
-            |          "name" : {
-            |            "type" :
-            |              "string"
-            |          }
-            |        },
-            |        "required" : [
-            |          "name"
-            |        ]
-            |      },
-            |      "Three" :
-            |        {
-            |        "type" :
-            |          "object",
-            |        "properties" : {
-            |          "name" : {
-            |            "type" :
-            |              "string"
-            |          }
-            |        },
-            |        "required" : [
-            |          "name"
-            |        ]
             |      }
             |    }
             |  }
@@ -4275,6 +4329,10 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |         "ConcreteBigModel":{
                              |            "type":"object",
                              |            "properties":{
+                             |               "type":{
+                             |                  "type":"string",
+                             |                  "enum":["ConcreteBigModel"]
+                             |               },
                              |               "f20":{
                              |                  "type":"boolean"
                              |               },
@@ -4346,6 +4404,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |               }
                              |            },
                              |            "required":[
+                             |               "type",
                              |               "f1",
                              |               "f2",
                              |               "f3",
@@ -4426,6 +4485,10 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |         "ConcreteBigModel":{
             |            "type":"object",
             |            "properties":{
+            |               "type":{
+            |                  "type":"string",
+            |                  "enum":["ConcreteBigModel"]
+            |               },
             |               "f20":{
             |                  "type":"boolean"
             |               },
@@ -4497,6 +4560,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |               }
             |            },
             |            "required":[
+            |               "type",
             |               "f1",
             |               "f2",
             |               "f3",

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -166,9 +166,16 @@ object OpenAPISpec extends ZIOSpecDefault {
           |            "type" : "string"
           |          },
           |          "uniqueItems" : true
+          |        },
+          |        "type" : {
+          |          "type" : "string",
+          |          "enum" : [
+          |            "One"
+          |          ]
           |        }
           |      },
           |      "required" : [
+          |        "type",
           |        "set"
           |      ]
           |    },
@@ -180,9 +187,16 @@ object OpenAPISpec extends ZIOSpecDefault {
           |          "items" : {
           |            "type" : "string"
           |          }
+          |        },
+          |        "type" : {
+          |          "type" : "string",
+          |          "enum" : [
+          |            "Two"
+          |          ]
           |        }
           |      },
           |      "required" : [
+          |        "type",
           |        "list"
           |      ]
           |    },


### PR DESCRIPTION
## Summary

When using `@discriminatorName` annotation on a sealed trait, the OpenAPI generator now correctly adds the discriminator property to each case class schema, as required by OpenAPI 3.x specification.

## Problem

Previously, the generator only created the `discriminator` object at the parent level but failed to add the discriminator property to each case schema. This resulted in incomplete OpenAPI specs that didn't comply with the specification.

**Before (incorrect):**
```yaml
Online:
  type: object
  properties:
    d: { type: string }
  required: [d]
```

**After (correct):**
```yaml
Online:
  type: object
  properties:
    status:
      type: string
      enum: [online]
    d: { type: string }
  required: [status, d]
```

## Changes

- Added `withDiscriminatorProperty` helper method to `JsonSchema.scala`
- Modified `fromZSchemaMultiple` to inject discriminator property into case schemas when `@discriminatorName` is present
- Updated test expectations to reflect the new correct behavior

## Behavior

1. Each case class schema now includes the discriminator property with `type: string` and `enum` containing the case name value
2. The discriminator property is marked as required
3. `@caseName` annotations are respected for custom case name values
4. `@noDiscriminator` annotation is respected (no property added)

Fixes #3868