### PR TITLE
fix: remove accidental println from forwardHeaders middleware

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ForwardHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ForwardHeaderSpec.scala
@@ -8,63 +8,46 @@ import zio.test._
 object ForwardHeaderSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("ForwardHeaderSpec")(
-      suite("integration")(
-        test("forward headers by header type") {
-          val routes = Routes(
-            Method.GET / "get"   -> handler((_: Request) =>
-              for {
-                client   <- ZIO.service[Client]
-                response <- (client @@ ZClientAspect.forwardHeaders)
-                  .batched(Request.post(url"http://localhost:8080/post", Body.empty))
-              } yield response,
-            ),
-            Method.POST / "post" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
-          ).sandbox @@ Middleware.forwardHeaders(Header.Accept)
-
-          for {
-            _        <- Server.installRoutes(routes)
-            response <- Client.batched(
-              Request.get(url"http://localhost:8080/get").addHeader(Header.Accept(MediaType.application.json)),
-            )
-          } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
-        },
-        test("forward by mapping headers") {
-          val routes = Routes(
-            Method.GET / "get2"   -> handler((_: Request) =>
-              for {
-                client   <- ZIO.service[Client]
-                response <- (client @@ ZClientAspect.forwardHeaders)
-                  .batched(Request.post(url"http://localhost:8080/post", Body.empty))
-              } yield response,
-            ),
-            Method.POST / "post2" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
-          ).sandbox @@ Middleware.forwardHeaders((headers: Headers) =>
-            Headers.fromIterable(headers.filter(_.headerName == Header.Accept.name)),
-          )
-
-          for {
-            _        <- Server.installRoutes(routes)
-            response <- Client.batched(
-              Request.get(url"http://localhost:8080/get2").addHeader(Header.Accept(MediaType.application.json)),
-            )
-          } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
-        },
-      ).provideShared(Client.default, Server.default) @@ TestAspect.withLiveClock @@ TestAspect.flaky,
-      test("forwardHeaders(f) does not write to stdout") {
-        val baos        = new java.io.ByteArrayOutputStream()
-        val originalOut = java.lang.System.out
-        val routes      = Routes(
-          Method.GET / "test" -> handler(Response.ok),
-        ).sandbox @@ Middleware.forwardHeaders((h: Headers) => h)
+      test("forward headers by header type") {
+        val routes = Routes(
+          Method.GET / "get"   -> handler((_: Request) =>
+            for {
+              client   <- ZIO.service[Client]
+              response <- (client @@ ZClientAspect.forwardHeaders)
+                .batched(Request.post(url"http://localhost:8080/post", Body.empty))
+            } yield response,
+          ),
+          Method.POST / "post" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
+        ).sandbox @@ Middleware.forwardHeaders(Header.Accept)
 
         for {
-          _ <- ZIO.attempt(java.lang.System.setOut(new java.io.PrintStream(baos)))
-          response <- routes
-            .runZIO(Request.get(URL.root / "test").addHeader(Header.Accept(MediaType.application.json)))
-            .ensuring(ZIO.attempt(java.lang.System.setOut(originalOut)).ignoreLogged)
-          stdout = baos.toString
-        } yield assertTrue(response.status == Status.Ok, stdout.isEmpty)
+          _        <- Server.installRoutes(routes)
+          response <- Client.batched(
+            Request.get(url"http://localhost:8080/get").addHeader(Header.Accept(MediaType.application.json)),
+          )
+        } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
       },
-    )
+      test("forward by mapping headers") {
+        val routes = Routes(
+          Method.GET / "get2"   -> handler((_: Request) =>
+            for {
+              client   <- ZIO.service[Client]
+              response <- (client @@ ZClientAspect.forwardHeaders)
+                .batched(Request.post(url"http://localhost:8080/post", Body.empty))
+            } yield response,
+          ),
+          Method.POST / "post2" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
+        ).sandbox @@ Middleware.forwardHeaders((headers: Headers) =>
+          Headers.fromIterable(headers.filter(_.headerName == Header.Accept.name)),
+        )
+
+        for {
+          _        <- Server.installRoutes(routes)
+          response <- Client.batched(
+            Request.get(url"http://localhost:8080/get2").addHeader(Header.Accept(MediaType.application.json)),
+          )
+        } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
+      },
+    ).provideShared(Client.default, Server.default) @@ TestAspect.withLiveClock @@ TestAspect.flaky
 
 }

