### PR TITLE
fix: Handle race condition in NettyConnectionPool channel refresh

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -171,14 +171,18 @@ private[netty] object NettyConnectionPool {
     channel: JChannel,
     timeout: Duration,
   ): Boolean = {
-    channel
-      .pipeline()
-      .replace(
-        Names.ReadTimeoutHandler,
-        Names.ReadTimeoutHandler,
-        new ReadTimeoutHandler(timeout.toMillis, TimeUnit.MILLISECONDS),
-      )
-    channel.isOpen
+    try {
+      channel
+        .pipeline()
+        .replace(
+          Names.ReadTimeoutHandler,
+          Names.ReadTimeoutHandler,
+          new ReadTimeoutHandler(timeout.toMillis, TimeUnit.MILLISECONDS),
+        )
+      channel.isOpen
+    } catch {
+      case _: NoSuchElementException => false
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #3268

Fixes a race condition in `NettyConnectionPool.refreshIdleTimeoutHandler` where `pipeline().replace()` throws `NoSuchElementException` when the `READ_TIMEOUT_HANDLER` has already been removed from a concurrently closing channel.

### Root Cause

When a channel is being closed, Netty removes handlers from the pipeline. If `refreshIdleTimeoutHandler` is called between the `channel.isOpen` check (line 302) and the actual `pipeline().replace()` call, the handler may already be gone, causing:

```
java.util.NoSuchElementException: READ_TIMEOUT_HANDLER
  at io.netty.channel.DefaultChannelPipeline.getContextOrDie
  at io.netty.channel.DefaultChannelPipeline.replace
  at zio.http.netty.client.NettyConnectionPool$.refreshIdleTimeoutHandler
```

This crashes the fiber instead of gracefully retrying with a fresh channel.

### Fix

Wrap the `pipeline().replace()` call in a try-catch that catches `NoSuchElementException` and returns `false`. This causes the caller to take the invalidation path — invalidating the stale channel and retrying with a fresh one from the pool — which is the correct behavior for a closing channel.