### PR TITLE
feat: Add AuthType.Custom and AuthType.Or support to OpenAPI spec generation

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -281,6 +281,26 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
 
   private val endpointWithAuth = Endpoint(GET / "withAuth").auth(AuthType.Bearer)
 
+  private val endpointWithCustomHeaderAuth =
+    Endpoint(GET / "withCustomHeaderAuth")
+      .auth(AuthType.Custom(HttpCodec.headerAs[String]("x-Api-Token")))
+
+  private val endpointWithCustomQueryAuth =
+    Endpoint(GET / "withCustomQueryAuth")
+      .auth(AuthType.Custom(HttpCodec.query[String]("api_key")))
+
+  private val endpointWithMultiHeaderAuth =
+    Endpoint(GET / "withMultiHeaderAuth")
+      .auth(AuthType.Custom(HttpCodec.headerAs[String]("x-Api-Key") ++ HttpCodec.headerAs[String]("x-Tenant-Id")))
+
+  private val endpointWithCookieAuth =
+    Endpoint(GET / "withCookieAuth")
+      .auth(AuthType.Custom(HttpCodec.headerAs[String]("cookie")))
+
+  private val endpointWithOrAuth =
+    Endpoint(GET / "withOrAuth")
+      .auth(AuthType.Bearer | AuthType.Custom(HttpCodec.headerAs[String]("x-Api-Token")))
+
   def toJsonAst(str: String): Json =
     Json.decoder.decodeJson(str).toOption.get
 
