### PR TITLE
CI: Add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - graal_graalvm@21
           - temurin@17
           - temurin@21
+          - temurin@25
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -75,6 +76,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+          cache: sbt
+
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt
@@ -167,6 +176,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+          cache: sbt
+
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.21, 2.13.18, 3.3.7]
+        scala: [2.12.x, 2.13.x, 3.x]
         java:
           - graal_graalvm@17
           - graal_graalvm@21
@@ -94,8 +94,8 @@ jobs:
           apps: sbt
 
       - name: Check formatting
-        if: matrix.scala == '2.13.18'
-        run: sbt ++2.13.18 fmtCheck
+        if: startsWith(matrix.scala, '2.13')
+        run: sbt ++${{ matrix.scala }} fmtCheck
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
@@ -109,10 +109,10 @@ jobs:
 
       - name: Check doc generation
         if: ${{ github.event_name == 'pull_request' }}
-        run: sbt ++2.13.18 doc
+        run: sbt ++${{ matrix.scala }} doc
 
       - name: zio-http-shaded Tests
-        if: matrix.scala == '2.13.18'
+        if: startsWith(matrix.scala, '2.13')
         env:
           PUBLISH_SHADED: true
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [graal_graalvm@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -189,32 +189,32 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.12.21)
+      - name: Download target directories (2.12.x)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-2.12.21-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.21)
+      - name: Inflate target directories (2.12.x)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.18)
+      - name: Download target directories (2.13.x)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-2.13.18-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.18)
+      - name: Inflate target directories (2.13.x)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.3.7)
+      - name: Download target directories (3.x)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-3.3.7-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.x-${{ matrix.java }}
 
-      - name: Inflate target directories (3.3.7)
+      - name: Inflate target directories (3.x)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -252,7 +252,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
@@ -279,7 +279,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -315,7 +315,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -353,7 +353,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -391,7 +391,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -429,7 +429,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -467,7 +467,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -505,7 +505,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -543,7 +543,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -581,7 +581,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -619,7 +619,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -657,7 +657,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -695,7 +695,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -733,7 +733,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -771,7 +771,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -809,7 +809,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -847,7 +847,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -885,7 +885,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -923,7 +923,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -961,7 +961,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -1000,7 +1000,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -1155,7 +1155,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -1234,7 +1234,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.18]
+        scala: [2.13.x]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

- Add `temurin@25` to the CI build matrix to test against JDK 25
- Use Scala version wildcards instead of hardcoded versions in CI matrices and conditions