### PR TITLE
fix: Support array query parameters in OpenAPI endpoint generation

### DIFF
--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -263,6 +263,8 @@ object Code {
     case object Duration                                           extends CodecType
     case object Instant                                            extends CodecType
     case class Aliased(underlying: CodecType, newtypeName: String) extends CodecType
+    case class SeqOf(elementType: CodecType, nonEmpty: Boolean)    extends CodecType
+    case class SetOf(elementType: CodecType, nonEmpty: Boolean)    extends CodecType
   }
   final case class QueryParamCode(name: String, queryType: CodecType)
   final case class HeadersCode(headers: List[HeaderCode])

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -456,6 +456,124 @@ object EndpointGenSpec extends ZIOSpecDefault {
           )
           assertTrue(scala.files.head == expected)
         },
+        test("empty request and response with array query parameters") {
+          val openapiJson = """{
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+              "/api/v1/users": {
+                "get": {
+                  "parameters": [
+                    {
+                      "name": "tags",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    },
+                    {
+                      "name": "ids",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "integer", "format": "int32" }
+                      }
+                    }
+                  ],
+                  "responses": { "200": { "description": "Success" } }
+                }
+              }
+            }
+          }"""
+          val openAPI     = OpenAPI.fromJson(openapiJson).toOption.get
+          val scala       = EndpointGen.fromOpenAPI(openAPI)
+          val expected    = Code.File(
+            List("api", "v1", "Users.scala"),
+            pkgPath = List("api", "v1"),
+            imports = List(Code.Import.FromBase(path = "component._")),
+            objects = List(
+              Code.Object(
+                "Users",
+                Map(
+                  Code.Field("get") -> Code.EndpointCode(
+                    Method.GET,
+                    Code.PathPatternCode(segments =
+                      List(Code.PathSegmentCode("api"), Code.PathSegmentCode("v1"), Code.PathSegmentCode("users")),
+                    ),
+                    queryParamsCode = Set(
+                      Code.QueryParamCode("tags", Code.CodecType.SeqOf(Code.CodecType.String, nonEmpty = false)),
+                      Code.QueryParamCode("ids", Code.CodecType.SeqOf(Code.CodecType.Int, nonEmpty = false)),
+                    ),
+                    headersCode = Code.HeadersCode.empty,
+                    inCode = Code.InCode("Unit"),
+                    outCodes = List(Code.OutCode.json("Unit", Status.Ok)),
+                    errorsCode = Nil,
+                    authTypeCode = None,
+                  ),
+                ),
+              ),
+            ),
+            caseClasses = Nil,
+            enums = Nil,
+          )
+          assertTrue(scala.files.head == expected)
+        },
+        test("empty request and response with non-empty array query parameters") {
+          val openapiJson = """{
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "1.0" },
+            "paths": {
+              "/api/v1/users": {
+                "get": {
+                  "parameters": [
+                    {
+                      "name": "tags",
+                      "in": "query",
+                      "schema": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1
+                      }
+                    }
+                  ],
+                  "responses": { "200": { "description": "Success" } }
+                }
+              }
+            }
+          }"""
+          val openAPI     = OpenAPI.fromJson(openapiJson).toOption.get
+          val scala       = EndpointGen.fromOpenAPI(openAPI)
+          val expected    = Code.File(
+            List("api", "v1", "Users.scala"),
+            pkgPath = List("api", "v1"),
+            imports = List(Code.Import.FromBase(path = "component._")),
+            objects = List(
+              Code.Object(
+                "Users",
+                Map(
+                  Code.Field("get") -> Code.EndpointCode(
+                    Method.GET,
+                    Code.PathPatternCode(segments =
+                      List(Code.PathSegmentCode("api"), Code.PathSegmentCode("v1"), Code.PathSegmentCode("users")),
+                    ),
+                    queryParamsCode = Set(
+                      Code.QueryParamCode("tags", Code.CodecType.SeqOf(Code.CodecType.String, nonEmpty = true)),
+                    ),
+                    headersCode = Code.HeadersCode.empty,
+                    inCode = Code.InCode("Unit"),
+                    outCodes = List(Code.OutCode.json("Unit", Status.Ok)),
+                    errorsCode = Nil,
+                    authTypeCode = None,
+                  ),
+                ),
+              ),
+            ),
+            caseClasses = Nil,
+            enums = Nil,
+          )
+          assertTrue(scala.files.head == expected)
+        },
         test("request body and empty response") {
           val endpoint = Endpoint(Method.POST / "api" / "v1" / "users").in[User]
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)


### PR DESCRIPTION
## Summary

Fixes #3371

This PR adds support for array query parameters when generating endpoints from OpenAPI specifications.

Previously, `EndpointGen` threw "Array query parameters are not supported" when parsing OpenAPI specs containing array-type query parameters (like Swagger Petstore's `/pet/findByTags` or `/pet/findByStatus` endpoints).

## Changes

- Add `SeqOf` and `SetOf` `CodecType` variants in `Code.scala` for collection query parameters
- Handle `JsonSchema.ArrayType` in `schemaToQueryParamCodec` instead of throwing an exception
- Generate `Chunk[T]` or `NonEmptyChunk[T]` types in `CodeGen.scala` for array query params
- Add tests for array query parameters using raw OpenAPI JSON

## Example

OpenAPI spec with array query parameter:
```json
{
  "name": "tags",
  "in": "query",
  "schema": {
    "type": "array",
    "items": { "type": "string" }
  }
}
```

Now correctly generates:
```scala
.query(HttpCodec.query[Chunk[String]]("tags"))
```

With `minItems: 1`, generates `NonEmptyChunk[T]` instead.