@@ -4795,6 +4815,208 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |    }
             |  }
             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("custom header auth to OpenAPI") {
+        val generated    = OpenAPIGen.fromEndpoints("Custom Header Auth", "1.0", endpointWithCustomHeaderAuth)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Custom Header Auth",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withCustomHeaderAuth": {
+                             |      "get": {
+                             |        "security": [
+                             |          {
+                             |            "x-Api-Token": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "x-Api-Token": {
+                             |        "type": "apiKey",
+                             |        "name": "x-Api-Token",
+                             |        "in": "header"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "x-Api-Token": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("custom query auth to OpenAPI") {
+        val generated    = OpenAPIGen.fromEndpoints("Custom Query Auth", "1.0", endpointWithCustomQueryAuth)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Custom Query Auth",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withCustomQueryAuth": {
+                             |      "get": {
+                             |        "security": [
+                             |          {
+                             |            "api_key": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "api_key": {
+                             |        "type": "apiKey",
+                             |        "name": "api_key",
+                             |        "in": "query"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "api_key": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("custom cookie auth to OpenAPI") {
+        val generated    = OpenAPIGen.fromEndpoints("Cookie Auth", "1.0", endpointWithCookieAuth)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Cookie Auth",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withCookieAuth": {
+                             |      "get": {
+                             |        "security": [
+                             |          {
+                             |            "cookie": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "cookie": {
+                             |        "type": "apiKey",
+                             |        "name": "cookie",
+                             |        "in": "cookie"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "cookie": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("or auth to OpenAPI") {
+        val generated    = OpenAPIGen.fromEndpoints("Or Auth", "1.0", endpointWithOrAuth)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Or Auth",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withOrAuth": {
+                             |      "get": {
+                             |        "security": [
+                             |          {
+                             |            "Bearer": []
+                             |          },
+                             |          {
+                             |            "x-Api-Token": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "Bearer": {
+                             |        "type": "http",
+                             |        "scheme": "Bearer"
+                             |      },
+                             |      "x-Api-Token": {
+                             |        "type": "apiKey",
+                             |        "name": "x-Api-Token",
+                             |        "in": "header"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "Bearer": []
+                             |    },
+                             |    {
+                             |      "x-Api-Token": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("custom multi-header auth to OpenAPI") {
+        val generated    = OpenAPIGen.fromEndpoints("Multi Header Auth", "1.0", endpointWithMultiHeaderAuth)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Multi Header Auth",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withMultiHeaderAuth": {
+                             |      "get": {
+                             |        "security": [
+                             |          {
+                             |            "x-Api-Key": [],
+                             |            "x-Tenant-Id": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "x-Api-Key": {
+                             |        "type": "apiKey",
+                             |        "name": "x-Api-Key",
+                             |        "in": "header"
+                             |      },
+                             |      "x-Tenant-Id": {
+                             |        "type": "apiKey",
+                             |        "name": "x-Tenant-Id",
+                             |        "in": "header"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "x-Api-Key": [],
+                             |      "x-Tenant-Id": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
         assertTrue(json == toJsonAst(expectedJson))
       },
     )

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -729,7 +729,7 @@ object OpenAPIGen {
       endpointSecurity(endpoint)
 
     def customAuthSchemes(codec: HttpCodec[_, _]): List[(String, SecurityScheme.ApiKey)] = {
-      val atoms = AtomizedMetaCodecs.flatten(codec)
+      val atoms         = AtomizedMetaCodecs.flatten(codec)
       val headerSchemes = atoms.header.map { meta =>
         val headerAtom = meta.codec.asInstanceOf[HttpCodec.Header[_]]
         val name       = headerAtom.headerType.names.head
@@ -738,7 +738,7 @@ object OpenAPIGen {
           else SecurityScheme.ApiKey.In.Header
         (name, SecurityScheme.ApiKey(description = None, name = name, in = in))
       }.toList
-      val querySchemes = atoms.query.map { meta =>
+      val querySchemes  = atoms.query.map { meta =>
         val queryAtom = meta.codec.asInstanceOf[HttpCodec.Query[_]]
         val name      = queryAtom.codec.recordFields.head._1.fieldName
         (name, SecurityScheme.ApiKey(description = None, name = name, in = SecurityScheme.ApiKey.In.Query))

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -1037,9 +1037,9 @@ object OpenAPIGen {
           case AuthType.ScopedAuth(auth, _)                       =>
             loop(auth)
           case custom: AuthType.Custom[_]                         =>
-            ListMap.from(customAuthSchemes(custom.codec).map { case (name, scheme) =>
+            ListMap(customAuthSchemes(custom.codec).map { case (name, scheme) =>
               OpenAPI.Key.fromString(name).get -> ReferenceOr.Or(scheme)
-            })
+            }: _*)
           case or: AuthType.Or[_, _, _]                           =>
             loop(or.auth1) ++ loop(or.auth2)
           case _                                                  => ListMap.empty

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -728,14 +728,40 @@ object OpenAPIGen {
     ): List[SecurityRequirement] =
       endpointSecurity(endpoint)
 
+    def customAuthSchemes(codec: HttpCodec[_, _]): List[(String, SecurityScheme.ApiKey)] = {
+      val atoms = AtomizedMetaCodecs.flatten(codec)
+      val headerSchemes = atoms.header.map { meta =>
+        val headerAtom = meta.codec.asInstanceOf[HttpCodec.Header[_]]
+        val name       = headerAtom.headerType.names.head
+        val in         =
+          if (name.equalsIgnoreCase("cookie")) SecurityScheme.ApiKey.In.Cookie
+          else SecurityScheme.ApiKey.In.Header
+        (name, SecurityScheme.ApiKey(description = None, name = name, in = in))
+      }.toList
+      val querySchemes = atoms.query.map { meta =>
+        val queryAtom = meta.codec.asInstanceOf[HttpCodec.Query[_]]
+        val name      = queryAtom.codec.recordFields.head._1.fieldName
+        (name, SecurityScheme.ApiKey(description = None, name = name, in = SecurityScheme.ApiKey.In.Query))
+      }.toList
+      headerSchemes ++ querySchemes
+    }
+
     def endpointSecurity(endpoint: Endpoint[_, _, _, _, _]): List[SecurityRequirement] = {
-      endpoint.authType match {
+      def loop(authType: AuthType): List[SecurityRequirement] = authType match {
         case AuthType.ScopedAuth(auth, scopes)                  =>
-          List(SecurityRequirement(Map(auth.toString() -> scopes)))
+          loop(auth).map { req =>
+            SecurityRequirement(req.securitySchemes.map { case (k, _) => k -> scopes })
+          }
         case AuthType.Basic | AuthType.Bearer | AuthType.Digest =>
-          List(SecurityRequirement(Map(endpoint.authType.toString() -> Nil)))
+          List(SecurityRequirement(Map(authType.toString() -> Nil)))
+        case custom: AuthType.Custom[_]                         =>
+          val schemes = customAuthSchemes(custom.codec)
+          List(SecurityRequirement(schemes.map { case (name, _) => name -> Nil }.toMap))
+        case or: AuthType.Or[_, _, _]                           =>
+          loop(or.auth1) ++ loop(or.auth2)
         case _                                                  => Nil
       }
+      loop(endpoint.authType.asInstanceOf[AuthType])
     }
 
     def operation(endpoint: Endpoint[_, _, _, _, _]): OpenAPI.Operation = {
@@ -994,32 +1020,32 @@ object OpenAPIGen {
     def httpSecuritySchemes(
       endpoint: Endpoint[_, _, _, _, _],
       params: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]],
-    ): ListMap[Key, ReferenceOr[SecurityScheme]] =
-      endpoint.authType match {
-        case AuthType.Basic | AuthType.Bearer | AuthType.Digest =>
-          ListMap(
-            OpenAPI.Key.fromString(endpoint.authType.toString()).get ->
-              ReferenceOr.Or[SecurityScheme.Http](
-                SecurityScheme.Http(
-                  scheme = endpoint.authType.toString(),
-                  bearerFormat = None,
-                  description = None,
+    ): ListMap[Key, ReferenceOr[SecurityScheme]] = {
+      def loop(authType: AuthType): ListMap[Key, ReferenceOr[SecurityScheme]] =
+        authType match {
+          case AuthType.Basic | AuthType.Bearer | AuthType.Digest =>
+            ListMap(
+              OpenAPI.Key.fromString(authType.toString()).get ->
+                ReferenceOr.Or[SecurityScheme.Http](
+                  SecurityScheme.Http(
+                    scheme = authType.toString(),
+                    bearerFormat = None,
+                    description = None,
+                  ),
                 ),
-              ),
-          )
-        case AuthType.ScopedAuth(auth, _)                       =>
-          ListMap(
-            OpenAPI.Key.fromString(auth.toString()).get ->
-              ReferenceOr.Or[SecurityScheme.Http](
-                SecurityScheme.Http(
-                  scheme = auth.toString(),
-                  bearerFormat = None,
-                  description = None,
-                ),
-              ),
-          )
-        case _                                                  => ListMap.empty
-      }
+            )
+          case AuthType.ScopedAuth(auth, _)                       =>
+            loop(auth)
+          case custom: AuthType.Custom[_]                         =>
+            ListMap.from(customAuthSchemes(custom.codec).map { case (name, scheme) =>
+              OpenAPI.Key.fromString(name).get -> ReferenceOr.Or(scheme)
+            })
+          case or: AuthType.Or[_, _, _]                           =>
+            loop(or.auth1) ++ loop(or.auth2)
+          case _                                                  => ListMap.empty
+        }
+      loop(endpoint.authType.asInstanceOf[AuthType])
+    }
 
     def getSecuritySchemes(
       endpoint: Endpoint[_, _, _, _, _],


### PR DESCRIPTION
closes #3992 
## Why
The OpenAPI spec generator did not handle `AuthType.Custom` or `AuthType.Or`, meaning endpoints using custom header/query/cookie authentication or alternative auth schemes were missing their security definitions in the generated OpenAPI spec.

## How
Refactored `endpointSecurity` and `httpSecuritySchemes` into recursive `loop` functions that pattern-match on all `AuthType` variants including `Custom`, `Or`, and nested `ScopedAuth`. Added a `customAuthSchemes` helper that introspects `HttpCodec` atoms to extract header and query parameter names and map them to `SecurityScheme.ApiKey` entries with the correct `in` location (header, query, or cookie via heuristic on the header name).

`AuthType.Or` produces multiple `SecurityRequirement` entries (OR semantics per OpenAPI spec), while `AuthType.Custom` with composed codecs (`++`) places all schemes in a single `SecurityRequirement` (AND semantics).
