### PR TITLE
Return 401 for missing/malformed Authorization header

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/Authorization401Spec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/Authorization401Spec.scala
@@ -1,0 +1,79 @@
+package zio.http.endpoint
+
+import zio.test._
+
+import zio.http._
+import zio.http.codec.HeaderCodec
+
+object Authorization401Spec extends ZIOHttpSpec {
+
+  override def spec =
+    suite("Authorization 401 Spec")(
+      test("Missing Authorization header with Bearer auth returns 401 Unauthorized") {
+        val endpoint = Endpoint(Method.GET / "secure")
+          .out[String]
+          .auth(AuthType.Bearer)
+        val route    = endpoint.implementHandler(handler((_: Unit) => "ok"))
+        val request  = Request(method = Method.GET, url = url"/secure")
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(
+          response.status == Status.Unauthorized,
+          response.header(Header.WWWAuthenticate).isDefined,
+        )
+      },
+      test("Missing Authorization header with Basic auth returns 401 Unauthorized") {
+        val endpoint = Endpoint(Method.GET / "secure")
+          .out[String]
+          .auth(AuthType.Basic)
+        val route    = endpoint.implementHandler(handler((_: Unit) => "ok"))
+        val request  = Request(method = Method.GET, url = url"/secure")
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(
+          response.status == Status.Unauthorized,
+          response.header(Header.WWWAuthenticate).isDefined,
+        )
+      },
+      test("Malformed Authorization header returns 401 Unauthorized") {
+        val endpoint = Endpoint(Method.GET / "secure")
+          .out[String]
+          .auth(AuthType.Bearer)
+        val route    = endpoint.implementHandler(handler((_: Unit) => "ok"))
+        val request  = Request(
+          method = Method.GET,
+          url = url"/secure",
+          headers = Headers("authorization", "InvalidScheme foobar"),
+        )
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(
+          response.status == Status.Unauthorized,
+        )
+      },
+      test("Missing non-auth header still returns 400 Bad Request") {
+        val endpoint = Endpoint(Method.GET / "test")
+          .header(HeaderCodec.accept)
+          .out[String]
+        val route    = endpoint.implementHandler(handler((_: Header.Accept) => "ok"))
+        val request  = Request(method = Method.GET, url = url"/test")
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(
+          response.status == Status.BadRequest,
+        )
+      },
+      test("Missing Authorization header via HeaderCodec.authorization returns 401") {
+        val endpoint = Endpoint(Method.GET / "secure")
+          .header(HeaderCodec.authorization)
+          .out[String]
+        val route    = endpoint.implementHandler(handler((_: Header.Authorization) => "ok"))
+        val request  = Request(method = Method.GET, url = url"/secure")
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(
+          response.status == Status.Unauthorized,
+        )
+      },
+    )
+}

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
@@ -17,8 +17,8 @@ sealed trait AuthType { self =>
       ]
 
   /**
-   * Returns the appropriate WWW-Authenticate header for this auth type,
-   * or None if no standard challenge is applicable.
+   * Returns the appropriate WWW-Authenticate header for this auth type, or None
+   * if no standard challenge is applicable.
    */
   def wwwAuthenticateHeader: Option[Header.WWWAuthenticate] = self match {
     case AuthType.Basic               => Some(Header.WWWAuthenticate.Basic())

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
@@ -16,6 +16,19 @@ sealed trait AuthType { self =>
         AuthType { type ClientRequirement = ClientReq },
       ]
 
+  /**
+   * Returns the appropriate WWW-Authenticate header for this auth type,
+   * or None if no standard challenge is applicable.
+   */
+  def wwwAuthenticateHeader: Option[Header.WWWAuthenticate] = self match {
+    case AuthType.Basic               => Some(Header.WWWAuthenticate.Basic())
+    case AuthType.Bearer              => Some(Header.WWWAuthenticate.Bearer(realm = "restricted"))
+    case AuthType.Digest              => Some(Header.WWWAuthenticate.Digest(realm = Some("restricted")))
+    case AuthType.Or(auth1, _, _)     => auth1.wwwAuthenticateHeader
+    case AuthType.ScopedAuth(auth, _) => auth.wwwAuthenticateHeader
+    case _                            => scala.None
+  }
+
 }
 
 object AuthType {

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -443,7 +443,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
                   case _          => Response.unauthorized
                 }
                 Handler.succeed(response)
-              case Some(_) =>
+              case Some(_)                                   =>
                 Handler.fromFunctionZIO { (request: zio.http.Request) =>
                   val error    = cause.defects.head.asInstanceOf[HttpCodecError]
                   val response = {
@@ -458,7 +458,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
                   }
                   ZIO.succeed(response)
                 }
-              case None    =>
+              case None                                      =>
                 Handler.failCause(cause)
             }
           }
@@ -1033,11 +1033,11 @@ object Endpoint {
 
   private def isAuthorizationError(cause: Cause[Any]): Boolean =
     cause.defects.exists {
-      case HttpCodecError.MissingHeader(name)        => name.toLowerCase == authHeaderName
-      case HttpCodecError.MissingHeaders(names)       => names.exists(_.toLowerCase == authHeaderName)
-      case HttpCodecError.MalformedHeader(name, _)    => name.toLowerCase == authHeaderName
+      case HttpCodecError.MissingHeader(name)          => name.toLowerCase == authHeaderName
+      case HttpCodecError.MissingHeaders(names)        => names.exists(_.toLowerCase == authHeaderName)
+      case HttpCodecError.MalformedHeader(name, _)     => name.toLowerCase == authHeaderName
       case HttpCodecError.DecodingErrorHeader(name, _) => name.toLowerCase == authHeaderName
-      case _                                          => false
+      case _                                           => false
     }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #3235. When an endpoint requires authentication via `.header(HeaderCodec.authorization)` or `.auth(AuthType.Bearer)`, a request without a valid Authorization header now returns **401 Unauthorized** instead of 400 Bad Request, per [RFC 7235 Section 3.1](https://www.rfc-editor.org/rfc/rfc7235#section-3.1).

## Changes

### `Endpoint.scala`
- Added `isAuthorizationError` helper that detects when a codec error is related to the Authorization header (handles `MissingHeader`, `MissingHeaders`, `MalformedHeader`, and `DecodingErrorHeader`)
- Added a case in the `catchAllCause` error handler that returns 401 with `WWW-Authenticate` header for auth-related errors

### `AuthType.scala`
- Added `wwwAuthenticateHeader` method that generates the appropriate `WWW-Authenticate` challenge value (e.g., `Bearer realm="restricted"`)

### Tests
- Missing Authorization header → 401 Unauthorized with WWW-Authenticate header
- Malformed Authorization header → 401 Unauthorized  
- Missing non-auth header → 400 Bad Request (regression guard)

## RFC Compliance
- **RFC 7235 §3.1**: "The server generating a 401 (Unauthorized) response MUST send a WWW-Authenticate header field"
- **RFC 6750 §3.1**: Malformed/invalid Authorization headers should also receive 401