### PR TITLE
fix: Unknown mode string now falls back to Prod instead of Dev (#3848)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Mode.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Mode.scala
@@ -20,9 +20,9 @@ object Mode {
     else if (str.equalsIgnoreCase("prod")) Prod
     else {
       Console.err.println(
-        s"[WARN] Unknown mode '$str', supported modes are 'dev', 'preprod' and 'prod'. Falling back to 'dev'.",
+        s"[WARN] Unknown mode '$str', supported modes are 'dev', 'preprod' and 'prod'. Falling back to 'prod'.",
       )
-      Dev
+      Prod
     }
 
   def isDev: Boolean     = current == Dev


### PR DESCRIPTION
## Summary

Fixes #3848

- When an unknown mode string was provided via `ZIO_HTTP_MODE` environment variable or `zio.http.mode` system property, the `Mode.fromString` method fell back to `Dev` mode. This could accidentally apply Dev-only loosening on security and verbosity to production environments.
- Changed the fallback from `Dev` to `Prod` and updated the warning message accordingly.