### PR TITLE
perf: use ThreadLocal reusable ArrayDeque in PathCodec.decode

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -239,5 +239,23 @@ object PathCodecSpec extends ZIOHttpSpec {
           )
         },
       ),
+      suite("consecutive decodes reuse stack correctly")(
+        test("multiple decodes on the same thread produce correct results") {
+          val codec = PathCodec.literal("users") / PathCodec.int("id")
+          val path1 = Path.decode("/users/1")
+          val path2 = Path.decode("/users/42")
+          val path3 = Path.decode("/users/999")
+
+          val r1 = codec.decode(path1)
+          val r2 = codec.decode(path2)
+          val r3 = codec.decode(path3)
+
+          assertTrue(
+            r1 == Right(1),
+            r2 == Right(42),
+            r3 == Right(999),
+          )
+        },
+      ),
     )
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -133,7 +133,7 @@ sealed trait PathCodec[A] extends codec.PathCodecPlatformSpecific { self =>
     var i                           = 0
     var j                           = 0
     var fail                        = ""
-    val stack: java.util.Deque[Any] = new java.util.ArrayDeque[Any](2)
+    val stack: java.util.Deque[Any] = zio.http.internal.ThreadLocals.deque
 
     // For root:
     stack.push(())

--- a/zio-http/shared/src/main/scala/zio/http/internal/ThreadLocals.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/ThreadLocals.scala
@@ -21,4 +21,21 @@ private[http] object ThreadLocals {
     }
   }
 
+  private val Deque: ThreadLocal[java.util.ArrayDeque[Any]] =
+    new ThreadLocal[java.util.ArrayDeque[Any]] {
+      override def initialValue(): java.util.ArrayDeque[Any] = null.asInstanceOf[java.util.ArrayDeque[Any]]
+    }
+
+  def deque: java.util.ArrayDeque[Any] = {
+    val d = Deque.get()
+    if (d == null) {
+      val newD = new java.util.ArrayDeque[Any](8)
+      Deque.set(newD)
+      newD
+    } else {
+      d.clear()
+      d
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary
- Every call to `PathCodec.decode` allocated a `new ArrayDeque(2)` which internally rounds up to `Object[8]` (~80-100 bytes per request).
- Replace with a `ThreadLocal` reusable deque that is cleared and reused across requests on the same thread, eliminating the per-request allocation.
- Added the reusable deque to the existing `ThreadLocals` utility alongside the existing `StringBuilder` pool.

**Note:** ZIO's fiber system typically runs on a fixed pool of carrier threads, so the `ThreadLocal` pool size is bounded. With Project Loom/virtual threads, each virtual thread gets its own copy — acceptable since ZIO doesn't use virtual threads by default.

## Test plan
- [x] All 24 existing PathCodecSpec tests pass
- [x] Added test verifying consecutive decodes on the same thread produce correct results
- [x] `sbt 'zioHttpJVM/testOnly zio.http.codec.PathCodecSpec'` — 25 tests pass