### PR TITLE
fix: prevent hashCode recomputation when computed value is 0 in SegmentCodec

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -45,7 +45,10 @@ sealed trait SegmentCodec[A] { self =>
   def format(value: A): Path
 
   override val hashCode: Int = {
-    if (_hashCode == 0) _hashCode = (this.getClass.getName(), render).hashCode
+    if (_hashCode == 0) {
+      val h = (this.getClass.getName(), render).hashCode
+      _hashCode = if (h == 0) 1 else h
+    }
     _hashCode
   }
 

--- a/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
@@ -101,5 +101,25 @@ object SegmentCodecSpec extends ZIOSpecDefault {
         assertTrue(codec.matches(path, 1) == 1)
       },
     ),
+    suite("hashCode")(
+      test("hashCode is stable across multiple calls") {
+        val codec = SegmentCodec.literal("test")
+        val hash1 = codec.hashCode
+        val hash2 = codec.hashCode
+        assertTrue(hash1 == hash2, hash1 != 0)
+      },
+      test("hashCode is non-zero for all standard segment codecs") {
+        val codecs: List[SegmentCodec[_]] = List(
+          SegmentCodec.empty,
+          SegmentCodec.literal("users"),
+          SegmentCodec.int("id"),
+          SegmentCodec.long("id"),
+          SegmentCodec.string("name"),
+          SegmentCodec.uuid("uuid"),
+          SegmentCodec.trailing,
+        )
+        assertTrue(codecs.forall(_.hashCode != 0))
+      },
+    ),
   )
 }


### PR DESCRIPTION
## Summary
- Applies the `if (h == 0) 1 else h` cached hashCode sentinel pattern to `SegmentCodec.hashCode`
- Prevents recomputation (including Tuple2 allocation) on every `hashCode` call when the computed value happens to be 0

### Background: the cached hashCode sentinel pattern

`SegmentCodec.hashCode` uses the lazily-initialized cached hashCode pattern described in Joshua Bloch's *Effective Java* (Item 11, 3rd edition):

```java
// Effective Java, Item 11 — Lazily initialized, cached hashCode
private volatile int hashCode;

@Override public int hashCode() {
    int result = hashCode;
    if (result == 0) {
        result = /* compute hash */;
        hashCode = result;
    }
    return result;
}
```

The canonical real-world example is [`java.lang.String.hashCode()`](https://github.com/openjdk-mirror/jdk7u-jdk/blob/master/src/share/classes/java/lang/String.java#L1452-L1466) in OpenJDK, which uses `hash == 0` as the sentinel for "not yet computed."

The one weakness of this pattern is that when the computed hash genuinely equals 0 (~1 in 2^32 probability), it will be recomputed on every call. The `if (h == 0) 1 else h` refinement remaps hash-0 to hash-1, eliminating even that edge case. The collision of mapping one extra value to 1 is negligible.

## Test plan
- [x] Existing SegmentCodecSpec tests pass (7 tests)
- [x] New test verifies hashCode is stable across multiple calls and non-zero
- [x] New test verifies all standard segment codec types produce non-zero hashCode