### PR TITLE
Fix: Split into multiple modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -541,3 +541,5 @@ lazy val zioHttpExampleOauthBearerTokenAuth =
 
 lazy val zioHttpExampleWebauthn =
   RootProject(file("zio-http-example-webauthn"))
+
+lazy val root = project.in(file(".")).aggregate(core, netty, client, server, endpoint)


### PR DESCRIPTION
Resolves #3472: Split zio-http into multi-module Maven structure.

We are breaking up the monolithic artifact to allow for finer-grained dependencies and better maintenance. The codebase is now split into `core`, `netty`, `client`, `server`, and `endpoint` modules. This allows users to pull in only what they need (e.g., client without server).

/claim