### PR TITLE
fix: Encode colons in query params for form-urlencoded compatibility

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
@@ -65,7 +65,7 @@ object DatastarRequest {
     while (idx <= lastIdx) {
       val segment = path.segments(idx)
       if (segment.nonEmpty && segment.head == '$') sb.append(segment)
-      else QueryParamEncoding.encodeComponentInto(path.segments(idx), Charsets.Http, sb, "%20")
+      else QueryParamEncoding.encodeComponentInto(path.segments(idx), Charsets.Http, sb, "%20", isPath = true)
       if (path.hasTrailingSlash || idx != lastIdx) sb.append('/')
       idx += 1
     }

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -295,6 +295,24 @@ object URLSpec extends ZIOHttpSpec {
           assertZIO(result)(isLeft)
         },
       ),
+      suite("query parameter encoding")(
+        test("colons in query param values should be percent-encoded") {
+          val url = URL.root.addQueryParam("pe", "http://example.com")
+          assertTrue(url.encode == "/?pe=http%3A%2F%2Fexample.com")
+        },
+        test("at-signs in query param values should be percent-encoded") {
+          val url = URL.root.addQueryParam("email", "user@example.com")
+          assertTrue(url.encode == "/?email=user%40example.com")
+        },
+        test("colons in path segments should NOT be percent-encoded") {
+          val url = URL(Path("/v1:validateAddress"))
+          assertTrue(url.encode == "/v1:validateAddress")
+        },
+        test("at-signs in path segments should NOT be percent-encoded") {
+          val url = URL(Path("/users/@me"))
+          assertTrue(url.encode == "/users/@me")
+        },
+      ),
       suite("relative resolution")(
         // next ones are edge cases
         test("absolute reference with relative base") {

--- a/zio-http/shared/src/main/scala/zio/http/Path.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Path.scala
@@ -134,7 +134,8 @@ final case class Path private[http] (flags: Path.Flags, segments: Chunk[String])
     var idx     = 0
     val lastIdx = segments.length - 1
     while (idx <= lastIdx) {
-      QueryParamEncoding.encodeComponentInto(segments(idx), Charsets.Http, sb, "%20")
+      // isPath = true allows ':' and '@' unescaped per RFC 3986 pchar rule
+      QueryParamEncoding.encodeComponentInto(segments(idx), Charsets.Http, sb, "%20", isPath = true)
       if (hasTrailingSlash || idx != lastIdx) sb.append('/')
       idx += 1
     }


### PR DESCRIPTION
## Summary

Fixes #3935 

Since PR #3870, colons (`:`) and at-signs (`@`) were left unescaped in both path segments and query parameters. However:
- **RFC 3986** allows these unescaped in `pchar` (path segments only)
- **application/x-www-form-urlencoded** requires them to be percent-encoded in query parameter values

This broke compatibility with systems expecting standard form-urlencoded format.

## Changes

- Added `isPath` parameter to `encodeComponentInto()` to distinguish encoding contexts
- **Path encoding** (`isPath=true`): allows `:` and `@` unescaped per RFC 3986 pchar rule
- **Query param encoding** (`isPath=false`, default): encodes `:` and `@` for form compatibility
- Added 4 regression tests covering both behaviors

## Before

```scala
URL.root.addQueryParam("pe", "http://example.com").encode
// Result: /?pe=http:%2F%2Fexample.com  (colon not encoded - WRONG)
```

## After

```scala
URL.root.addQueryParam("pe", "http://example.com").encode
// Result: /?pe=http%3A%2F%2Fexample.com  (colon encoded - CORRECT)
```

Path segments with colons still work correctly:
```scala
URL(Path("/v1:validateAddress")).encode
// Result: /v1:validateAddress  (colon preserved in path - CORRECT per RFC 3986)
```