### PR TITLE
perf: pre-build fixed CORS headers at construction time

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -86,6 +86,24 @@ object Middleware extends HandlerAspects {
         case _                                        => Set.empty
       }
 
+    // Pre-build fixed headers at construction time to avoid per-request allocation.
+    // The repetition of config fields across branches is intentional: each call to
+    // Headers(...) produces a flat FromIterable, avoiding any Concat wrapper that
+    // Headers#++ would introduce.
+    val (nonPreflightHeaders, preflightBaseHeaders): (Headers, Headers) =
+      config.maxAge match {
+        case Some(maxAge) =>
+          (
+            Headers(config.allowedMethods, config.allowCredentials, config.exposedHeaders, maxAge),
+            Headers(config.allowedMethods, config.allowCredentials, maxAge),
+          )
+        case None         =>
+          (
+            Headers(config.allowedMethods, config.allowCredentials, config.exposedHeaders),
+            Headers(config.allowedMethods, config.allowCredentials),
+          )
+      }
+
     def allowedHeaders(
       requestedHeaders: Option[Header.AccessControlRequestHeaders],
       allowedHeaders: Header.AccessControlAllowHeaders,
@@ -116,15 +134,10 @@ object Middleware extends HandlerAspects {
       requestedHeaders: Option[Header.AccessControlRequestHeaders],
       isPreflight: Boolean,
     ): Headers =
-      Headers(
-        allowOrigin,
-        config.allowedMethods,
-        config.allowCredentials,
-      ) ++
-        Headers.ifThenElse(isPreflight)(
-          onTrue = Headers(allowedHeaders(requestedHeaders, config.allowedHeaders)),
-          onFalse = Headers(config.exposedHeaders),
-        ) ++ config.maxAge.fold(Headers.empty)(Headers(_))
+      if (isPreflight)
+        Headers(allowOrigin, allowedHeaders(requestedHeaders, config.allowedHeaders)) ++ preflightBaseHeaders
+      else
+        Headers(allowOrigin) ++ nonPreflightHeaders
 
     // HandlerAspect:
     val aspect =


### PR DESCRIPTION
## Summary

Pre-builds two `Headers` values at CORS middleware construction time, so that the per-request `corsHeaders` method only needs to wrap the request-dependent values (`allowOrigin` and, for preflight, the computed `allowedHeaders` intersection).

### What changed

**Construction time** — a single `config.maxAge` match builds both:
- `nonPreflightHeaders`: `Headers(allowedMethods, allowCredentials, exposedHeaders [, maxAge])`
- `preflightBaseHeaders`: `Headers(allowedMethods, allowCredentials [, maxAge])`

Each is built via the varargs `Headers(...)` factory, which produces a flat `FromIterable` with **zero** `Concat` wrappers. The config fields are intentionally repeated across branches to keep the result flat — extracting them into a shared base and using `++` would introduce `Concat` nodes.

**Per-request** — `corsHeaders` is now:
```scala
if (isPreflight)
  Headers(allowOrigin, computedAllowedHeaders) ++ preflightBaseHeaders
else
  Headers(allowOrigin) ++ nonPreflightHeaders
```
Both paths allocate exactly **1 `FromIterable` + 1 `Concat`** (down from 3 `FromIterable` + 2 `Concat` before).

### Allocation savings per request

| | Before | After |
|---|---|---|
| Non-preflight | 3 `FromIterable` + 2 `Concat` | 1 `FromIterable` + 1 `Concat` |
| Preflight | 3 `FromIterable` + 2 `Concat` | 1 `FromIterable` + 1 `Concat` |

## Test plan
- [x] All 11 existing CorsSpec tests pass