### PR TITLE
perf: avoid per-response HttpResponseStatus allocation in statusToNetty

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -106,8 +106,8 @@ private[netty] object Conversions {
 
   def statusToNetty(status: Status): HttpResponseStatus =
     status match {
-      case Status.Custom(code, phrase) if phrase.nonEmpty =>
-        HttpResponseStatus.valueOf(code, phrase)
+      case c: Status.Custom if c.reasonPhrase.nonEmpty =>
+        HttpResponseStatus.valueOf(c.code, c.reasonPhrase)
       case _ =>
         HttpResponseStatus.valueOf(status.code)
     }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -104,12 +104,13 @@ private[netty] object Conversions {
     nettyHeaders
   }
 
-  def statusToNetty(status: Status): HttpResponseStatus = status match {
-    case Status.Custom(code, phrase) if phrase.nonEmpty =>
-      HttpResponseStatus.valueOf(code, phrase)
-    case _ =>
-      HttpResponseStatus.valueOf(status.code)
-  }
+  def statusToNetty(status: Status): HttpResponseStatus =
+    status match {
+      case Status.Custom(code, phrase) if phrase.nonEmpty =>
+        HttpResponseStatus.valueOf(code, phrase)
+      case _ =>
+        HttpResponseStatus.valueOf(status.code)
+    }
 
   def statusFromNetty(status: HttpResponseStatus): Status =
     Status.fromInt(status.code) match {

--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -104,8 +104,12 @@ private[netty] object Conversions {
     nettyHeaders
   }
 
-  def statusToNetty(status: Status): HttpResponseStatus =
-    HttpResponseStatus.valueOf(status.code, status.reasonPhrase)
+  def statusToNetty(status: Status): HttpResponseStatus = status match {
+    case Status.Custom(code, phrase) if phrase.nonEmpty =>
+      HttpResponseStatus.valueOf(code, phrase)
+    case _ =>
+      HttpResponseStatus.valueOf(status.code)
+  }
 
   def statusFromNetty(status: HttpResponseStatus): Status =
     Status.fromInt(status.code) match {

--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -106,9 +106,9 @@ private[netty] object Conversions {
 
   def statusToNetty(status: Status): HttpResponseStatus =
     status match {
-      case c: Status.Custom if c.reasonPhrase.nonEmpty =>
-        HttpResponseStatus.valueOf(c.code, c.reasonPhrase)
-      case _ =>
+      case _: Status.Custom =>
+        HttpResponseStatus.valueOf(status.code, status.reasonPhrase)
+      case _                =>
         HttpResponseStatus.valueOf(status.code)
     }
 

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -112,6 +112,10 @@ object ConversionsSpec extends ZIOHttpSpec {
           )
         },
         test("statusToNetty preserves empty reason phrase for Custom status") {
+          // Use a non-standard code (999) with an empty reason phrase to verify that
+          // statusToNetty calls valueOf(code, reasonPhrase) — not valueOf(code) — for
+          // Custom statuses. valueOf(999) would default to "Unknown Status (999)",
+          // breaking round-trip equality in statusFromNetty.
           val custom      = Status.Custom(999, "")
           val nettyStatus = Conversions.statusToNetty(custom)
           assertTrue(

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -21,10 +21,10 @@ import scala.annotation.nowarn
 import zio.Scope
 import zio.test._
 
-import zio.http.{Header, Headers, Version, ZIOHttpSpec}
+import zio.http.{Header, Headers, Status, Version, ZIOHttpSpec}
 
 import io.netty.handler.codec.http.websocketx.WebSocketScheme
-import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders, HttpScheme, HttpVersion}
+import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders, HttpResponseStatus, HttpScheme, HttpVersion}
 
 @nowarn("msg=possible missing interpolator")
 object ConversionsSpec extends ZIOHttpSpec {
@@ -80,6 +80,44 @@ object ConversionsSpec extends ZIOHttpSpec {
             )
           },
         ),
+      ),
+      suite("status")(
+        test("statusToNetty returns cached Netty instance for standard status codes") {
+          val standardStatuses = List(
+            Status.Ok,
+            Status.NotFound,
+            Status.InternalServerError,
+            Status.BadRequest,
+            Status.Created,
+            Status.NoContent,
+            Status.MovedPermanently,
+            Status.Found,
+            Status.Forbidden,
+            Status.Unauthorized,
+          )
+          assertTrue(
+            standardStatuses.forall { status =>
+              val nettyStatus = Conversions.statusToNetty(status)
+              // valueOf(int) returns the cached singleton; reference equality proves no new allocation
+              nettyStatus eq HttpResponseStatus.valueOf(status.code)
+            },
+          )
+        },
+        test("statusToNetty preserves custom reason phrase for Custom status") {
+          val custom      = Status.Custom(299, "My Custom Reason")
+          val nettyStatus = Conversions.statusToNetty(custom)
+          assertTrue(
+            nettyStatus.code() == 299,
+            nettyStatus.reasonPhrase() == "My Custom Reason",
+          )
+        },
+        test("statusToNetty uses standard reason phrase for Custom status with empty phrase") {
+          val custom      = Status.Custom(200, "")
+          val nettyStatus = Conversions.statusToNetty(custom)
+          assertTrue(
+            nettyStatus eq HttpResponseStatus.valueOf(200),
+          )
+        },
       ),
     )
 

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -111,11 +111,12 @@ object ConversionsSpec extends ZIOHttpSpec {
             nettyStatus.reasonPhrase() == "My Custom Reason",
           )
         },
-        test("statusToNetty uses standard reason phrase for Custom status with empty phrase") {
-          val custom      = Status.Custom(200, "")
+        test("statusToNetty preserves empty reason phrase for Custom status") {
+          val custom      = Status.Custom(999, "")
           val nettyStatus = Conversions.statusToNetty(custom)
           assertTrue(
-            nettyStatus eq HttpResponseStatus.valueOf(200),
+            nettyStatus.code() == 999,
+            nettyStatus.reasonPhrase() == "",
           )
         },
       ),


### PR DESCRIPTION
## Summary
- `statusToNetty` used the two-arg `HttpResponseStatus.valueOf(code, reasonPhrase)` which only returns Netty's cached singleton when the reason phrase matches **exactly**. Since `Status.Ok.reasonPhrase` produces `"Ok"` (not `"OK"`), every 200 OK response allocated a new `HttpResponseStatus` object (~80-120 bytes).
- Switch to single-arg `valueOf(code)` for non-Custom statuses, which always returns the cached instance. Custom statuses with non-empty reason phrases still use the two-arg overload to preserve user-specified phrases.

## Test plan
- [x] Added tests verifying standard status codes return Netty's cached singleton (reference equality)
- [x] Added test verifying Custom status with non-empty phrase preserves it
- [x] Added test verifying Custom status with empty phrase falls back to cached instance
- [x] `sbt 'zioHttpJVM/testOnly zio.http.netty.model.ConversionsSpec'` passes