### PR TITLE
feat: Add OpenAPI endpoint summary support

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -44,7 +44,7 @@ object MimaSettings {
         ProblemFilters.exclude[MissingClassProblem]("zio.http.netty.NettyHeaderEncoding$"),
         exclude[Problem]("zio.http.template2.*"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.Route.toHandlerUnsandboxed"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|"),
       ),
       mimaFailOnProblem := failOnProblem,
     )

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -4725,6 +4725,59 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |}""".stripMargin
         assertTrue(json == toJsonAst(expectedJson))
       },
+      test("endpoint with summary to OpenAPI") {
+        val endpoint     = Endpoint(GET / "users")
+          .summary("List all users")
+          .out[SimpleOutputBody]
+        val generated    = OpenAPIGen.fromEndpoints("Summary Test", "1.0", endpoint)
+        val json         = toJsonAst(generated)
+        val expectedJson = """|{
+                              |  "openapi" : "3.1.0",
+                              |  "info" : {
+                              |    "title" : "Summary Test",
+                              |    "version" : "1.0"
+                              |  },
+                              |  "paths" : {
+                              |    "/users" : {
+                              |      "get" : {
+                              |        "summary" : "List all users",
+                              |        "responses" : {
+                              |          "200" : {
+                              |            "content" : {
+                              |              "application/json" : {
+                              |                "schema" : {
+                              |                  "$ref" : "#/components/schemas/SimpleOutputBody"
+                              |                }
+                              |              }
+                              |            }
+                              |          }
+                              |        }
+                              |      }
+                              |    }
+                              |  },
+                              |  "components" : {
+                              |    "schemas" : {
+                              |      "SimpleOutputBody" : {
+                              |        "type" : "object",
+                              |        "properties" : {
+                              |          "userName" : {
+                              |            "type" : "string"
+                              |          },
+                              |          "score" : {
+                              |            "type" : "integer",
+                              |            "format" : "int32"
+                              |          }
+                              |        },
+                              |        "required" : [
+                              |          "userName",
+                              |          "score"
+                              |        ]
+                              |      }
+                              |    }
+                              |  }
+                              |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
     )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -16,7 +16,7 @@
 
 package zio.http.endpoint
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, unroll}
 import scala.reflect.ClassTag
 
 import zio._
@@ -57,7 +57,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   codecError: HttpCodec[HttpCodecType.ResponseType, HttpCodecError],
   documentation: Doc,
   authType: Auth,
-  summary: Option[String] = None,
+  @unroll summary: Option[String] = None,
 ) extends EndpointPlatformSpecific[PathInput, Input, Err, Output, Auth] {
   self =>
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -57,6 +57,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   codecError: HttpCodec[HttpCodecType.ResponseType, HttpCodecError],
   documentation: Doc,
   authType: Auth,
+  summary: Option[String] = None,
 ) extends EndpointPlatformSpecific[PathInput, Input, Err, Output, Auth] {
   self =>
 
@@ -78,6 +79,12 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
    * additional documentation that will be included in OpenAPI generation.
    */
   def ??(that: Doc): Endpoint[PathInput, Input, Err, Output, Auth] = copy(documentation = self.documentation + that)
+
+  /**
+   * Returns a new endpoint with a short summary for OpenAPI documentation.
+   */
+  def summary(text: String): Endpoint[PathInput, Input, Err, Output, Auth] =
+    copy(summary = Some(text))
 
   /**
    * Flattens out this endpoint to a chunk of alternatives. Each alternative is
@@ -546,6 +553,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -563,6 +571,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -580,6 +589,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -597,6 +607,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -614,6 +625,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -649,6 +661,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -667,6 +680,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -685,6 +699,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -704,6 +719,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -722,6 +738,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
 
   /**
@@ -811,6 +828,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
   }
 
@@ -835,6 +853,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
   }
 
@@ -859,6 +878,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
   }
 
@@ -895,6 +915,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
   }
 
@@ -913,6 +934,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       codecError,
       documentation,
       authType,
+      summary,
     )
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -742,7 +742,7 @@ object OpenAPIGen {
       val maybeDoc = Some(endpoint.documentation + pathDoc).filter(!_.isEmpty)
       OpenAPI.Operation(
         tags = endpoint.tags,
-        summary = None,
+        summary = endpoint.summary,
         description = maybeDoc,
         externalDocs = None,
         operationId = None,


### PR DESCRIPTION
## Summary

Closes #3862

Adds support for setting a `summary` on `Endpoint` that flows through to the generated OpenAPI specification.

### Changes

- **`Endpoint.scala`**: Added `summary: Option[String] = None` field to the `Endpoint` case class and a `.summary(text: String)` builder method. Also propagated the `summary` field through all 15 explicit positional constructor calls in methods like `out`, `outStream`, `inStream`, `header`, `query`, etc. to prevent the field from being silently reset to `None`.
- **`OpenAPIGen.scala`**: Wired `endpoint.summary` into `OpenAPI.Operation` construction (line 745).
- **`OpenAPIGenSpec.scala`**: Added test verifying that `summary` appears in generated OpenAPI JSON.

### Usage

```scala
val endpoint = Endpoint(GET / "users")
  .summary("List all users")
  .out[List[User]]
```

Generates:
```json
{
  "paths": {
    "/users": {
      "get": {
        "summary": "List all users",
        ...
      }
    }
  }
}
```