### PR TITLE
test: add regression test for response examples in OpenAPI (#3259)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -31,6 +31,9 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
   final case class ImageMetadata(name: String, size: Int)
   implicit val imageMetadataSchema: Schema[ImageMetadata]               =
     DeriveSchema.gen[ImageMetadata]
+  final case class Greeting(msg: String)
+  implicit val greetingSchema: Schema[Greeting]                         =
+    DeriveSchema.gen[Greeting]
 
   final case class WithTransientField(name: String, @transientField age: Int = 42)
   implicit val withTransientFieldSchema: Schema[WithTransientField] =
@@ -4723,6 +4726,75 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |    }
                              |  }
                              |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("response examples via examplesOut - issue #3259") {
+
+        val endpoint =
+          Endpoint(GET / "greeting" / string("name"))
+            .out[Greeting]
+            .examplesOut("1" -> Greeting("Hi Jane"))
+
+        val generated    = OpenAPIGen.fromEndpoints("Test", "1.0", endpoint)
+        val json         = toJsonAst(generated)
+        val expectedJson =
+          """{
+            |  "openapi" : "3.1.0",
+            |  "info" : {
+            |    "title" : "Test",
+            |    "version" : "1.0"
+            |  },
+            |  "paths" : {
+            |    "/greeting/{name}" : {
+            |      "get" : {
+            |        "parameters" : [
+            |          {
+            |            "name" : "name",
+            |            "in" : "path",
+            |            "required" : true,
+            |            "schema" : {
+            |              "type" : "string"
+            |            },
+            |            "style" : "simple"
+            |          }
+            |        ],
+            |        "responses" : {
+            |          "200" : {
+            |            "content" : {
+            |              "application/json" : {
+            |                "schema" : {
+            |                  "$ref" : "#/components/schemas/Greeting"
+            |                },
+            |                "examples" : {
+            |                  "1" : {
+            |                    "value" : {
+            |                      "msg" : "Hi Jane"
+            |                    }
+            |                  }
+            |                }
+            |              }
+            |            }
+            |          }
+            |        }
+            |      }
+            |    }
+            |  },
+            |  "components" : {
+            |    "schemas" : {
+            |      "Greeting" : {
+            |        "type" : "object",
+            |        "properties" : {
+            |          "msg" : {
+            |            "type" : "string"
+            |          }
+            |        },
+            |        "required" : [
+            |          "msg"
+            |        ]
+            |      }
+            |    }
+            |  }
+            |}""".stripMargin
         assertTrue(json == toJsonAst(expectedJson))
       },
     )


### PR DESCRIPTION
## Summary
- Closes #3259 — Adds a regression test confirming that response object examples are correctly rendered in generated OpenAPI docs
- The bug was already fixed at some point between 3.0.1 and current main
- The test uses `.out[Greeting].examplesOut("1" -> Greeting("Hi Jane"))` matching the issue's exact scenario and verifies the generated JSON contains `{"msg": "Hi Jane"}` instead of `{"msg": "string"}`

## Changes
- `OpenAPIGenSpec.scala`: Added `Greeting` case class and `"response examples via examplesOut - issue #3259"` test