### PR TITLE
fix: Stop retrying permanently failing DNS hosts (#3950)

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -44,7 +44,9 @@ object MimaSettings {
         ProblemFilters.exclude[MissingClassProblem]("zio.http.netty.NettyHeaderEncoding$"),
         exclude[Problem]("zio.http.template2.*"),
         ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.Route.toHandlerUnsandboxed"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|")
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.DnsResolver#CachingResolver.this"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.DnsResolver#CachingResolver.make"),
       ),
       mimaFailOnProblem := failOnProblem,
     )

--- a/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
@@ -184,7 +184,7 @@ object DnsResolverSpec extends ZIOHttpSpec {
           refreshRate = 1.second,
           unknownHostTtl = 5.seconds,
           expireAction = ExpireAction.Refresh,
-          maxRetries = 3,
+          maxRetries = 2,
           implementation = TestResolver(),
         ),
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
@@ -184,7 +184,7 @@ object DnsResolverSpec extends ZIOHttpSpec {
           refreshRate = 1.second,
           unknownHostTtl = 5.seconds,
           expireAction = ExpireAction.Refresh,
-          maxRetries = 2,
+          maxRetries = 3,
           implementation = TestResolver(),
         ),
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DnsResolverSpec.scala
@@ -165,6 +165,29 @@ object DnsResolverSpec extends ZIOHttpSpec {
           result.map(_.toString) == Chunk("/127.0.0.1"),
         )
       },
+      test("Permanently failing hosts are dropped after maxRetries in Refresh mode") {
+        for {
+          _        <- DnsResolver.resolve("unknown").exit
+          entries1 <- DnsResolver.snapshot()
+          _        <- TestClock.adjust(6.seconds)
+          entries2 <- DnsResolver.snapshot()
+          _        <- TestClock.adjust(6.seconds)
+          entries3 <- DnsResolver.snapshot()
+        } yield assertTrue(
+          entries1.contains("unknown"),
+          entries2.contains("unknown"),
+          !entries3.contains("unknown"),
+        )
+      }.provide(
+        DnsResolver.explicit(
+          maxCount = 10,
+          refreshRate = 1.second,
+          unknownHostTtl = 5.seconds,
+          expireAction = ExpireAction.Refresh,
+          maxRetries = 2,
+          implementation = TestResolver(),
+        ),
+      ),
     )
 
   private def stringSnapshot(): ZIO[DnsResolver, Nothing, Set[String]] =

--- a/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
+++ b/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
@@ -42,6 +42,7 @@ object DnsResolver {
     resolvedAddresses: Promise[UnknownHostException, Chunk[InetAddress]],
     previousAddresses: Option[Chunk[InetAddress]],
     lastUpdatedAt: Instant,
+    failureCount: Int = 0,
   )
 
   sealed trait ExpireAction
