### PR TITLE
fix: internalize new OpenAPI example methods to avoid public API change

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -75,7 +75,7 @@ object OpenAPIGen {
     def examples(schema: Schema[_], generate: Boolean): Map[String, OpenAPI.ReferenceOr.Or[OpenAPI.Example]] =
       examples(schema, generate, MediaType.application.json)
 
-    def examples(
+    private[openapi] def examples(
       schema: Schema[_],
       generate: Boolean,
       mediaType: MediaType,
@@ -151,7 +151,7 @@ object OpenAPIGen {
     def contentExamples(genExamples: Boolean): Map[String, OpenAPI.ReferenceOr.Or[OpenAPI.Example]] =
       contentExamples(genExamples, MediaType.application.json)
 
-    def contentExamples(
+    private[openapi] def contentExamples(
       genExamples: Boolean,
       mediaType: MediaType,
     ): Map[String, OpenAPI.ReferenceOr.Or[OpenAPI.Example]] =


### PR DESCRIPTION
## Summary

- Makes `MetaCodec.examples(schema, generate, mediaType)` and `AtomizedMetaCodecs.contentExamples(genExamples, mediaType)` method overloads `private[openapi]`
- These methods were added by #3863 as internal implementation details but were accidentally exposed as public API
- This change allows a **patch release** instead of requiring a minor version bump

## Changes

The new method overloads with `mediaType` parameter are only used internally within `OpenAPIGen` and don't need to be part of the public API.