### PR TITLE
Fix Accept header content negotiation + Support array query params in OpenAPI

### DIFF
--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -263,6 +263,8 @@ object Code {
     case object Duration                                           extends CodecType
     case object Instant                                            extends CodecType
     case class Aliased(underlying: CodecType, newtypeName: String) extends CodecType
+    case class SeqOf(elementType: CodecType, nonEmpty: Boolean)    extends CodecType
+    case class SetOf(elementType: CodecType, nonEmpty: Boolean)    extends CodecType
   }
   final case class QueryParamCode(name: String, queryType: CodecType)
   final case class HeadersCode(headers: List[HeaderCode])

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -456,6 +456,124 @@ object EndpointGenSpec extends ZIOSpecDefault {
           )
           assertTrue(scala.files.head == expected)
         },
+        test("empty request and response with array query parameters") {
+          val openapiJson = """{
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+              "/api/v1/users": {
+                "get": {
+                  "parameters": [
+                    {
+                      "name": "tags",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    },
+                    {
+                      "name": "ids",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "integer", "format": "int32" }
+                      }
+                    }
+                  ],
+                  "responses": { "200": { "description": "Success" } }
+                }
+              }
+            }
+          }"""
+          val openAPI     = OpenAPI.fromJson(openapiJson).toOption.get
+          val scala       = EndpointGen.fromOpenAPI(openAPI)
+          val expected    = Code.File(
+            List("api", "v1", "Users.scala"),
+            pkgPath = List("api", "v1"),
+            imports = List(Code.Import.FromBase(path = "component._")),
+            objects = List(
+              Code.Object(
+                "Users",
+                Map(
+                  Code.Field("get") -> Code.EndpointCode(
+                    Method.GET,
+                    Code.PathPatternCode(segments =
+                      List(Code.PathSegmentCode("api"), Code.PathSegmentCode("v1"), Code.PathSegmentCode("users")),
+                    ),
+                    queryParamsCode = Set(
+                      Code.QueryParamCode("tags", Code.CodecType.SeqOf(Code.CodecType.String, nonEmpty = false)),
+                      Code.QueryParamCode("ids", Code.CodecType.SeqOf(Code.CodecType.Int, nonEmpty = false)),
+                    ),
+                    headersCode = Code.HeadersCode.empty,
+                    inCode = Code.InCode("Unit"),
+                    outCodes = List(Code.OutCode.json("Unit", Status.Ok)),
+                    errorsCode = Nil,
+                    authTypeCode = None,
+                  ),
+                ),
+              ),
+            ),
+            caseClasses = Nil,
+            enums = Nil,
+          )
+          assertTrue(scala.files.head == expected)
+        },
+        test("empty request and response with non-empty array query parameters") {
+          val openapiJson = """{
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+              "/api/v1/users": {
+                "get": {
+                  "parameters": [
+                    {
+                      "name": "tags",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1
+                      }
+                    }
+                  ],
+                  "responses": { "200": { "description": "Success" } }
+                }
+              }
+            }
+          }"""
+          val openAPI     = OpenAPI.fromJson(openapiJson).toOption.get
+          val scala       = EndpointGen.fromOpenAPI(openAPI)
+          val expected    = Code.File(
+            List("api", "v1", "Users.scala"),
+            pkgPath = List("api", "v1"),
+            imports = List(Code.Import.FromBase(path = "component._")),
+            objects = List(
+              Code.Object(
+                "Users",
+                Map(
+                  Code.Field("get") -> Code.EndpointCode(
+                    Method.GET,
+                    Code.PathPatternCode(segments =
+                      List(Code.PathSegmentCode("api"), Code.PathSegmentCode("v1"), Code.PathSegmentCode("users")),
+                    ),
+                    queryParamsCode = Set(
+                      Code.QueryParamCode("tags", Code.CodecType.SeqOf(Code.CodecType.String, nonEmpty = true)),
+                    ),
+                    headersCode = Code.HeadersCode.empty,
+                    inCode = Code.InCode("Unit"),
+                    outCodes = List(Code.OutCode.json("Unit", Status.Ok)),
+                    errorsCode = Nil,
+                    authTypeCode = None,
+                  ),
+                ),
+              ),
+            ),
+            caseClasses = Nil,
+            enums = Nil,
+          )
+          assertTrue(scala.files.head == expected)
+        },
         test("request body and empty response") {
           val endpoint = Endpoint(Method.POST / "api" / "v1" / "users").in[User]
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -3049,7 +3049,18 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |        {
             |        "type" :
             |          "object",
-            |        "properties" : {}
+            |        "properties" : {
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "One"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type"
+            |        ]
             |      },
             |      "SealedTraitCustomDiscriminator" :
             |        {
@@ -3081,9 +3092,17 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "name" : {
             |            "type" :
             |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "three"
+            |            ]
             |          }
             |        },
             |        "required" : [
+            |          "type",
             |          "name"
             |        ]
             |      },
@@ -3095,9 +3114,17 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "name" : {
             |            "type" :
             |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "Two"
+            |            ]
             |          }
             |        },
             |        "required" : [
+            |          "type",
             |          "name"
             |        ]
             |      }
@@ -3975,7 +4002,18 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |        {
             |        "type" :
             |          "object",
-            |        "properties" : {}
+            |        "properties" : {
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "One"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type"
+            |        ]
             |      },
             |      "SealedTraitCustomDiscriminator" :
             |        {
@@ -3999,6 +4037,50 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          }
             |        }
             |      },
