### PR TITLE
perf: replace double map lookup with single .get in SegmentSubtree

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -829,8 +829,9 @@ object PathCodec {
         val segment = segments(i)
 
         // Fast path, jump down the tree:
+        val literalChild = subtree.literals.get(segment)
         if (
-          subtree.literals.contains(segment)
+          literalChild.isDefined
           && (subtree.literalsWithCollisions.eq(Set.empty) || !skipLiteralsFor.contains(i))
         ) {
 
@@ -840,7 +841,7 @@ object PathCodec {
             trySkipLiteralIdx = i +: trySkipLiteralIdx
           }
 
-          subtree = subtree.literals(segment)
+          subtree = literalChild.get
 
           result = subtree.value
           i += 1

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -828,10 +828,10 @@ object PathCodec {
       while (i < nSegments) {
         val segment = segments(i)
 
-        // Fast path, jump down the tree:
-        val literalChild = subtree.literals.get(segment)
+        // Fast path, jump down the tree (single lookup instead of contains+apply):
+        val literalChild = subtree.literals.getOrElse(segment, null)
         if (
-          literalChild.isDefined
+          literalChild != null
           && (subtree.literalsWithCollisions.eq(Set.empty) || !skipLiteralsFor.contains(i))
         ) {
 
@@ -841,7 +841,7 @@ object PathCodec {
             trySkipLiteralIdx = i +: trySkipLiteralIdx
           }
 
-          subtree = literalChild.get
+          subtree = literalChild
 
           result = subtree.value
           i += 1

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -828,10 +828,10 @@ object PathCodec {
       while (i < nSegments) {
         val segment = segments(i)
 
-        // Fast path, jump down the tree (single lookup instead of contains+apply):
+        // Fast path, jump down the tree:
         val literalChild = subtree.literals.getOrElse(segment, null)
         if (
-          literalChild != null
+          (literalChild ne null)
           && (subtree.literalsWithCollisions.eq(Set.empty) || !skipLiteralsFor.contains(i))
         ) {
 


### PR DESCRIPTION
## Summary
- The route tree lookup in `SegmentSubtree.get` performed `contains(segment)` followed by `literals(segment)`, resulting in two map lookups for the same key.
- Replace with a single `.get(segment)` call and check `.isDefined`.
- This is primarily a code quality improvement. The performance difference is small since `String.hashCode` is cached after first computation and small maps (1-4 entries) use linear scanning.

## Test plan
- [x] All 24 PathCodecSpec tests pass
- [x] All 30 RouteSpec tests pass
- [x] `sbt 'zioHttpJVM/testOnly zio.http.codec.PathCodecSpec zio.http.RouteSpec'` — 54 tests pass