### PR TITLE
perf: pre-build CORS allowed headers Set at construction time

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -49,6 +49,20 @@ object CorsSpec extends ZIOHttpSpec with TestExtensions {
     ),
   )
 
+  val appSomeAllowedHeaders = Routes(
+    Method.GET / "success" -> handler(Response.ok),
+  ).handleErrorCause { cause =>
+    Response(Status.InternalServerError, body = Body.fromString(cause.prettyPrint))
+  } @@ cors(
+    CorsConfig(
+      allowedOrigin = { case _ =>
+        Some(Header.AccessControlAllowOrigin.All)
+      },
+      allowedMethods = Header.AccessControlAllowMethods.All,
+      allowedHeaders = Header.AccessControlAllowHeaders.Some(zio.NonEmptyChunk("content-type", "authorization")),
+    ),
+  )
+
   val appNoServerHeaders = Routes(
     Method.GET / "success" -> handler(Response.ok),
   ).handleErrorCause { cause =>
@@ -280,6 +294,55 @@ object CorsSpec extends ZIOHttpSpec with TestExtensions {
         extractStatus(res) == Status.Ok,
         res.hasHeader(Header.AccessControlAllowOrigin("http", "allowed.com")),
       )
+    },
+    test("OPTIONS request with AllowedHeaders.Some returns intersection of requested and allowed headers") {
+      val request =
+        Request
+          .options(URL(Path.root / "success"))
+          .copy(
+            headers = Headers(
+              Header.Origin("http", "test-env"),
+              Header.AccessControlRequestMethod(Method.GET),
+              Header.AccessControlRequestHeaders(zio.NonEmptyChunk("content-type", "authorization", "x-custom-header")),
+            ),
+          )
+
+      for {
+        res <- appSomeAllowedHeaders.runZIO(request)
+      } yield {
+        val allowHeaders = res.header(Header.AccessControlAllowHeaders)
+        assertTrue(
+          extractStatus(res) == Status.NoContent,
+          allowHeaders.isDefined,
+          allowHeaders.get match {
+            case Header.AccessControlAllowHeaders.Some(values) =>
+              values.toSet == Set("content-type", "authorization")
+            case _                                             => false
+          },
+        )
+      }
+    },
+    test("OPTIONS request with AllowedHeaders.Some returns None when no intersection") {
+      val request =
+        Request
+          .options(URL(Path.root / "success"))
+          .copy(
+            headers = Headers(
+              Header.Origin("http", "test-env"),
+              Header.AccessControlRequestMethod(Method.GET),
+              Header.AccessControlRequestHeaders(zio.NonEmptyChunk("x-custom-header", "x-other-header")),
+            ),
+          )
+
+      for {
+        res <- appSomeAllowedHeaders.runZIO(request)
+      } yield {
+        val allowHeaders = res.header(Header.AccessControlAllowHeaders)
+        assertTrue(
+          extractStatus(res) == Status.NoContent,
+          allowHeaders.isEmpty || allowHeaders.get == Header.AccessControlAllowHeaders.None,
+        )
+      }
     },
   )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -79,6 +79,12 @@ object Middleware extends HandlerAspects {
    *   https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
    */
   def cors(config: CorsConfig): Middleware[Any] = {
+    // Pre-build the allowed headers Set once at construction time to avoid per-request allocation
+    val allowedHeadersSet: Option[Set[String]] = config.allowedHeaders match {
+      case Header.AccessControlAllowHeaders.Some(values) => Some(values.toSet)
+      case _                                             => None
+    }
+
     def allowedHeaders(
       requestedHeaders: Option[Header.AccessControlRequestHeaders],
       allowedHeaders: Header.AccessControlAllowHeaders,
@@ -86,10 +92,10 @@ object Middleware extends HandlerAspects {
       // Returning an intersection of requested headers and allowed headers
       // if there are no requested headers, we return the configured allowed headers without modification
       allowedHeaders match {
-        case Header.AccessControlAllowHeaders.Some(values) =>
+        case Header.AccessControlAllowHeaders.Some(_) =>
           requestedHeaders match {
             case Some(Header.AccessControlRequestHeaders(headers)) =>
-              val intersection = headers.toSet.intersect(values.toSet)
+              val intersection = headers.toSet.intersect(allowedHeadersSet.get)
               NonEmptyChunk.fromIterableOption(intersection) match {
                 case Some(values) => Header.AccessControlAllowHeaders.Some(values)
                 case None         => Header.AccessControlAllowHeaders.None

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -80,10 +80,11 @@ object Middleware extends HandlerAspects {
    */
   def cors(config: CorsConfig): Middleware[Any] = {
     // Pre-build the allowed headers Set once at construction time to avoid per-request allocation
-    val allowedHeadersSet: Option[Set[String]] = config.allowedHeaders match {
-      case Header.AccessControlAllowHeaders.Some(values) => Some(values.toSet)
-      case _                                             => None
-    }
+    val allowedHeadersSet: Set[String] =
+      config.allowedHeaders match {
+        case Header.AccessControlAllowHeaders.Some(values) => values.toSet
+        case _                                             => Set.empty
+      }
 
     def allowedHeaders(
       requestedHeaders: Option[Header.AccessControlRequestHeaders],
@@ -95,7 +96,7 @@ object Middleware extends HandlerAspects {
         case Header.AccessControlAllowHeaders.Some(_) =>
           requestedHeaders match {
             case Some(Header.AccessControlRequestHeaders(headers)) =>
-              val intersection = headers.toSet.intersect(allowedHeadersSet.get)
+              val intersection = headers.toSet.intersect(allowedHeadersSet)
               NonEmptyChunk.fromIterableOption(intersection) match {
                 case Some(values) => Header.AccessControlAllowHeaders.Some(values)
                 case None         => Header.AccessControlAllowHeaders.None

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -82,8 +82,8 @@ object Middleware extends HandlerAspects {
     // Pre-build the allowed headers Set once at construction time to avoid per-request allocation
     val allowedHeadersSet: Set[String] =
       config.allowedHeaders match {
-        case Header.AccessControlAllowHeaders.Some(values) => values.toSet
-        case _                                             => Set.empty
+        case s: Header.AccessControlAllowHeaders.Some => s.values.toSet
+        case _                                        => Set.empty
       }
 
     def allowedHeaders(
@@ -93,7 +93,7 @@ object Middleware extends HandlerAspects {
       // Returning an intersection of requested headers and allowed headers
       // if there are no requested headers, we return the configured allowed headers without modification
       allowedHeaders match {
-        case Header.AccessControlAllowHeaders.Some(_) =>
+        case _: Header.AccessControlAllowHeaders.Some =>
           requestedHeaders match {
             case Some(Header.AccessControlRequestHeaders(headers)) =>
               val intersection = headers.toSet.intersect(allowedHeadersSet)

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -103,12 +103,12 @@ object Middleware extends HandlerAspects {
               }
             case None                                              => allowedHeaders
           }
-        case Header.AccessControlAllowHeaders.All          =>
+        case Header.AccessControlAllowHeaders.All     =>
           requestedHeaders match {
             case Some(Header.AccessControlRequestHeaders(headers)) => Header.AccessControlAllowHeaders.Some(headers)
             case _                                                 => Header.AccessControlAllowHeaders.All
           }
-        case Header.AccessControlAllowHeaders.None         => Header.AccessControlAllowHeaders.None
+        case Header.AccessControlAllowHeaders.None    => Header.AccessControlAllowHeaders.None
       }
 
     def corsHeaders(


### PR DESCRIPTION
## Summary
- Pre-builds `values.toSet` at CORS middleware construction time instead of on every preflight request
- Only `headers.toSet` (the per-request requested headers) needs to remain per-request
- Adds tests for `AllowedHeaders.Some` intersection behavior and empty intersection

## Test plan
- [x] Existing CorsSpec tests pass (11 tests)
- [x] New test verifies intersection of requested and allowed headers returns correct subset
- [x] New test verifies empty intersection returns None