### PR TITLE
perf: skip allocations in removeDotSegments for paths without dot segments

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/PathSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/PathSpec.scala
@@ -464,6 +464,20 @@ object PathSpec extends ZIOHttpSpec with ExitAssertion {
 
         assertTrue(result == expected)
       },
+      test("returns same instance when no dot segments exist") {
+        val path   = Path(Path.Flags(Path.Flag.LeadingSlash), Chunk("api", "users", "123"))
+        val result = path.removeDotSegments
+        // Reference equality: no allocations when no dot segments are present
+        assertTrue(result eq path)
+      },
+      test("returns same instance for typical request paths") {
+        val paths = List(
+          Path(Path.Flags(Path.Flag.LeadingSlash), Chunk("api", "v1", "items")),
+          Path(Path.Flags(Path.Flag.LeadingSlash), Chunk("health")),
+          Path(Path.Flags(Path.Flag.LeadingSlash), Chunk("a", "b", "c", "d")),
+        )
+        assertTrue(paths.forall { p => p.removeDotSegments eq p })
+      },
     ),
   )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Path.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Path.scala
@@ -213,51 +213,52 @@ final case class Path private[http] (flags: Path.Flags, segments: Chunk[String])
       if (s == "." || s == "..") noDots = false
       j += 1
     }
-    if (noDots) return self
+    if (noDots) self
+    else {
+      val segments     = new Array[String](self.segments.length)
+      var segmentCount = 0
+      // leading/trailing slashes may change but is unlikely
+      var flags        = self.flags
 
-    val segments     = new Array[String](self.segments.length)
-    var segmentCount = 0
-    // leading/trailing slashes may change but is unlikely
-    var flags        = self.flags
+      var i   = 0
+      val max = self.segments.length
 
-    var i   = 0
-    val max = self.segments.length
+      if (!Flag.LeadingSlash.check(flags)) {
+        // § 5.2.4.2.A/D no leading slash, so skip all initial `./` and `../`
+        while (i < max && (self.segments(i) == "." | self.segments(i) == "..")) {
+          i += 1
+        }
+        // if the entire input was consumed, there is no more trailing slash
+        if (i == max) flags = Flag.TrailingSlash.remove(flags)
+      }
 
-    if (!Flag.LeadingSlash.check(flags)) {
-      // § 5.2.4.2.A/D no leading slash, so skip all initial `./` and `../`
-      while (i < max && (self.segments(i) == "." | self.segments(i) == "..")) {
+      var loop = i < max
+      while (loop) {
+        val segment = self.segments(i)
+
         i += 1
+        loop = i < max
+
+        if (segment == "..") {
+          segmentCount = (segmentCount - 1).max(0)
+          // § 5.2.4.2.C resolving `/..` and `/../` removes preceding slashes and is itself replaced by a slash
+          // so if we popped the first one we definitely have a leading slash
+          if (segmentCount == 0) flags = Flag.LeadingSlash.add(flags)
+          // § 5.2.4.2.C resolving `/..` and `/../` are both as-if replaced by a `/`
+          // so if this is the last segment, then we have a trailing slash
+          if (i == max) flags = Flag.TrailingSlash.add(flags)
+        } else if (segment == ".") {
+          // § 5.2.4.2.B resolving `/.` and `/./` are both as-if replaced by a `/`
+          // so if this is the last segment, then we have a trailing slash
+          if (i == max) flags = Flag.TrailingSlash.add(flags)
+        } else {
+          segments(segmentCount) = segment
+          segmentCount += 1
+        }
       }
-      // if the entire input was consumed, there is no more trailing slash
-      if (i == max) flags = Flag.TrailingSlash.remove(flags)
+
+      Path(flags, Chunk.fromArray(segments.take(segmentCount)))
     }
-
-    var loop = i < max
-    while (loop) {
-      val segment = self.segments(i)
-
-      i += 1
-      loop = i < max
-
-      if (segment == "..") {
-        segmentCount = (segmentCount - 1).max(0)
-        // § 5.2.4.2.C resolving `/..` and `/../` removes preceding slashes and is itself replaced by a slash
-        // so if we popped the first one we definitely have a leading slash
-        if (segmentCount == 0) flags = Flag.LeadingSlash.add(flags)
-        // § 5.2.4.2.C resolving `/..` and `/../` are both as-if replaced by a `/`
-        // so if this is the last segment, then we have a trailing slash
-        if (i == max) flags = Flag.TrailingSlash.add(flags)
-      } else if (segment == ".") {
-        // § 5.2.4.2.B resolving `/.` and `/./` are both as-if replaced by a `/`
-        // so if this is the last segment, then we have a trailing slash
-        if (i == max) flags = Flag.TrailingSlash.add(flags)
-      } else {
-        segments(segmentCount) = segment
-        segmentCount += 1
-      }
-    }
-
-    Path(flags, Chunk.fromArray(segments.take(segmentCount)))
   }
 
   /**

--- a/zio-http/shared/src/main/scala/zio/http/Path.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Path.scala
@@ -206,14 +206,14 @@ final case class Path private[http] (flags: Path.Flags, segments: Chunk[String])
   def removeDotSegments: Path = {
     // See https://www.rfc-editor.org/rfc/rfc3986#section-5.2.4
     // Fast path: skip all allocations when no dot segments exist (the common case)
-    var hasDots = false
-    var j       = 0
-    while (j < self.segments.length && !hasDots) {
+    var noDots = true
+    var j      = 0
+    while (j < self.segments.length && noDots) {
       val s = self.segments(j)
-      if (s == "." || s == "..") hasDots = true
+      if (s == "." || s == "..") noDots = false
       j += 1
     }
-    if (!hasDots) return self
+    if (noDots) return self
 
     val segments     = new Array[String](self.segments.length)
     var segmentCount = 0

--- a/zio-http/shared/src/main/scala/zio/http/Path.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Path.scala
@@ -205,6 +205,16 @@ final case class Path private[http] (flags: Path.Flags, segments: Chunk[String])
    */
   def removeDotSegments: Path = {
     // See https://www.rfc-editor.org/rfc/rfc3986#section-5.2.4
+    // Fast path: skip all allocations when no dot segments exist (the common case)
+    var hasDots = false
+    var j       = 0
+    while (j < self.segments.length && !hasDots) {
+      val s = self.segments(j)
+      if (s == "." || s == "..") hasDots = true
+      j += 1
+    }
+    if (!hasDots) return self
+
     val segments     = new Array[String](self.segments.length)
     var segmentCount = 0
     // leading/trailing slashes may change but is unlikely


### PR DESCRIPTION
## Summary
- `removeDotSegments` is called on every decoded path but always allocates a new `Array`, `Chunk`, and `Path` (~152 bytes) even when no `.` or `..` segments exist (the overwhelmingly common case).
- Add a pre-scan that returns `self` immediately when no dot segments are found, eliminating unnecessary allocations per request.

## Test plan
- [x] Added test verifying reference equality (`eq`) when no dot segments are present
- [x] Added test verifying typical request paths return the same instance
- [x] All existing `removeDotSegments` tests still pass (dot segments are still resolved correctly)
- [x] `sbt 'zioHttpJVM/testOnly zio.http.PathSpec'` — 47 tests pass