### PR TITLE
perf: avoid ConcatIterator allocation in Headers.Concat#iterator

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
@@ -382,6 +382,7 @@ object HeaderSpec extends ZIOHttpSpec {
         assert(result)(isLeft)
       },
     ),
+    concatSpec,
   )
 
   private val acceptJson                = Headers(Header.Accept(MediaType.application.json))
@@ -397,4 +398,29 @@ object HeaderSpec extends ZIOHttpSpec {
 
   private def predefinedHeaders: Headers =
     Headers(Header.Accept(MediaType.application.json), Header.ContentType(MediaType.application.json))
+
+  private val concatSpec = suite("Concat")(
+    test("iterator yields all headers from both sides in order") {
+      val left   = Headers(Header.ContentType(MediaType.application.json))
+      val right  = Headers(Header.Accept(MediaType.text.html))
+      val concat = left ++ right
+      val names  = concat.iterator.map(_.headerName).toList
+      assertTrue(names == List("content-type", "accept"))
+    },
+    test("iterator works with nested Concat") {
+      val a      = Headers(Header.ContentType(MediaType.application.json))
+      val b      = Headers(Header.Accept(MediaType.text.html))
+      val c      = Headers(Header.Host("example.com"))
+      val concat = a ++ b ++ c
+      val names  = concat.iterator.map(_.headerName).toList
+      assertTrue(names == List("content-type", "accept", "host"))
+    },
+    test("iterator works when one side is empty") {
+      val left   = Headers.empty
+      val right  = Headers(Header.Host("example.com"))
+      val concat = left ++ right
+      val names  = concat.iterator.map(_.headerName).toList
+      assertTrue(names == List("host"))
+    },
+  )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Headers.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Headers.scala
@@ -118,8 +118,12 @@ object Headers {
     override def contains(key: CharSequence): Boolean =
       first.contains(key) || second.contains(key)
 
-    override def iterator: Iterator[Header] =
-      first.iterator ++ second.iterator
+    override def iterator: Iterator[Header] = new Iterator[Header] {
+      private val firstIter  = first.iterator
+      private val secondIter = second.iterator
+      def hasNext: Boolean   = firstIter.hasNext || secondIter.hasNext
+      def next(): Header     = if (firstIter.hasNext) firstIter.next() else secondIter.next()
+    }
 
     private[http] override def getUnsafe(key: CharSequence): String = {
       val fromFirst = first.getUnsafe(key)


### PR DESCRIPTION
## Summary
- Replaces `first.iterator ++ second.iterator` with a hand-rolled `Iterator` in `Headers.Concat#iterator`
- `Iterator#++` allocates a `ConcatIterator` wrapper + a thunk for the by-name second argument — 2-3 objects per iteration
- The hand-rolled version allocates just 1 anonymous `Iterator` object that directly delegates `hasNext`/`next()` to the two underlying iterators
- This runs on the response write path (`headersToNetty` → `encodeHeaderListToNetty` → `.iterator`) for every response with `Concat` headers

## Test plan
- [x] All 53 existing HeaderSpec tests pass
- [x] New tests verify Concat iterator yields headers from both sides in order
- [x] New test verifies nested Concat iteration works correctly
- [x] New test verifies Concat with Empty side works correctly