### PR TITLE
fix: Embedded route should not match root path (#3609)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -105,7 +105,7 @@ sealed trait PathCodec[A] extends codec.PathCodecPlatformSpecific { self =>
             )
           }
       case Segment(SegmentCodec.Empty)   =>
-        alts :+= codec.asInstanceOf[PathCodec[Any]]
+        if (alts.isEmpty) alts :+= codec.asInstanceOf[PathCodec[Any]]
       case pc                            =>
         if (alts.isEmpty) alts :+= pc.asInstanceOf[PathCodec[Any]]
         else


### PR DESCRIPTION
## Summary

Fixes #3609

When using embedded routes with a prefix like `literal("api") / Routes(...)`, hitting the root path `/` was incorrectly returning the response from the nested API route instead of the root route.

## Root Cause

The `PathCodec.alternatives` method was incorrectly adding `Empty` as a **separate alternative** when concatenated with other path segments. This caused `literal("api") / Routes(GET / "" -> ...)` to generate two route alternatives:
1. `/api` (correct)
2. `/` (incorrect - the root path)

When merging with `Routes(GET / "" -> ...)`, the API route's spurious root alternative was overwriting the legitimate root route.

## Fix

Changed the handling of `Segment(SegmentCodec.Empty)` in the `alternatives` method to only add it as an alternative when there are no other alternatives (i.e., when the path is truly just the root path), not when it's concatenated with other path segments.

## Test

Added a regression test that verifies:
- `/` returns "from / route"
- `/api` returns "from api route"

## Verification

- All RoutesSpec tests pass
- All PathCodecSpec tests pass
- All endpoint tests pass (192 tests)