### PR TITLE
fix: log server startup failure before orDie (#3440)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ServerStartupErrorSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerStartupErrorSpec.scala
@@ -50,7 +50,7 @@ object ServerStartupErrorSpec extends ZIOSpecDefault {
                   assertTrue(
                     exit.isFailure,
                     errorLog.isDefined,
-                    errorLog.get.logLevel == LogLevel.Error,
+                    errorLog.exists(_.logLevel == LogLevel.Error),
                   )
                 }
               }

--- a/zio-http/jvm/src/test/scala/zio/http/ServerStartupErrorSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerStartupErrorSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import java.net.ServerSocket
+
+import zio._
+import zio.test._
+
+import zio.http.netty.NettyConfig
+
+object ServerStartupErrorSpec extends ZIOSpecDefault {
+
+  private val routes = Routes(
+    Method.GET / "ok" -> Handler.ok,
+  )
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("ServerStartupErrorSpec")(
+      test("logs error when port is already in use") {
+        ZIO
+          .acquireRelease(ZIO.attemptBlocking(new ServerSocket(0)))(s => ZIO.attemptBlocking(s.close()).ignore)
+          .flatMap { socket =>
+            val port = socket.getLocalPort
+            Server
+              .installRoutes(routes)
+              .provide(
+                Server.customized,
+                ZLayer.succeed(Server.Config.default.port(port)),
+                ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+              )
+              .exit
+              .flatMap { exit =>
+                ZTestLogger.logOutput.map { entries =>
+                  val errorLog = entries.find(_.message() == "Failed to start server")
+                  assertTrue(
+                    exit.isFailure,
+                    errorLog.isDefined,
+                    errorLog.get.logLevel == LogLevel.Error,
+                  )
+                }
+              }
+          }
+      },
+    ) @@ TestAspect.withLiveClock
+}

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -576,11 +576,12 @@ object Server extends ServerPlatformSpecific {
     ): URIO[R, Unit] =
       for {
         _ <- initialInstall.succeed(())
-        _ <- serverStarted.await.orDie
+        _ <- serverStarted.await.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause)).orDie
         _ <- ZIO.environment[R].flatMap(env => driver.addApp(routes, env.prune[R]))
       } yield ()
 
-    override def port: UIO[Int] = serverStarted.await.orDie
+    override def port: UIO[Int] =
+      serverStarted.await.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause)).orDie
 
   }
 }

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -570,18 +570,20 @@ object Server extends ServerPlatformSpecific {
     // or a throwable if starting the driver failed for any reason.
     private val serverStarted: Promise[Throwable, Int],
   ) extends Server {
+    private val awaitStarted: UIO[Int] =
+      serverStarted.await.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause)).orDie
+
     override private[http] def installInternal[R](routes: Routes[R, Response])(implicit
       trace: Trace,
       tag: EnvironmentTag[R],
     ): URIO[R, Unit] =
       for {
         _ <- initialInstall.succeed(())
-        _ <- serverStarted.await.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause)).orDie
+        _ <- awaitStarted
         _ <- ZIO.environment[R].flatMap(env => driver.addApp(routes, env.prune[R]))
       } yield ()
 
-    override def port: UIO[Int] =
-      serverStarted.await.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause)).orDie
+    override def port: UIO[Int] = awaitStarted
 
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #3440 — When the port is already busy, `.exitCode` now surfaces the error log instead of exiting silently with code 0
- Added `.tapErrorCause(cause => ZIO.logErrorCause("Failed to start server", cause))` before `.orDie` in `ServerLive.installInternal` and `ServerLive.port`
- Added `ServerStartupErrorSpec` test verifying error logging on port-busy failure

## Changes
- `Server.scala`: Log error cause before `.orDie` in two places (`installInternal` and `port`)
- `ServerStartupErrorSpec.scala`: New test that holds a port busy and verifies error logging when server fails to start