+            |      "Three" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "name" : {
+            |            "type" :
+            |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "three"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type",
+            |          "name"
+            |        ]
+            |      },
+            |      "Two" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "name" : {
+            |            "type" :
+            |              "string"
+            |          },
+            |          "type" : {
+            |            "type" :
+            |              "string",
+            |            "enum" : [
+            |              "Two"
+            |            ]
+            |          }
+            |        },
+            |        "required" : [
+            |          "type",
+            |          "name"
+            |        ]
+            |      },
             |      "WithOptionalAdtPayload" :
             |        {
             |        "type" :
@@ -4011,34 +4093,6 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |            ]
             |          }
             |        }
-            |      },
-            |      "Two" :
-            |        {
-            |        "type" :
-            |          "object",
-            |        "properties" : {
-            |          "name" : {
-            |            "type" :
-            |              "string"
-            |          }
-            |        },
-            |        "required" : [
-            |          "name"
-            |        ]
-            |      },
-            |      "Three" :
-            |        {
-            |        "type" :
-            |          "object",
-            |        "properties" : {
-            |          "name" : {
-            |            "type" :
-            |              "string"
-            |          }
-            |        },
-            |        "required" : [
-            |          "name"
-            |        ]
             |      }
             |    }
             |  }
@@ -4275,6 +4329,10 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |         "ConcreteBigModel":{
                              |            "type":"object",
                              |            "properties":{
+                             |               "type":{
+                             |                  "type":"string",
+                             |                  "enum":["ConcreteBigModel"]
+                             |               },
                              |               "f20":{
                              |                  "type":"boolean"
                              |               },
@@ -4346,6 +4404,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |               }
                              |            },
                              |            "required":[
+                             |               "type",
                              |               "f1",
                              |               "f2",
                              |               "f3",
@@ -4426,6 +4485,10 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |         "ConcreteBigModel":{
             |            "type":"object",
             |            "properties":{
+            |               "type":{
+            |                  "type":"string",
+            |                  "enum":["ConcreteBigModel"]
+            |               },
             |               "f20":{
             |                  "type":"boolean"
             |               },
@@ -4497,6 +4560,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |               }
             |            },
             |            "required":[
+            |               "type",
             |               "f1",
             |               "f2",
             |               "f3",

--- a/zio-http/shared/src/main/scala/zio/http/codec/Alternator.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/Alternator.scala
@@ -34,6 +34,8 @@ sealed trait Alternator[L, R] {
   def unleft(out: Out): Option[L]
 
   def unright(out: Out): Option[R]
+
+  def isSameType: Boolean = false
 }
 
 object Alternator extends AlternatorLowPriority1 {
@@ -50,6 +52,8 @@ object Alternator extends AlternatorLowPriority1 {
       def unleft(out: Out): Option[A] = Some(out)
 
       def unright(out: Out): Option[A] = Some(out)
+
+      override def isSameType: Boolean = true
     }
 }
 

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -166,9 +166,16 @@ object OpenAPISpec extends ZIOSpecDefault {
           |            "type" : "string"
           |          },
           |          "uniqueItems" : true
+          |        },
+          |        "type" : {
+          |          "type" : "string",
+          |          "enum" : [
+          |            "One"
+          |          ]
           |        }
           |      },
           |      "required" : [
+          |        "type",
           |        "set"
           |      ]
           |    },
@@ -180,9 +187,16 @@ object OpenAPISpec extends ZIOSpecDefault {
           |          "items" : {
           |            "type" : "string"
           |          }
+          |        },
+          |        "type" : {
+          |          "type" : "string",
+          |          "enum" : [
+          |            "Two"
+          |          ]
           |        }
           |      },
           |      "required" : [
+          |        "type",
           |        "list"
           |      ]
           |    },


### PR DESCRIPTION
## Summary

This PR includes two fixes:

1. **Fixes #3284** - Accept header content negotiation for multiple output codecs
2. **Fixes #3371** - Support array query parameters in OpenAPI endpoint generation

---

## Fix 1: Accept Header Content Negotiation (#3284)

When endpoints use multiple output codecs combined with `|` (e.g., `jsonCodec | textCodec`), the server now respects the client's `Accept` header instead of always returning the first codec's media type.

### Changes
- Add `matchesMediaType` method to `EncoderDecoder.Single` to check if an alternative can produce a given media type
- Reorder alternatives in `Multiple.encodeWith` based on Accept header preferences
- Add `isSameType` flag to `Alternator` trait to handle same-type codec alternatives
- Add `toLeftLenient`/`toRightLenient` transforms for safe same-type codec handling in `flattenFallbacks`

---

## Fix 2: Array Query Parameters in OpenAPI (#3371)

Previously, `EndpointGen` threw "Array query parameters are not supported" when parsing OpenAPI specs containing array-type query parameters (like Swagger Petstore's `/pet/findByTags` endpoint).

### Changes
- Add `SeqOf` and `SetOf` `CodecType` variants in `Code.scala` for collection query parameters
- Handle `JsonSchema.ArrayType` in `schemaToQueryParamCodec` instead of throwing an exception
- Generate `Chunk[T]` or `NonEmptyChunk[T]` types in `CodeGen.scala` for array query params
- Add tests for array query parameters using raw OpenAPI JSON

### Example

OpenAPI spec with array query parameter:
```json
{
  "name": "tags",
  "in": "query",
  "schema": {
    "type": "array",
    "items": { "type": "string" }
  }
}
```

Now correctly generates:
```scala
.query(HttpCodec.query[Chunk[String]]("tags"))
```

With `minItems: 1`, generates `NonEmptyChunk[T]` instead.