### PR TITLE
fix: Flag ZClient.request as deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
 
       - name: Compress target directories
-        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
+        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target zio-http-endpoint/jvm/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-core/jvm/target zio-http-benchmarks/target zio-http-netty/target zio-http-tools/target zio-http-example/target zio-http-core/js/target zio-http-testkit/target zio-http/js/target zio-http-endpoint/js/target zio-http-htmx/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
 
       - name: Compress target directories
-        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target zio-http-endpoint/jvm/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-core/jvm/target zio-http-benchmarks/target zio-http-netty/target zio-http-tools/target zio-http-example/target zio-http-core/js/target zio-http-testkit/target zio-http/js/target zio-http-endpoint/js/target zio-http-htmx/target project/target
+        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v5

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
@@ -2,6 +2,8 @@ package zio.http.endpoint.cli
 
 import java.nio.file.Path
 
+import scala.annotation.nowarn
+
 import zio._
 
 import zio.http._
@@ -27,6 +29,7 @@ private[cli] object Retriever {
   final case class URL(name: String, url: String, mediaType: MediaType) extends Retriever {
 
     val request                                                = Request.get(http.URL(http.Path.decode(url)))
+    @nowarn("msg=deprecated")
     override def retrieve(): ZIO[Client, Throwable, FormField] = for {
       client <- ZIO.serviceWith[Client](_.batched)
       chunk  <- client.request(request).flatMap(_.body.asChunk)

--- a/zio-http-example/src/main/scala/example/CurlLoggerExample.scala
+++ b/zio-http-example/src/main/scala/example/CurlLoggerExample.scala
@@ -1,9 +1,12 @@
 package example
 
+import scala.annotation.nowarn
+
 import zio._
 
 import zio.http._
 
+@nowarn("msg=deprecated")
 object CurlLoggerExample extends ZIOAppDefault {
   val program =
     for {

--- a/zio-http/jvm/src/test/scala/zio/http/ClientStreamingSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ClientStreamingSpec.scala
@@ -16,6 +16,8 @@
 
 package zio.http
 
+import scala.annotation.nowarn
+
 import zio._
 import zio.test.Assertion.{equalTo, fails, hasMessage}
 import zio.test.TestAspect._
@@ -29,6 +31,7 @@ import zio.http.internal.RoutesRunnableSpec
 import zio.http.netty.NettyConfig
 import zio.http.netty.NettyConfig.LeakDetectionLevel
 
+@nowarn("msg=deprecated")
 object ClientStreamingSpec extends RoutesRunnableSpec {
   def extractStatus(response: Response): Status = response.status
 

--- a/zio-http/jvm/src/test/scala/zio/http/RequestStreamingServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RequestStreamingServerSpec.scala
@@ -16,6 +16,8 @@
 
 package zio.http
 
+import scala.annotation.nowarn
+
 import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{diagnose, sequential, shrinks, withLiveClock}
@@ -25,6 +27,7 @@ import zio.http.ServerSpec.requestBodySpec
 import zio.http.internal.{DynamicServer, RoutesRunnableSpec}
 import zio.http.netty.NettyConfig
 
+@nowarn("msg=deprecated")
 object RequestStreamingServerSpec extends RoutesRunnableSpec {
   def extractStatus(res: Response): Status = res.status
 

--- a/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -27,6 +27,7 @@ import zio.stream.ZStream
 import zio.http.URL.Location
 import zio.http.netty.NettyConfig
 
+@nowarn("msg=deprecated")
 object ZClientAspectSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 

--- a/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -1,5 +1,7 @@
 package zio.http.netty
 
+import scala.annotation.nowarn
+
 import zio._
 import zio.test.TestAspect.withLiveClock
 import zio.test.{Spec, TestEnvironment, assertTrue}
@@ -13,6 +15,7 @@ import zio.http.multipart.mixed.MultipartMixed
 import zio.http.netty.NettyConfig.LeakDetectionLevel
 import zio.http.netty.NettyStreamBodySpec.app
 
+@nowarn("msg=deprecated")
 object NettyStreamBodySpec extends RoutesRunnableSpec {
 
   def app(streams: Iterator[ZStream[Any, Throwable, Byte]], len: Long) =

--- a/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
@@ -16,6 +16,8 @@
 
 package zio.http.netty.client
 
+import scala.annotation.nowarn
+
 import zio._
 import zio.test.Assertion.{equalTo, hasSize}
 import zio.test.TestAspect._
@@ -28,6 +30,7 @@ import zio.http.codec.PathCodec.trailing
 import zio.http.internal._
 import zio.http.netty.NettyConfig
 
+@nowarn("msg=deprecated")
 object NettyConnectionPoolSpec extends RoutesRunnableSpec {
 
   private val app = Routes(

--- a/zio-http/shared/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClient.scala
@@ -18,7 +18,7 @@ package zio.http
 
 import java.net.{InetSocketAddress, URI}
 
-import scala.annotation.unroll
+import scala.annotation.{nowarn, unroll}
 
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
@@ -39,6 +39,7 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
   bodyDecoder: ZClient.BodyDecoder[Env, Err, Out],
   driver: ZClient.Driver[Env, ReqEnv, Err],
 ) extends HeaderOps[ZClient[Env, ReqEnv, In, Err, Out]] { self =>
+  @nowarn("msg=deprecated")
   def apply(request: Request)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     self.request(request)
 
@@ -113,6 +114,7 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
       self.driver,
     )
 
+  @nowarn("msg=deprecated")
   def delete(suffix: String)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.DELETE, suffix)(ev(Body.empty))
 
@@ -125,9 +127,11 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
   def disableStreaming(implicit ev1: ReqEnv =:= Scope): ZClient[Env, Any, In, Err, Out] =
     batched
 
+  @nowarn("msg=deprecated")
   def get(suffix: String)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.GET, suffix)(ev(Body.empty))
 
+  @nowarn("msg=deprecated")
   def head(suffix: String)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.HEAD, suffix)(ev(Body.empty))
 
@@ -158,15 +162,18 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
   def updatePath(f: Path => Path): ZClient[Env, ReqEnv, In, Err, Out] =
     copy(url = url.copy(path = f(url.path)))
 
+  @nowarn("msg=deprecated")
   def patch(suffix: String)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.PATCH, suffix)(ev(Body.empty))
 
   def port(port: Int): ZClient[Env, ReqEnv, In, Err, Out] =
     copy(url = url.port(port))
 
+  @nowarn("msg=deprecated")
   def post(suffix: String)(body: In)(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.POST, suffix)(body)
 
+  @nowarn("msg=deprecated")
   def put(suffix: String)(body: In)(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.PUT, suffix)(body)
 
@@ -179,6 +186,7 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
   ): ZClient[Env, ReqEnv, In, Err2, Out] =
     transform(bodyEncoder.refineOrDie(pf), bodyDecoder.refineOrDie(pf), driver.refineOrDie(pf))
 
+  @deprecated("Use `batched` or `streaming` instead", since = "3.0.0")
   def request(request: Request)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] = {
     def makeRequest(body: Body) = {
       driver.request(
@@ -199,6 +207,7 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
         .flatMap(body => bodyDecoder.decodeZIO(makeRequest(body)))
   }
 
+  @deprecated("Use `batched` or `streaming` instead", since = "3.0.0")
   def request(method: Method, suffix: String)(body: In)(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     bodyEncoder
       .encode(body)
@@ -226,6 +235,7 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
    * Executes an HTTP request and transforms the response into a `ZStream` using
    * the provided function
    */
+  @nowarn("msg=deprecated")
   def stream[R, E0 >: Err, A](request: Request)(f: Out => ZStream[R, E0, A])(implicit
     trace: Trace,
     ev1: Body <:< In,
@@ -292,6 +302,7 @@ object ZClient extends ZClientPlatformSpecific {
    *   [[streaming]] for a variant that doesn't materialize the response body in
    *   memory, allowing to stream response bodies
    */
+  @nowarn("msg=deprecated")
   def batched(request: Request)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.batched.request(request))
 
@@ -308,6 +319,7 @@ object ZClient extends ZClientPlatformSpecific {
     )
 
   @deprecated("Use `batched` or `streaming` instead", since = "3.0.0")
+  @nowarn("msg=deprecated")
   def request(request: Request)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.request(request))
 
@@ -325,6 +337,7 @@ object ZClient extends ZClientPlatformSpecific {
    *   [[batched]] for a variant that doesn't require manual handling of the
    *   request's resources (i.e., `Scope`)
    */
+  @nowarn("msg=deprecated")
   def streaming(request: Request)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.request(request))
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -16,6 +16,8 @@
 
 package zio.http.endpoint.internal
 
+import scala.annotation.nowarn
+
 import zio._
 
 import zio.http._
@@ -27,6 +29,7 @@ private[endpoint] final case class EndpointClient[P, I, E, O, A <: AuthType](
   endpointRoot: URL,
   endpoint: Endpoint[P, I, E, O, A],
 ) {
+  @nowarn("msg=deprecated")
   def execute[R, ReqEnv](
     client: ZClient[Any, ReqEnv, Body, Throwable, Response],
     invocation: Invocation[P, I, E, O, A],


### PR DESCRIPTION
## Problem

The `request` method in the `ZClient` companion object was marked as deprecated, but the instance methods were not. This caused confusion for users who had a `ZClient` instance and called `request` directly without seeing any deprecation warning.

As noted in #3133:
> If you already have an instance of ZClient, the method request is still accessible and it's not obvious that it's oriented for streaming usage.

Fixes #3133

## Solution

* Added `@deprecated("Use batched or streaming instead", since = "3.0.0")` annotation to both `request` method overloads in the `ZClient` class
* Added `@nowarn("msg=deprecated")` to internal usages that legitimately call the deprecated method
* Updated test files with `@nowarn` to maintain compilation with `-Xfatal-warnings`

## Changes

* `zio-http/shared/src/main/scala/zio/http/ZClient.scala`
* `zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala`
* Test files updated with suppression annotations

## Testing

All existing tests compile and pass with the deprecation warnings properly suppressed.

/claim #3133