### PR TITLE
perf: cache headerType on Header.Custom via null-init field

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
@@ -400,19 +400,14 @@ object HeaderSpec extends ZIOHttpSpec {
     Headers(Header.Accept(MediaType.application.json), Header.ContentType(MediaType.application.json))
 
   private val customHeaderSpec = suite("Custom header")(
-    test("headerName returns lowercase name without allocating headerType") {
-      val h = Header.Custom("X-Request-Id", "abc-123")
+    test("headerType is cached and returns correct values") {
+      val h   = Header.Custom("X-Request-Id", "abc-123")
+      val ht1 = h.headerType
+      val ht2 = h.headerType
       assertTrue(
+        ht1 eq ht2,
         h.headerName == "x-request-id",
         h.renderedValue == "abc-123",
-      )
-    },
-    test("headerType is consistent with direct overrides") {
-      val h  = Header.Custom("Content-Type", "text/plain")
-      val ht = h.headerType
-      assertTrue(
-        ht.name == h.headerName,
-        ht.render(h) == h.renderedValue,
       )
     },
   )

--- a/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
@@ -382,6 +382,7 @@ object HeaderSpec extends ZIOHttpSpec {
         assert(result)(isLeft)
       },
     ),
+    customHeaderSpec,
   )
 
   private val acceptJson                = Headers(Header.Accept(MediaType.application.json))
@@ -397,4 +398,22 @@ object HeaderSpec extends ZIOHttpSpec {
 
   private def predefinedHeaders: Headers =
     Headers(Header.Accept(MediaType.application.json), Header.ContentType(MediaType.application.json))
+
+  private val customHeaderSpec = suite("Custom header")(
+    test("headerName returns lowercase name without allocating headerType") {
+      val h = Header.Custom("X-Request-Id", "abc-123")
+      assertTrue(
+        h.headerName == "x-request-id",
+        h.renderedValue == "abc-123",
+      )
+    },
+    test("headerType is consistent with direct overrides") {
+      val h  = Header.Custom("Content-Type", "text/plain")
+      val ht = h.headerType
+      assertTrue(
+        ht.name == h.headerName,
+        ht.render(h) == h.renderedValue,
+      )
+    },
+  )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -199,8 +199,20 @@ object Header {
     override type Self = Custom
     override def self: Self = this
 
-    override def headerName: String    = customName.toString.toLowerCase
-    override def renderedValue: String = value.toString
+    private[this] var _headerName: String    = _
+    private[this] var _renderedValue: String = _
+
+    override def headerName: String = {
+      var n = _headerName
+      if (n == null) { n = customName.toString.toLowerCase; _headerName = n }
+      n
+    }
+
+    override def renderedValue: String = {
+      var v = _renderedValue
+      if (v == null) { v = value.toString; _renderedValue = v }
+      v
+    }
 
     override def headerType: HeaderType.Typed[Custom] = new Header.HeaderType {
       override type HeaderValue = Custom

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -203,7 +203,7 @@ object Header {
 
     override def headerType: HeaderType.Typed[Custom] = {
       var ht = _headerType
-      if (ht == null) {
+      if (ht eq null) {
         ht = new Header.HeaderType {
           override type HeaderValue = Custom
 

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -199,29 +199,23 @@ object Header {
     override type Self = Custom
     override def self: Self = this
 
-    private[this] var _headerName: String    = _
-    private[this] var _renderedValue: String = _
+    private[this] var _headerType: HeaderType.Typed[Custom] = _
 
-    override def headerName: String = {
-      var n = _headerName
-      if (n == null) { n = customName.toString.toLowerCase; _headerName = n }
-      n
-    }
+    override def headerType: HeaderType.Typed[Custom] = {
+      var ht = _headerType
+      if (ht == null) {
+        ht = new Header.HeaderType {
+          override type HeaderValue = Custom
 
-    override def renderedValue: String = {
-      var v = _renderedValue
-      if (v == null) { v = value.toString; _renderedValue = v }
-      v
-    }
+          override def name: String = self.customName.toString.toLowerCase
 
-    override def headerType: HeaderType.Typed[Custom] = new Header.HeaderType {
-      override type HeaderValue = Custom
+          override def parse(value: String): Either[String, HeaderValue] = Right(Custom(self.customName, value))
 
-      override def name: String = self.headerName
-
-      override def parse(value: String): Either[String, HeaderValue] = Right(Custom(self.customName, value))
-
-      override def render(value: HeaderValue): String = value.renderedValue
+          override def render(value: HeaderValue): String = value.value.toString
+        }
+        _headerType = ht
+      }
+      ht
     }
 
     private[http] override def headerNameAsCharSequence: CharSequence    = customName

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -199,14 +199,17 @@ object Header {
     override type Self = Custom
     override def self: Self = this
 
+    override def headerName: String    = customName.toString.toLowerCase
+    override def renderedValue: String = value.toString
+
     override def headerType: HeaderType.Typed[Custom] = new Header.HeaderType {
       override type HeaderValue = Custom
 
-      override def name: String = self.customName.toString.toLowerCase
+      override def name: String = self.headerName
 
       override def parse(value: String): Either[String, HeaderValue] = Right(Custom(self.customName, value))
 
-      override def render(value: HeaderValue): String = value.value.toString
+      override def render(value: HeaderValue): String = value.renderedValue
     }
 
     private[http] override def headerNameAsCharSequence: CharSequence    = customName


### PR DESCRIPTION
## Summary
- `Header.Custom.headerType` is a `def` that allocates a new anonymous `HeaderType` on every call. The default `headerName` and `renderedValue` delegate to `headerType`, causing unnecessary allocation when these fields are accessed.
- Cache the `HeaderType` instance using a private null-init field so it is only allocated once per `Custom` header instance.
- Note: the primary hot path (incoming request headers via `Headers.Native`) is unaffected — this fixes the path for user-constructed headers.

## Test plan
- [x] All 50 existing HeaderSpec tests pass
- [x] Added test verifying `headerType` is cached (referential identity via `eq`) and returns correct values
- [x] `sbt 'zioHttpJVM/testOnly zio.http.HeaderSpec'` — 51 tests pass