### PR TITLE
fix: Formatting Root route pattern returns empty path (#3760)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -468,6 +468,10 @@ object RoutePatternSpec extends ZIOHttpSpec {
 
         assertTrue(routePattern.format((1, "abc")) == Right(Path("/users/1/posts/abc")))
       },
+      test("root - issue #3760") {
+        val routePattern = Method.GET / Root
+        assertTrue(routePattern.format(()) == Right(Path("/")))
+      },
     )
 
   def structureEquals = suite("structure equals")(

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -501,9 +501,7 @@ sealed trait PathCodec[A] extends codec.PathCodecPlatformSpecific { self =>
         loop(left, value)
     }
 
-    loop(self, value).map { path =>
-      if (path.nonEmpty) path.addLeadingSlash else path
-    }
+    loop(self, value).map(_.addLeadingSlash)
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #3760

- `PathCodec.format` was returning `Path("")` for `Root` instead of `Path("/")`
- The fix ensures all paths get a leading slash by unconditionally calling `addLeadingSlash` on the formatted path result

## Changes

- **PathCodec.scala**: Changed the format method to always add leading slash (previously only added it for non-empty paths)
- **RoutePatternSpec.scala**: Added test case verifying `Method.GET / Root` formats to `Path("/")`

## Test

```scala
test("root - issue #3760") {
  val routePattern = Method.GET / Root
  assertTrue(routePattern.format(()) == Right(Path("/")))
}
```