### PR TITLE
feat: Add Route#handleErrorRequestZIO for symmetry (#3159)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -402,6 +402,20 @@ object RouteSpec extends ZIOHttpSpec {
           body == "handleErrorCause",
         )
       },
+      test("handleErrorRequestZIO should handle typed errors with request info") {
+        val route        = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
+        val errorHandled = route.handleErrorRequestZIO { (err, req) =>
+          ZIO.succeed(Response.internalServerError(s"error: ${err.getMessage} path: ${req.path.encode}"))
+        }
+        val request      = Request.get(URL.decode("/endpoint").toOption.get)
+        for {
+          response <- errorHandled.toRoutes.runZIO(request)
+          body     <- response.body.asString
+        } yield assertTrue(
+          extractStatus(response) == Status.InternalServerError,
+          body == "error: hmm... path: /endpoint",
+        )
+      },
     ),
     test("Handled#toHandler should not suspend") {
       val request = Request(headers = Headers.empty, method = Method.GET)

--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -416,6 +416,22 @@ object RouteSpec extends ZIOHttpSpec {
           body == "error: hmm... path: /endpoint",
         )
       },
+      test("handleErrorRequestZIO should propagate defects without calling error handler") {
+        val route        = Method.GET / "endpoint" -> handler { (_: Request) =>
+          ZIO.die(new RuntimeException("boom"))
+        }
+        val errorHandled = route.handleErrorRequestZIO { (_: Throwable, _: Request) =>
+          ZIO.succeed(Response.text("should not be called"))
+        }
+        val request      = Request.get(URL.decode("/endpoint").toOption.get)
+        for {
+          response <- errorHandled.toRoutes.runZIO(request)
+          body     <- response.body.asString
+        } yield assertTrue(
+          extractStatus(response) == Status.InternalServerError,
+          !body.contains("should not be called"),
+        )
+      },
     ),
     test("Handled#toHandler should not suspend") {
       val request = Request(headers = Headers.empty, method = Method.GET)

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -242,6 +242,25 @@ sealed trait Route[-Env, +Err] { self =>
     )
 
   /**
+   * Handles all typed errors in the route by converting them into a ZIO effect
+   * that produces a response, taking into account the request that caused the
+   * error. This method can be used to convert a route that does not handle its
+   * errors into one that does handle its errors.
+   *
+   * If the underlying handler uses the error channel to send responses, this
+   * method will not pass the responses to the provided function.
+   */
+  final def handleErrorRequestZIO[Env1 <: Env](
+    f: (Err, Request) => ZIO[Env1, Nothing, Response],
+  )(implicit trace: Trace): Route[Env1, Nothing] =
+    self.handleErrorRequestCauseZIO { (request, cause) =>
+      cause.failureOrCause match {
+        case Left(err)    => f(err, request)
+        case Right(cause) => ZIO.refailCause(cause)
+      }
+    }
+
+  /**
    * Handles all typed errors, as well as all non-recoverable errors, by
    * converting them into responses, taking into account the request that caused
    * the error. This method can be used to convert a route that does not handle

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -256,7 +256,7 @@ sealed trait Route[-Env, +Err] { self =>
     self.handleErrorRequestCauseZIO { (request, cause) =>
       cause.failureOrCause match {
         case Left(err)    => f(err, request)
-        case Right(cause) => ZIO.refailCause(cause)
+        case Right(cause) => ErrorResponseConfig.configRef.getWith(c => ZIO.succeed(Response.fromCause(cause, c)))
       }
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -256,7 +256,7 @@ sealed trait Route[-Env, +Err] { self =>
     self.handleErrorRequestCauseZIO { (request, cause) =>
       cause.failureOrCause match {
         case Left(err)    => f(err, request)
-        case Right(cause) => ErrorResponseConfig.configRef.getWith(c => ZIO.succeed(Response.fromCause(cause, c)))
+        case Right(cause) => ZIO.refailCause(cause.asInstanceOf[Cause[Nothing]])
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds `Route#handleErrorRequestZIO` method that handles typed errors by converting them into a `ZIO` effect that produces a `Response`, while also receiving the `Request` that caused the error
- This method follows ZIO conventions: **typed errors are handled by the user function, defects are refailed/propagated** (not caught)
- This fills a gap in the error handling API: `handleErrorZIO` exists (without request), `handleErrorRequest` exists (without ZIO), `handleErrorRequestCauseZIO` exists (with cause) — but `handleErrorRequestZIO` (with request + ZIO, typed errors only) was missing

## Changes

- **`Route.scala`**: Added `handleErrorRequestZIO` method that delegates to `handleErrorRequestCauseZIO`, matching typed failures with `failureOrCause` and using `ZIO.refailCause` for defects (consistency with `handleErrorZIO`)
- **`RouteSpec.scala`**: Added test verifying that defects propagate without invoking the error handler function

## Closes #3159