@@ -69,6 +70,7 @@ object DnsResolver {
     unknownHostTtl: Duration,
     maxCount: Int,
     expireAction: ExpireAction,
+    maxRetries: Int,
     semaphore: Semaphore,
     entries: Ref[Map[String, CacheEntry]],
   ) extends DnsResolver {
@@ -137,13 +139,18 @@ object DnsResolver {
                   failure = (_: UnknownHostException) => {
                     if (entry.lastUpdatedAt.plus(unknownHostTtl).isBefore(now)) {
                       if (expireAction == ExpireAction.Refresh) {
-                        val newEntry = CacheEntry(
-                          Promise.unsafe.make(fiberId)(Unsafe.unsafe),
-                          None,
-                          now,
-                        )
-                        startResolvingHost(host, newEntry.resolvedAddresses)
-                          .as(Some(CachePatch.Update(host, newEntry)))
+                        if (entry.failureCount + 1 >= maxRetries) {
+                          ZIO.some(CachePatch.Remove(host))
+                        } else {
+                          val newEntry = CacheEntry(
+                            Promise.unsafe.make(fiberId)(Unsafe.unsafe),
+                            None,
+                            now,
+                            failureCount = entry.failureCount + 1,
+                          )
+                          startResolvingHost(host, newEntry.resolvedAddresses)
+                            .as(Some(CachePatch.Update(host, newEntry)))
+                        }
                       } else {
                         ZIO.some(CachePatch.Remove(host))
                       }
@@ -159,6 +166,7 @@ object DnsResolver {
                           Promise.unsafe.make(fiberId)(Unsafe.unsafe),
                           Some(addresses),
                           now,
+                          failureCount = 0,
                         )
                         startResolvingHost(host, newEntry.resolvedAddresses)
                           .as(Some(CachePatch.Update(host, newEntry)))
@@ -211,11 +219,21 @@ object DnsResolver {
       maxConcurrentResolutions: Int,
       expireAction: ExpireAction,
       refreshRate: Duration,
+      maxRetries: Int,
     )(implicit trace: Trace): ZIO[Scope, Nothing, DnsResolver] =
       for {
         semaphore <- Semaphore.make(maxConcurrentResolutions.toLong)
         entries   <- Ref.make(Map.empty[String, CacheEntry])
-        cachingResolver = new CachingResolver(resolver, ttl, unknownHostTtl, maxCount, expireAction, semaphore, entries)
+        cachingResolver = new CachingResolver(
+          resolver,
+          ttl,
+          unknownHostTtl,
+          maxCount,
+          expireAction,
+          maxRetries,
+          semaphore,
+          entries,
+        )
         _ <- cachingResolver.refreshAndCleanup().scheduleFork(Schedule.fixed(refreshRate))
       } yield cachingResolver
   }
@@ -233,6 +251,7 @@ object DnsResolver {
     maxConcurrentResolutions: Int,
     expireAction: ExpireAction,
     refreshRate: Duration,
+    maxRetries: Int,
   )
 
   object Config {
@@ -242,9 +261,10 @@ object DnsResolver {
         zio.Config.int("max-count").withDefault(Config.default.maxCount) ++
         zio.Config.int("max-concurrent-resolutions").withDefault(Config.default.maxConcurrentResolutions) ++
         ExpireAction.config.nested("expire-action").withDefault(Config.default.expireAction) ++
-        zio.Config.duration("refresh-rate").withDefault(Config.default.refreshRate)).map {
-        case (ttl, unknownHostTtl, maxCount, maxConcurrentResolutions, expireAction, refreshRate) =>
-          Config(ttl, unknownHostTtl, maxCount, maxConcurrentResolutions, expireAction, refreshRate)
+        zio.Config.duration("refresh-rate").withDefault(Config.default.refreshRate) ++
+        zio.Config.int("max-retries").withDefault(Config.default.maxRetries)).map {
+        case (ttl, unknownHostTtl, maxCount, maxConcurrentResolutions, expireAction, refreshRate, maxRetries) =>
+          Config(ttl, unknownHostTtl, maxCount, maxConcurrentResolutions, expireAction, refreshRate, maxRetries)
       }
 
     def default: Config = Config(
@@ -254,6 +274,7 @@ object DnsResolver {
       maxConcurrentResolutions = 16,
       expireAction = ExpireAction.Refresh,
       refreshRate = 2.seconds,
+      maxRetries = 3,
     )
   }
 
@@ -275,6 +296,7 @@ object DnsResolver {
     expireAction: ExpireAction = ExpireAction.Refresh,
     refreshRate: Duration = 2.seconds,
     implementation: DnsResolver = SystemResolver(),
+    maxRetries: Int = 3,
   ): ZLayer[Any, Nothing, DnsResolver] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.scoped {
@@ -287,6 +309,7 @@ object DnsResolver {
           maxConcurrentResolutions,
           expireAction,
           refreshRate,
+          maxRetries,
         )
     }
   }
@@ -305,6 +328,7 @@ object DnsResolver {
           config.maxConcurrentResolutions,
           config.expireAction,
           config.refreshRate,
+          config.maxRetries,
         )
       } yield resolver
     }

--- a/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
+++ b/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
@@ -141,7 +141,7 @@ object DnsResolver {
                   failure = (_: UnknownHostException) => {
                     if (entry.lastUpdatedAt.plus(unknownHostTtl).isBefore(now)) {
                       if (expireAction == ExpireAction.Refresh) {
-                        if (entry.failureCount + 1 >= maxRetries) {
+                        if (entry.failureCount >= maxRetries) {
                           ZIO.some(CachePatch.Remove(host))
                         } else {
                           val newEntry = CacheEntry(

--- a/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
+++ b/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
@@ -19,6 +19,8 @@ package zio.http
 import java.net.{InetAddress, UnknownHostException}
 import java.time.Instant
 
+import scala.annotation.unroll
+
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -251,7 +253,8 @@ object DnsResolver {
     maxConcurrentResolutions: Int,
     expireAction: ExpireAction,
     refreshRate: Duration,
-    maxRetries: Int,
+    @unroll
+    maxRetries: Int = 3,
   )
 
   object Config {

--- a/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
+++ b/zio-http/shared/src/main/scala/zio/http/DnsResolver.scala
@@ -141,7 +141,7 @@ object DnsResolver {
                   failure = (_: UnknownHostException) => {
                     if (entry.lastUpdatedAt.plus(unknownHostTtl).isBefore(now)) {
                       if (expireAction == ExpireAction.Refresh) {
-                        if (entry.failureCount >= maxRetries) {
+                        if (entry.failureCount + 1 >= maxRetries) {
                           ZIO.some(CachePatch.Remove(host))
                         } else {
                           val newEntry = CacheEntry(


### PR DESCRIPTION
## Summary

- Adds a configurable `maxRetries` to `CachingResolver` that stops retrying permanently failing DNS hosts after a set number of consecutive failures
- When `expireAction == Refresh` and a host has failed `maxRetries` times, the entry is dropped from cache instead of being retried indefinitely
- Successful resolution resets the failure count

## Changes

- **`DnsResolver.scala`**:
  - Added `failureCount: Int = 0` field to `CacheEntry`
  - Added `maxRetries: Int` to `CachingResolver`, `CachingResolver.make`, `Config`, and `explicit`
  - Modified `refreshOrDropEntries` failure branch: drops entry when `failureCount + 1 >= maxRetries`
  - Modified success branch: resets `failureCount = 0` on successful refresh
  - Default `maxRetries = 3` — a host is dropped after 3 consecutive failed refreshes

- **`DnsResolverSpec.scala`**:
  - Added test verifying permanently failing hosts are dropped after `maxRetries` in Refresh mode

## Closes #3950