--- a/zio-http/jvm/src/test/scala/zio/http/ForwardHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ForwardHeaderSpec.scala
@@ -8,46 +8,63 @@ import zio.test._
 object ForwardHeaderSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("ForwardHeaderSpec")(
-      test("forward headers by header type") {
-        val routes = Routes(
-          Method.GET / "get"   -> handler((_: Request) =>
-            for {
-              client   <- ZIO.service[Client]
-              response <- (client @@ ZClientAspect.forwardHeaders)
-                .batched(Request.post(url"http://localhost:8080/post", Body.empty))
-            } yield response,
-          ),
-          Method.POST / "post" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
-        ).sandbox @@ Middleware.forwardHeaders(Header.Accept)
+      suite("integration")(
+        test("forward headers by header type") {
+          val routes = Routes(
+            Method.GET / "get"   -> handler((_: Request) =>
+              for {
+                client   <- ZIO.service[Client]
+                response <- (client @@ ZClientAspect.forwardHeaders)
+                  .batched(Request.post(url"http://localhost:8080/post", Body.empty))
+              } yield response,
+            ),
+            Method.POST / "post" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
+          ).sandbox @@ Middleware.forwardHeaders(Header.Accept)
+
+          for {
+            _        <- Server.installRoutes(routes)
+            response <- Client.batched(
+              Request.get(url"http://localhost:8080/get").addHeader(Header.Accept(MediaType.application.json)),
+            )
+          } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
+        },
+        test("forward by mapping headers") {
+          val routes = Routes(
+            Method.GET / "get2"   -> handler((_: Request) =>
+              for {
+                client   <- ZIO.service[Client]
+                response <- (client @@ ZClientAspect.forwardHeaders)
+                  .batched(Request.post(url"http://localhost:8080/post", Body.empty))
+              } yield response,
+            ),
+            Method.POST / "post2" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
+          ).sandbox @@ Middleware.forwardHeaders((headers: Headers) =>
+            Headers.fromIterable(headers.filter(_.headerName == Header.Accept.name)),
+          )
+
+          for {
+            _        <- Server.installRoutes(routes)
+            response <- Client.batched(
+              Request.get(url"http://localhost:8080/get2").addHeader(Header.Accept(MediaType.application.json)),
+            )
+          } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
+        },
+      ).provideShared(Client.default, Server.default) @@ TestAspect.withLiveClock @@ TestAspect.flaky,
+      test("forwardHeaders(f) does not write to stdout") {
+        val baos        = new java.io.ByteArrayOutputStream()
+        val originalOut = java.lang.System.out
+        val routes      = Routes(
+          Method.GET / "test" -> handler(Response.ok),
+        ).sandbox @@ Middleware.forwardHeaders((h: Headers) => h)
 
         for {
-          _        <- Server.installRoutes(routes)
-          response <- Client.batched(
-            Request.get(url"http://localhost:8080/get").addHeader(Header.Accept(MediaType.application.json)),
-          )
-        } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
+          _ <- ZIO.attempt(java.lang.System.setOut(new java.io.PrintStream(baos)))
+          response <- routes
+            .runZIO(Request.get(URL.root / "test").addHeader(Header.Accept(MediaType.application.json)))
+            .ensuring(ZIO.attempt(java.lang.System.setOut(originalOut)).ignoreLogged)
+          stdout = baos.toString
+        } yield assertTrue(response.status == Status.Ok, stdout.isEmpty)
       },
-      test("forward by mapping headers") {
-        val routes = Routes(
-          Method.GET / "get2"   -> handler((_: Request) =>
-            for {
-              client   <- ZIO.service[Client]
-              response <- (client @@ ZClientAspect.forwardHeaders)
-                .batched(Request.post(url"http://localhost:8080/post", Body.empty))
-            } yield response,
-          ),
-          Method.POST / "post2" -> handler((req: Request) => Response.ok.addHeader(req.header(Header.Accept).get)),
-        ).sandbox @@ Middleware.forwardHeaders((headers: Headers) =>
-          Headers.fromIterable(headers.filter(_.headerName == Header.Accept.name)),
-        )
-
-        for {
-          _        <- Server.installRoutes(routes)
-          response <- Client.batched(
-            Request.get(url"http://localhost:8080/get2").addHeader(Header.Accept(MediaType.application.json)),
-          )
-        } yield assertTrue(response.headers(Header.Accept).contains(Header.Accept(MediaType.application.json)))
-      },
-    ).provideShared(Client.default, Server.default) @@ TestAspect.withLiveClock @@ TestAspect.flaky
+    )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -213,7 +213,6 @@ object Middleware extends HandlerAspects {
           Handler.scoped[Env1] {
             handler { (req: Request) =>
               val headerValues = f(req.headers)
-              println(s"Forwarding headers: $headerValues")
               RequestStore.update[ForwardedHeaders] { old =>
                 ForwardedHeaders {
                   old.map(_.headers).getOrElse(Headers.empty) ++


### PR DESCRIPTION
## Summary
- The `forwardHeaders(f: Headers => Headers)` overload contained a forgotten debug `println(s"Forwarding headers: $headerValues")` that runs on every request using this middleware variant.
- The other two overloads (typed-header and string-name variants) do not have this `println`, confirming it was accidentally left in during development.

## Test plan
- [x] Added test verifying `forwardHeaders(f)` produces no stdout output
- [x] `sbt 'zioHttpJVM/testOnly zio.http.ForwardHeaderSpec'` passes