### PR TITLE
fix: Handle nested sealed trait hierarchies in TextBinaryCodec and JsonSchema (#3801, #3946)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val ZioVersion                   = "2.1.24"
   val ZioCliVersion                = "0.8.0"
   val ZioJsonVersion               = "0.9.0"
-  val ZioSchemaVersion             = "1.8.1"
+  val ZioSchemaVersion             = "1.8.2"
   val SttpVersion                  = "3.3.18"
   val ZioConfigVersion             = "4.0.6"
 

--- a/zio-http/jvm/src/test/scala/zio/http/codec/TextBinaryCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/TextBinaryCodecSpec.scala
@@ -10,19 +10,6 @@ import zio.http.ZIOHttpSpec
 
 object TextBinaryCodecSpec extends ZIOHttpSpec {
 
-  @simpleEnum sealed trait Fruit
-  object Fruit {
-    case object Apple extends Fruit
-
-    @simpleEnum sealed trait Citrus extends Fruit
-    object Citrus {
-      case object Orange extends Citrus
-      case object Lemon  extends Citrus
-    }
-
-    implicit val schema: Schema[Fruit] = DeriveSchema.gen[Fruit]
-  }
-
   @simpleEnum sealed trait Color
   object Color {
     case object Red   extends Color
@@ -33,38 +20,6 @@ object TextBinaryCodecSpec extends ZIOHttpSpec {
   }
 
   override def spec = suite("TextBinaryCodecSpec")(
-    suite("nested @simpleEnum sealed trait")(
-      test("encode Apple") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.encode(Fruit.Apple)
-        assertTrue(result == Chunk.fromArray("Apple".getBytes))
-      },
-      test("encode Orange (nested)") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.encode(Fruit.Citrus.Orange)
-        assertTrue(result == Chunk.fromArray("Orange".getBytes))
-      },
-      test("encode Lemon (nested)") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.encode(Fruit.Citrus.Lemon)
-        assertTrue(result == Chunk.fromArray("Lemon".getBytes))
-      },
-      test("decode Apple") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.decode(Chunk.fromArray("Apple".getBytes))
-        assertTrue(result == Right(Fruit.Apple))
-      },
-      test("decode Orange (nested)") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.decode(Chunk.fromArray("Orange".getBytes))
-        assertTrue(result == Right(Fruit.Citrus.Orange))
-      },
-      test("decode Lemon (nested)") {
-        val codec  = TextBinaryCodec.fromSchema[Fruit]
-        val result = codec.decode(Chunk.fromArray("Lemon".getBytes))
-        assertTrue(result == Right(Fruit.Citrus.Lemon))
-      },
-    ),
     suite("flat @simpleEnum sealed trait (backward compatibility)")(
       test("encode Red") {
         val codec  = TextBinaryCodec.fromSchema[Color]

--- a/zio-http/jvm/src/test/scala/zio/http/codec/TextBinaryCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/TextBinaryCodecSpec.scala
@@ -1,0 +1,87 @@
+package zio.http.codec
+
+import zio._
+import zio.test._
+
+import zio.schema._
+import zio.schema.annotation.simpleEnum
+
+import zio.http.ZIOHttpSpec
+
+object TextBinaryCodecSpec extends ZIOHttpSpec {
+
+  @simpleEnum sealed trait Fruit
+  object Fruit {
+    case object Apple extends Fruit
+
+    @simpleEnum sealed trait Citrus extends Fruit
+    object Citrus {
+      case object Orange extends Citrus
+      case object Lemon  extends Citrus
+    }
+
+    implicit val schema: Schema[Fruit] = DeriveSchema.gen[Fruit]
+  }
+
+  @simpleEnum sealed trait Color
+  object Color {
+    case object Red   extends Color
+    case object Green extends Color
+    case object Blue  extends Color
+
+    implicit val schema: Schema[Color] = DeriveSchema.gen[Color]
+  }
+
+  override def spec = suite("TextBinaryCodecSpec")(
+    suite("nested @simpleEnum sealed trait")(
+      test("encode Apple") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.encode(Fruit.Apple)
+        assertTrue(result == Chunk.fromArray("Apple".getBytes))
+      },
+      test("encode Orange (nested)") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.encode(Fruit.Citrus.Orange)
+        assertTrue(result == Chunk.fromArray("Orange".getBytes))
+      },
+      test("encode Lemon (nested)") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.encode(Fruit.Citrus.Lemon)
+        assertTrue(result == Chunk.fromArray("Lemon".getBytes))
+      },
+      test("decode Apple") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.decode(Chunk.fromArray("Apple".getBytes))
+        assertTrue(result == Right(Fruit.Apple))
+      },
+      test("decode Orange (nested)") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.decode(Chunk.fromArray("Orange".getBytes))
+        assertTrue(result == Right(Fruit.Citrus.Orange))
+      },
+      test("decode Lemon (nested)") {
+        val codec  = TextBinaryCodec.fromSchema[Fruit]
+        val result = codec.decode(Chunk.fromArray("Lemon".getBytes))
+        assertTrue(result == Right(Fruit.Citrus.Lemon))
+      },
+    ),
+    suite("flat @simpleEnum sealed trait (backward compatibility)")(
+      test("encode Red") {
+        val codec  = TextBinaryCodec.fromSchema[Color]
+        val result = codec.encode(Color.Red)
+        assertTrue(result == Chunk.fromArray("Red".getBytes))
+      },
+      test("decode Green") {
+        val codec  = TextBinaryCodec.fromSchema[Color]
+        val result = codec.decode(Chunk.fromArray("Green".getBytes))
+        assertTrue(result == Right(Color.Green))
+      },
+      test("roundtrip Blue") {
+        val codec   = TextBinaryCodec.fromSchema[Color]
+        val encoded = codec.encode(Color.Blue)
+        val decoded = codec.decode(encoded)
+        assertTrue(decoded == Right(Color.Blue))
+      },
+    ),
+  )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -26,7 +26,7 @@ import zio.test._
 import zio.stream.ZStream
 
 import zio.schema._
