### PR TITLE
perf: hoist metrics request labels to aspect-construction time

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/MetricsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/MetricsSpec.scala
@@ -116,5 +116,24 @@ object MetricsSpec extends ZIOHttpSpec with TestExtensions {
           after  <- gauge.value
         } yield assertTrue(before == MetricState.Gauge(0), before == after, during == MetricState.Gauge(1))
       },
+      test("metrics labels are consistent across multiple requests to the same route") {
+        val total = Metric
+          .counterInt("http_requests_total")
+          .tagged("test", "label_consistency")
+          .tagged("path", "/items")
+          .tagged("method", "GET")
+          .tagged("status", "200")
+
+        val routes = (Method.GET / "items" -> Handler.ok).toRoutes @@ metrics(
+          extraLabels = Set(MetricLabel("test", "label_consistency")),
+        )
+
+        for {
+          _     <- routes.runZIO(Request.get(url = URL(Path.root / "items")))
+          _     <- routes.runZIO(Request.get(url = URL(Path.root / "items")))
+          _     <- routes.runZIO(Request.get(url = URL(Path.root / "items")))
+          count <- total.value
+        } yield assertTrue(count == MetricState.Counter(3))
+      },
     )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -416,10 +416,11 @@ object Middleware extends HandlerAspects {
         _ <- requestDuration.tagged(labels).update(took / nanosToSeconds)
       } yield ()
 
-    def aspect(routePattern: RoutePattern[_])(implicit trace: Trace): HandlerAspect[Any, Unit] =
-      HandlerAspect.interceptHandlerStateful(Handler.fromFunctionZIO[Request] { req =>
-        val requestLabels = labelsForRequest(routePattern)
+    def aspect(routePattern: RoutePattern[_])(implicit trace: Trace): HandlerAspect[Any, Unit] = {
+      // Computed once at route registration time, not per request
+      val requestLabels = labelsForRequest(routePattern)
 
+      HandlerAspect.interceptHandlerStateful(Handler.fromFunctionZIO[Request] { req =>
         for {
           start <- Clock.nanoTime
           _     <- concurrentRequests.tagged(requestLabels).increment
@@ -429,6 +430,7 @@ object Middleware extends HandlerAspects {
 
         report(start, requestLabels, allLabels).as(response)
       })
+    }
 
     new Middleware[Any] {
       def apply[Env1, Err](routes: Routes[Env1, Err]): Routes[Env1, Err] =


### PR DESCRIPTION
## Summary
- `labelsForRequest(routePattern)` was called **per-request** inside the handler closure, despite the route pattern being fixed at middleware application time. This allocated `MetricLabel` objects and a `Set` on every request.
- Hoist the computation to `aspect` construction time so it runs **once per route**, eliminating per-request allocations. Also, `routePattern.method.render` and `routePattern.pathCodec.render` are no longer recomputed per request.

## Test plan
- [x] All 4 existing MetricsSpec tests pass (requests_total, duration, concurrent, path mapper)
- [x] Added test verifying metrics labels are consistent across multiple requests to the same route
- [x] `sbt 'zioHttpJVM/testOnly zio.http.internal.middlewares.MetricsSpec'` — 5 tests pass