### PR TITLE
fix: prevent response header interleaving on keep-alive connections (#3395)

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -194,7 +194,15 @@ private[zio] final case class ServerInboundHandler(
               }
 
             ctx.writeAndFlush(jResponse)
-            NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx)
+            NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx) match {
+              case Some(bodyTask) =>
+                ctx.channel().config().setAutoRead(false)
+                Some(bodyTask.ensuring(ZIO.succeed {
+                  ctx.channel().config().setAutoRead(true)
+                  ctx.channel().read()
+                }))
+              case None           => None
+            }
           } else {
             ctx.writeAndFlush(jResponse)
             None

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -196,10 +196,14 @@ private[zio] final case class ServerInboundHandler(
             ctx.writeAndFlush(jResponse)
             NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx) match {
               case Some(bodyTask) =>
-                ctx.channel().config().setAutoRead(false)
+                val channelConfig    = ctx.channel().config()
+                val previousAutoRead = channelConfig.isAutoRead
+                if (previousAutoRead) channelConfig.setAutoRead(false)
                 Some(bodyTask.ensuring(ZIO.succeed {
-                  ctx.channel().config().setAutoRead(true)
-                  ctx.channel().read()
+                  if (previousAutoRead) {
+                    channelConfig.setAutoRead(true)
+                    ctx.channel().read()
+                  }
                 }))
               case None           => None
             }

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -21,7 +21,7 @@ import java.nio.file.Files
 
 import zio._
 import zio.test.Assertion._
-import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.test.TestAspect.{sequential, timeout, withLiveClock}
 import zio.test._
 
 import zio.http.internal.{DynamicServer, RoutesRunnableSpec, serverTestLayer}
@@ -378,7 +378,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         for {
           tempDir <- ZIO.attemptBlocking {
             val dir = Files.createTempDirectory("static-test").toFile
-            (0 until 10).foreach { i =>
+            (0 until 3).foreach { i =>
               val file = new File(dir, s"file-$i.txt")
               Files.write(file.toPath, s"content-$i".getBytes)
             }
@@ -394,12 +394,12 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
             },
           )
           port    <- Server.installRoutes(routes)
-          urls = (0 until 10).map(i => URL.decode(s"http://localhost:$port/files/file-$i.txt").toOption.get).toList
+          urls = (0 until 3).map(i => URL.decode(s"http://localhost:$port/files/file-$i.txt").toOption.get).toList
           results <- ZIO
             .foreachPar(urls) { url =>
               ZIO.serviceWithZIO[Client](_.request(Request.get(url)))
             }
-            .repeatN(9)
+            .repeatN(2)
           _       <- ZIO.attemptBlocking {
             tempDir.listFiles().foreach(_.delete())
             tempDir.delete()
@@ -409,7 +409,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
           results.forall(_.headers.get(Header.ContentType).isDefined),
         )
       }
-    },
+    } @@ TestAspect.timeout(2.minutes),
   )
 
   private def createTestFile(content: String): ZIO[Scope, Throwable, File] =

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -376,14 +376,21 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
     test("concurrent file requests return proper headers") {
       ZIO.scoped {
         for {
-          tempDir <- ZIO.attemptBlocking {
-            val dir = Files.createTempDirectory("static-test").toFile
-            (0 until 3).foreach { i =>
-              val file = new File(dir, s"file-$i.txt")
-              Files.write(file.toPath, s"content-$i".getBytes)
-            }
-            dir
-          }
+          tempDir <- ZIO.acquireRelease(
+            ZIO.attemptBlocking {
+              val dir = Files.createTempDirectory("static-test").toFile
+              (0 until 3).foreach { i =>
+                val file = new File(dir, s"file-$i.txt")
+                Files.write(file.toPath, s"content-$i".getBytes(Charsets.Utf8))
+              }
+              dir
+            },
+          )(dir =>
+            ZIO.attemptBlocking {
+              dir.listFiles().foreach(_.delete())
+              dir.delete()
+            }.ignoreLogged,
+          )
           routes = Routes(
             Method.GET / "files" / trailing -> Handler.fromFunctionHandler[(Path, Request)] {
               case (path: Path, _: Request) =>
@@ -396,14 +403,12 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
           port    <- Server.installRoutes(routes)
           urls = (0 until 3).map(i => URL.decode(s"http://localhost:$port/files/file-$i.txt").toOption.get).toList
           results <- ZIO
-            .foreachPar(urls) { url =>
-              ZIO.serviceWithZIO[Client](_.request(Request.get(url)))
+            .foreach(0 to 2) { _ =>
+              ZIO.foreachPar(urls) { url =>
+                ZIO.serviceWithZIO[Client](_.request(Request.get(url)))
+              }
             }
-            .repeatN(2)
-          _       <- ZIO.attemptBlocking {
-            tempDir.listFiles().foreach(_.delete())
-            tempDir.delete()
-          }
+            .map(_.flatten)
         } yield assertTrue(
           results.forall(_.status == Status.Ok),
           results.forall(_.headers.get(Header.ContentType).isDefined),

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -46,7 +46,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
       .deploy
 
   override def spec = suite("StaticFileServerSpec") {
-    serve.as(List(staticSpec, rangeSpec))
+    serve.as(List(staticSpec, rangeSpec, concurrentSpec))
   }.provideShared(Scope.default, DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock @@ sequential
 
   private def staticSpec = suite("Static RandomAccessFile Server")(
@@ -370,6 +370,46 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
         )
       },
     ),
+  )
+
+  private def concurrentSpec = suite("Concurrent file responses")(
+    test("concurrent file requests return proper headers") {
+      ZIO.scoped {
+        for {
+          tempDir <- ZIO.attemptBlocking {
+            val dir = Files.createTempDirectory("static-test").toFile
+            (0 until 10).foreach { i =>
+              val file = new File(dir, s"file-$i.txt")
+              Files.write(file.toPath, s"content-$i".getBytes)
+            }
+            dir
+          }
+          routes = Routes(
+            Method.GET / "files" / trailing -> Handler.fromFunctionHandler[(Path, Request)] {
+              case (path: Path, _: Request) =>
+                Handler
+                  .fromFileZIO(ZIO.attempt(new File(tempDir, path.encode)))
+                  .orElse(Handler.notFound)
+                  .contramap(_._2)
+            },
+          )
+          port    <- Server.installRoutes(routes)
+          urls = (0 until 10).map(i => URL.decode(s"http://localhost:$port/files/file-$i.txt").toOption.get).toList
+          results <- ZIO
+            .foreachPar(urls) { url =>
+              ZIO.serviceWithZIO[Client](_.request(Request.get(url)))
+            }
+            .repeatN(9)
+          _       <- ZIO.attemptBlocking {
+            tempDir.listFiles().foreach(_.delete())
+            tempDir.delete()
+          }
+        } yield assertTrue(
+          results.forall(_.status == Status.Ok),
+          results.forall(_.headers.get(Header.ContentType).isDefined),
+        )
+      }
+    },
   )
 
   private def createTestFile(content: String): ZIO[Scope, Throwable, File] =


### PR DESCRIPTION
## Summary

- Disables Netty auto-read while streaming response bodies on keep-alive connections to prevent response interleaving
- When a non-`FullHttpResponse` body is being written, `setAutoRead(false)` prevents Netty from reading the next HTTP request until the current body write completes
- Auto-read is re-enabled via `ensuring` to guarantee cleanup even on errors
- Adds concurrent file serving test to `StaticFileServerSpec` to verify headers are preserved under parallel load

## Problem

On keep-alive connections serving streaming responses (e.g., static files), Netty's event loop could read and begin processing the next HTTP request while the previous response body was still being written. This caused response headers from one request to be interleaved with the body of another, resulting in missing `Content-Type` and other headers on the client side.

## Fix

In `ServerInboundHandler.attemptFullWrite`, after writing the HTTP response header for streaming bodies, the channel's auto-read is disabled. The body write task is wrapped with `ensuring` to re-enable auto-read and trigger a manual `read()` once the body is fully written. This serializes request processing per connection during body streaming while preserving full concurrency for non-streaming (`FullHttpResponse`) responses.

Closes #3395