-import zio.schema.annotation.validate
+import zio.schema.annotation.{noDiscriminator, validate}
 import zio.schema.validation.Validation
 
 import zio.http.Method._
@@ -34,6 +34,7 @@ import zio.http._
 import zio.http.codec.HttpContentCodec.protobuf
 import zio.http.codec._
 import zio.http.endpoint.EndpointSpec.ImageMetadata
+import zio.http.endpoint.openapi.OpenAPIGen
 import zio.http.netty.NettyConfig
 
 object RoundtripSpec extends ZIOHttpSpec {
@@ -89,6 +90,26 @@ object RoundtripSpec extends ZIOHttpSpec {
   case class OptOut(age: Option[Int], name: Option[String])
 
   implicit val optOutSchema: Schema[OptOut] = DeriveSchema.gen[OptOut]
+
+  @noDiscriminator
+  sealed trait NestedShape
+  object NestedShape {
+    implicit val schema: Schema[NestedShape] = DeriveSchema.gen[NestedShape]
+
+    sealed trait Polygon extends NestedShape
+    object Polygon {
+      case class Triangle(base: Double, height: Double) extends Polygon
+      object Triangle { implicit val schema: Schema[Triangle] = DeriveSchema.gen[Triangle] }
+      case class Rectangle(width: Double, length: Double) extends Polygon
+      object Rectangle { implicit val schema: Schema[Rectangle] = DeriveSchema.gen[Rectangle] }
+    }
+
+    sealed trait Curved extends NestedShape
+    object Curved {
+      case class Circle(radius: Double) extends Curved
+      object Circle { implicit val schema: Schema[Circle] = DeriveSchema.gen[Circle] }
+    }
+  }
 
   case class Name(firstName: String, lastName: String)
 
@@ -779,6 +800,27 @@ object RoundtripSpec extends ZIOHttpSpec {
             response.body.asString.map(s =>
               assertTrue(s.contains("Malformed request body failed to decode: (extra field)")),
             ),
+        )
+      }
+      test("round-trip nested sealed trait hierarchy through endpoint") {
+        val api   = Endpoint(POST / "shapes").in[NestedShape].out[NestedShape]
+        val route = api.implementPurely((shape: NestedShape) => shape)
+
+        val triangle: NestedShape  = NestedShape.Polygon.Triangle(3.0, 4.0)
+        val rectangle: NestedShape = NestedShape.Polygon.Rectangle(5.0, 10.0)
+        val circle: NestedShape    = NestedShape.Curved.Circle(2.5)
+
+        testEndpoint(api, Routes(route), triangle, triangle) &&
+        testEndpoint(api, Routes(route), rectangle, rectangle) &&
+        testEndpoint(api, Routes(route), circle, circle)
+      }
+      test("OpenAPI spec for nested sealed trait has flat oneOf with leaf types only") {
+        val api       = Endpoint(POST / "shapes").in[NestedShape].out[NestedShape]
+        val generated = OpenAPIGen.fromEndpoints("Shapes API", "1.0", api)
+        val json      = generated.toJson
+        assertTrue(
+          !json.contains("Polygon") && !json.contains("Curved"),
+          json.contains("Triangle") && json.contains("Rectangle") && json.contains("Circle"),
         )
       }
 

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -114,6 +114,23 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
     case class NestedThree(name: String) extends SimpleNestedSealedTrait
   }
 
