### PR TITLE
fix: Handle NoContent and NotModified status codes as empty body in client

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -193,6 +193,20 @@ object RoundtripSpec extends ZIOHttpSpec {
         val healthCheckHandler = healthCheckAPI.implementAs(())
         testEndpoint(healthCheckAPI, Routes(healthCheckHandler), (), ())
       }
+      test("NoContent status returns empty body - issue #3861") {
+        val noContentAPI     = Endpoint(DELETE / "posts" / int("postId")).out[Unit](Status.NoContent)
+        val noContentHandler = noContentAPI.implementHandler {
+          Handler.fromFunction { _ => () }
+        }
+        testEndpoint(noContentAPI, Routes(noContentHandler), 42, ())
+      }
+      test("NotModified status returns empty body - issue #3861") {
+        val notModifiedAPI     = Endpoint(GET / "resource" / int("id")).out[Unit](Status.NotModified)
+        val notModifiedHandler = notModifiedAPI.implementHandler {
+          Handler.fromFunction { _ => () }
+        }
+        testEndpoint(notModifiedAPI, Routes(notModifiedHandler), 1, ())
+      }
       test("simple get with query params from case class") {
         val endpoint = Endpoint(GET / "query")
           .query(HttpCodec.query[Params])


### PR DESCRIPTION
## Summary

Fixes #3861

For HTTP status codes that must not have a body (204 No Content, 304 Not Modified, and 1xx Informational), the client now correctly treats the response as having an empty body even when no `Content-Length` header is present.

## Problem

When using an endpoint defined with `NoContent` (204) status, the client-side codec failed with:
```
Malformed request body failed to decode: Non-empty body cannot be decoded as Unit
```

The root cause was in `NettyResponse.make` which only checked for `Content-Length: 0` to determine if a response has an empty body. For 204 NoContent responses, the server correctly omits the `Content-Length` header entirely (per HTTP spec), causing the client to create an async streaming body which doesn't report as empty.

## Solution

Added a helper method `statusMustNotHaveBody` that checks for status codes that per HTTP specification must not have a body:
- 1xx Informational responses
- 204 No Content
- 304 Not Modified

The condition in `NettyResponse.make` now uses this check in addition to the existing `Content-Length: 0` check.

## Testing

Added two new tests to `RoundtripSpec`:
- `NoContent status returns empty body - issue #3861`
- `NotModified status returns empty body - issue #3861`