### PR TITLE
fix: Accept header content negotiation for multiple output codecs

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/Alternator.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/Alternator.scala
@@ -34,6 +34,8 @@ sealed trait Alternator[L, R] {
   def unleft(out: Out): Option[L]
 
   def unright(out: Out): Option[R]
+
+  def isSameType: Boolean = false
 }
 
 object Alternator extends AlternatorLowPriority1 {
@@ -50,6 +52,8 @@ object Alternator extends AlternatorLowPriority1 {
       def unleft(out: Out): Option[A] = Some(out)
 
       def unright(out: Out): Option[A] = Some(out)
+
+      override def isSameType: Boolean = true
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3284

When endpoints use multiple output codecs combined with `|` (e.g., `jsonCodec | textCodec`), the server now respects the client's `Accept` header instead of always returning the first codec's media type.

## Changes

- Add `matchesMediaType` method to `EncoderDecoder.Single` to check if an alternative can produce a given media type
- Reorder alternatives in `Multiple.encodeWith` based on Accept header preferences
- Add `isSameType` flag to `Alternator` trait to handle same-type codec alternatives
- Add `toLeftLenient`/`toRightLenient` transforms for safe same-type codec handling in `flattenFallbacks`

## Test

Added test case "content negotiation with multiple output codecs" in `RequestSpec` that verifies:
- `Accept: text/plain` returns plain text response
- `Accept: application/json` returns JSON response