+  @noDiscriminator
+  sealed trait NestedAnimal
+
+  object NestedAnimal    {
+    implicit val schema: Schema[NestedAnimal] = DeriveSchema.gen[NestedAnimal]
+
+    sealed trait Dog extends NestedAnimal
+    object Dog {
+      case class GoldenRetriever(name: String) extends Dog
+    }
+
+    sealed trait Fish extends NestedAnimal
+    object Fish {
+      case class Bass(color: String) extends Fish
+    }
+  }
+
   @description("A recursive structure")
   case class Recursive(
     nestedOption: Option[Recursive],
@@ -124,11 +141,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
     nestedTuple: (Recursive, Recursive),
     nestedOverAnother: NestedRecursive,
   )
-  object Recursive               {
+  object Recursive       {
     implicit val schema: Schema[Recursive] = DeriveSchema.gen[Recursive]
   }
   case class NestedRecursive(next: Recursive)
-  object NestedRecursive         {
+  object NestedRecursive {
     implicit val schema: Schema[NestedRecursive] = DeriveSchema.gen[NestedRecursive]
   }
 
@@ -3339,6 +3356,81 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          },
             |          {
             |            "$ref" : "#/components/schemas/NestedThree"
+            |          }
+            |        ]
+            |      }
+            |    }
+            |  }
+            |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("nested sealed trait hierarchy flattened to leaf types") {
+        val endpoint     = Endpoint(GET / "static").in[NestedAnimal]
+        val generated    = OpenAPIGen.fromEndpoints("Simple Endpoint", "1.0", endpoint)
+        val json         = toJsonAst(generated)
+        val expectedJson =
+          """{
+            |  "openapi" : "3.1.0",
+            |  "info" : {
+            |    "title" : "Simple Endpoint",
+            |    "version" : "1.0"
+            |  },
+            |  "paths" : {
+            |    "/static" : {
+            |      "get" : {
+            |        "requestBody" :
+            |          {
+            |          "content" : {
+            |            "application/json" : {
+            |              "schema" :
+            |                {
+            |                "$ref" : "#/components/schemas/NestedAnimal"
+            |              }
+            |            }
+            |          },
+            |          "required" : true
+            |        }
+            |      }
+            |    }
+            |  },
+            |  "components" : {
+            |    "schemas" : {
+            |      "Bass" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "color" : {
+            |            "type" :
+            |              "string"
+            |          }
+            |        },
+            |        "required" : [
+            |          "color"
+            |        ]
+            |      },
+            |      "GoldenRetriever" :
+            |        {
+            |        "type" :
+            |          "object",
+            |        "properties" : {
+            |          "name" : {
+            |            "type" :
+            |              "string"
+            |          }
+            |        },
+            |        "required" : [
+            |          "name"
+            |        ]
+            |      },
+            |      "NestedAnimal" :
+            |        {
+            |        "oneOf" : [
+            |          {
+            |            "$ref" : "#/components/schemas/GoldenRetriever"
+            |          },
+            |          {
+            |            "$ref" : "#/components/schemas/Bass"
             |          }
             |        ]
             |      }

--- a/zio-http/shared/src/main/scala/zio/http/codec/TextBinaryCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/TextBinaryCodec.scala
@@ -52,14 +52,20 @@ object TextBinaryCodec {
             codec.streamDecoder.map(v => Some(v).asInstanceOf[A])
         }
       case enum0: Schema.Enum[_] if enum0.annotations.exists(_.isInstanceOf[simpleEnum]) =>
-        val stringCodec    = fromSchema(Schema.Primitive(StandardType.StringType)).asInstanceOf[BinaryCodec[String]]
-        val caseMap        = enum0.nonTransientCases
-          .map(case_ =>
-            case_.schema.asInstanceOf[Schema.CaseClass0[A]].defaultConstruct() ->
-              case_.caseName,
-          )
-          .toMap
-        val reverseCaseMap = caseMap.map(_.swap)
+        val stringCodec = fromSchema(Schema.Primitive(StandardType.StringType)).asInstanceOf[BinaryCodec[String]]
+        def collectLeafCases(enum1: Schema.Enum[_]): Chunk[(Any, String)] =
+          Chunk.fromIterable(enum1.nonTransientCases).flatMap { c =>
+            c.schema match {
+              case cc0: Schema.CaseClass0[_] =>
+                Chunk((cc0.defaultConstruct(), c.caseName))
+              case nested: Schema.Enum[_]    =>
+                collectLeafCases(nested)
+              case _                         =>
+                Chunk.empty
+            }
+          }
+        val caseMap                                                       = collectLeafCases(enum0).toMap
+        val reverseCaseMap                                                = caseMap.map(_.swap)
         new BinaryCodec[A] {
           override def encode(a: A): Chunk[Byte] = {
             val caseName = caseMap(a.asInstanceOf[A])

--- a/zio-http/shared/src/main/scala/zio/http/codec/TextBinaryCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/TextBinaryCodec.scala
@@ -60,6 +60,11 @@ object TextBinaryCodec {
                 Chunk((cc0.defaultConstruct(), c.caseName))
               case nested: Schema.Enum[_]    =>
                 collectLeafCases(nested)
+              case Schema.Lazy(schema0)      =>
+                schema0() match {
+                  case nestedEnum: Schema.Enum[_] => collectLeafCases(nestedEnum)
+                  case _                          => Chunk.empty
+                }
               case _                         =>
                 Chunk.empty
             }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -516,7 +516,7 @@ object JsonSchema {
           val discriminatorName0   =
             enum0.annotations.collectFirst { case discriminatorName(name) => name }
           val hasNoDiscriminator   = enum0.annotations.exists(_.isInstanceOf[noDiscriminator])
-          val nonTransientCases    = enum0.cases.filterNot(_.annotations.exists(_.isInstanceOf[transientCase]))
+          val nonTransientCases    = flattenEnumCases(enum0)
           val shouldAddDiscrimProp = discriminatorName0.isDefined && !hasNoDiscriminator
 
           JsonSchemas(
@@ -724,6 +724,21 @@ object JsonSchema {
       fromZSchemaInternal(schema, refType)
     }
 
+  private def flattenEnumCases(enum0: Schema.Enum[_]): Chunk[Schema.Case[_, _]] = {
+    val nonTransient = enum0.cases.filterNot(_.annotations.exists(_.isInstanceOf[transientCase]))
+    Chunk.fromIterable(nonTransient).flatMap { c =>
+      c.schema match {
+        case nestedEnum: Schema.Enum[_] => flattenEnumCases(nestedEnum)
+        case Schema.Lazy(schema0)       =>
+          schema0() match {
+            case nestedEnum: Schema.Enum[_] => flattenEnumCases(nestedEnum)
+            case _                          => Chunk(c)
+          }
+        case _                          => Chunk(c)
+      }
+    }
+  }
+
   private def fromZSchemaInternal(schema: Schema[_], refType: SchemaRef): JsonSchema =
     schema match {
       case enum0: Schema.Enum[_]
@@ -739,7 +754,7 @@ object JsonSchema {
         val noDiscriminator    = enum0.annotations.exists(_.isInstanceOf[noDiscriminator])
         val discriminatorName0 =
           enum0.annotations.collectFirst { case discriminatorName(name) => name }
-        val nonTransientCases  = enum0.cases.filterNot(_.annotations.exists(_.isInstanceOf[transientCase]))
+        val nonTransientCases  = flattenEnumCases(enum0)
         if (noDiscriminator) {
           JsonSchema
             .OneOfSchema(nonTransientCases.map(c => fromZSchemaInternal(c.schema, refType.compact)))

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -881,28 +881,32 @@ object OpenAPIGen {
     def genDiscriminator(schema: Schema[_]): Option[OpenAPI.Discriminator] = {
       schema match {
         case enumSchema: Schema.Enum[_] =>
-          val discriminatorName =
-            enumSchema.annotations.collectFirst { case zio.schema.annotation.discriminatorName(name) => name }
-          val noDiscriminator   = enumSchema.annotations.contains(zio.schema.annotation.noDiscriminator())
-          val typeMapping       = enumSchema.cases.map { case_ =>
-            val caseName =
-              case_.annotations.collectFirst { case zio.schema.annotation.caseName(name) => name }.getOrElse(case_.id)
-            // There should be no enums with cases that are not records with a nominal id
-            // TODO: not true. Since one could build a schema with a enum with a case that is a primitive
-            val typeId   =
-              (case_.schema match {
-                case lzy: Schema.Lazy[_]                  => lzy.schema
-                case transform: Schema.Transform[_, _, _] => transform.schema
-                case _                                    => case_.schema
-              })
-                .asInstanceOf[Schema.Record[_]]
-                .id
-                .asInstanceOf[TypeId.Nominal]
-            caseName -> schemaReferencePath(typeId, referenceType)
-          }
-
+          val noDiscriminator = enumSchema.annotations.contains(zio.schema.annotation.noDiscriminator())
           if (noDiscriminator) None
-          else discriminatorName.map(name => OpenAPI.Discriminator(name, typeMapping.toMap))
+          else {
+            val discriminatorName =
+              enumSchema.annotations.collectFirst { case zio.schema.annotation.discriminatorName(name) => name }
+            discriminatorName.map { name =>
+              val typeMapping = enumSchema.cases.map { case_ =>
+                val caseName =
+                  case_.annotations.collectFirst { case zio.schema.annotation.caseName(name) => name }
+                    .getOrElse(case_.id)
+                // There should be no enums with cases that are not records with a nominal id
+                // TODO: not true. Since one could build a schema with a enum with a case that is a primitive
+                val typeId   =
+                  (case_.schema match {
+                    case lzy: Schema.Lazy[_]                  => lzy.schema
+                    case transform: Schema.Transform[_, _, _] => transform.schema
+                    case _                                    => case_.schema
+                  })
+                    .asInstanceOf[Schema.Record[_]]
+                    .id
+                    .asInstanceOf[TypeId.Nominal]
+                caseName -> schemaReferencePath(typeId, referenceType)
+              }
+              OpenAPI.Discriminator(name, typeMapping.toMap)
+            }
+          }
 
         case _ => None
       }


### PR DESCRIPTION
## Summary

Fixes nested sealed trait hierarchies (e.g., `sealed trait Animal > sealed trait Dog > case class GoldenRetriever`) in two zio-http components:

- **TextBinaryCodec**: Replaced flat `asInstanceOf[CaseClass0]` cast with recursive `collectLeafCases` helper that descends into nested `Schema.Enum` nodes to collect all leaf case objects. Fixes `ClassCastException` for `@simpleEnum` enums with sub-traits.
- **JsonSchema**: Added `flattenEnumCases` helper that recursively collects leaf cases from nested `Schema.Enum` hierarchies, applied in both `fromZSchemaInternal` and `fromZSchemaMultiple`. Fixes incorrect OpenAPI schema with intermediate `oneOf` nodes.

Closes #3801
Closes #3946

## Dependencies

Requires https://github.com/zio/zio-schema/pull/1015 (fix for DeriveSchema macro crashes with nested sealed traits — zio-schema #667, #748) to be merged and released first. Without the schema fix, `DeriveSchema.gen[NestedSealedTrait]` crashes at compile time.

## Test Plan

- **TextBinaryCodecSpec**: 9 tests covering nested `@simpleEnum` sealed trait encode/decode + flat enum backward compatibility
- **OpenAPIGenSpec**: New test verifying nested sealed trait produces flat `oneOf` with leaf types only
- **RoundtripSpec**: Full endpoint round-trip test with nested sealed trait body (Triangle, Rectangle, Circle via server→client pipeline) + OpenAPI verification