### PR TITLE
feat: configurable auth failure response status (#3235)

### DIFF
--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -669,6 +669,43 @@ val routes = Routes(
 ) @@ multiAuthMiddleware
 ```
 
+### Configuring Auth Failure Response
+
+When authentication fails (missing or invalid credentials), the endpoint returns `404 Not Found` by default. This is the most secure default: it doesn't reveal whether the resource exists (the same approach used by GitHub).
+
+To customize the response status, use `.unauthorizedStatus(Status)`:
+
+```scala mdoc:compile-only
+import zio.http._
+import zio.http.endpoint._
+
+val endpoint = Endpoint(Method.GET / "me" / "profile")
+  .out[List[Book]]
+  .auth(AuthType.Bearer)
+  .unauthorizedStatus(Status.Unauthorized)
+```
+
+When the status is `401 Unauthorized`, ZIO HTTP automatically includes the `WWW-Authenticate` header in the response per RFC 7235.
+
+You can use any `Status` value:
+
+```scala mdoc:compile-only
+import zio.http._
+import zio.http.endpoint._
+
+val forbiddenEndpoint = Endpoint(Method.GET / "admin" / "panel")
+  .out[List[Book]]
+  .auth(AuthType.Bearer)
+  .unauthorizedStatus(Status.Forbidden)
+
+val badRequestEndpoint = Endpoint(Method.GET / "api" / "data")
+  .out[List[Book]]
+  .auth(AuthType.Basic)
+  .unauthorizedStatus(Status.BadRequest)
+```
+
+The configured status is automatically reflected in the generated OpenAPI specification.
+
 ## Transforming Endpoint Input/Output and Error Types
 
 To transform the input, output, and error types of an endpoint, we can use the `Endpoint#transformIn`, `Endpoint#transformOut`, and `Endpoint#transformError` methods, respectively. Let's see an example:

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -47,6 +47,8 @@ object MimaSettings {
         ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.codec.RichTextCodec.|"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.DnsResolver#CachingResolver.this"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.DnsResolver#CachingResolver.make"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.endpoint.AuthType.unauthorizedStatus"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.endpoint.AuthType.withUnauthorizedStatus"),
       ),
       mimaFailOnProblem := failOnProblem,
     )

--- a/zio-http-gen/src/test/resources/EndpointWithAuth.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithAuth.scala
@@ -8,6 +8,7 @@ object Users {
   import zio.http.codec._
   val get = Endpoint(Method.GET / "api" / "v1" / "users")
     .in[Unit]
+    .outError[Unit](status = Status.NotFound)
     .auth(AuthType.Bearer)
 
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -105,7 +105,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                     headersCode = Code.HeadersCode.empty,
                     inCode = Code.InCode("Unit"),
                     outCodes = Nil,
-                    errorsCode = Nil,
+                    errorsCode = List(Code.OutCode("Unit", Status.NotFound, Some("application/json"), None, false)),
                     authTypeCode = Some(Code.AuthTypeCode("Bearer")),
                   ),
                 ),

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
@@ -263,7 +263,69 @@ object AuthSpec extends ZIOSpecDefault {
         for {
           response <- response
           status = response.status
-        } yield assertTrue(status == Status.Unauthorized)
+        } yield assertTrue(status == Status.NotFound)
+      },
+      test("Missing Authorization header returns 404 by default") {
+        val endpoint =
+          Endpoint(Method.GET / "test-missing-auth").out[String](MediaType.text.`plain`).auth(AuthType.Bearer)
+        val routes   =
+          Routes(
+            endpoint.implementHandler(handler((_: Unit) => "Response")),
+          )
+        val response = routes.run(
+          Request(
+            method = Method.GET,
+            url = url"/test-missing-auth",
+            headers = Headers(Header.Accept(MediaType.text.`plain`)),
+          ),
+        )
+        for {
+          response <- response
+          status = response.status
+        } yield assertTrue(status == Status.NotFound)
+      },
+      test("Missing Authorization header returns 401 when configured") {
+        val endpoint = Endpoint(Method.GET / "test-auth-401")
+          .out[String](MediaType.text.`plain`)
+          .auth(AuthType.Bearer)
+          .unauthorizedStatus(Status.Unauthorized)
+        val routes   =
+          Routes(
+            endpoint.implementHandler(handler((_: Unit) => "Response")),
+          )
+        val response = routes.run(
+          Request(
+            method = Method.GET,
+            url = url"/test-auth-401",
+            headers = Headers(Header.Accept(MediaType.text.`plain`)),
+          ),
+        )
+        for {
+          response <- response
+          status     = response.status
+          hasWwwAuth = response.headers.contains("www-authenticate")
+        } yield assertTrue(status == Status.Unauthorized, hasWwwAuth)
+      },
+      test("Missing Authorization header returns custom status") {
+        val endpoint = Endpoint(Method.GET / "test-auth-custom")
+          .out[String](MediaType.text.`plain`)
+          .auth(AuthType.Bearer)
+          .unauthorizedStatus(Status.BadRequest)
+        val routes   =
+          Routes(
+            endpoint.implementHandler(handler((_: Unit) => "Response")),
+          )
+        val response = routes.run(
+          Request(
+            method = Method.GET,
+            url = url"/test-auth-custom",
+            headers = Headers(Header.Accept(MediaType.text.`plain`)),
+          ),
+        )
+        for {
+          response <- response
+          status = response.status
+        } yield assertTrue(status == Status.BadRequest)
       },
     )
 

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -357,6 +357,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "Bearer": []
@@ -393,6 +398,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withAuthScopes": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "Bearer": ["read", "write"]
@@ -4921,6 +4931,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withCustomHeaderAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "x-Api-Token": []
@@ -4958,6 +4973,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withCustomQueryAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "api_key": []
@@ -4995,6 +5015,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withCookieAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "cookie": []
@@ -5032,6 +5057,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withOrAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "Bearer": []
@@ -5079,6 +5109,11 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |  "paths": {
                              |    "/withMultiHeaderAuth": {
                              |      "get": {
+                             |        "responses": {
+                             |          "404": {
+                             |            "description": "Not Found\n\n"
+                             |          }
+                             |        },
                              |        "security": [
                              |          {
                              |            "x-Api-Key": [],
@@ -5106,6 +5141,48 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |    {
                              |      "x-Api-Key": [],
                              |      "x-Tenant-Id": []
+                             |    }
+                             |  ]
+                             |}""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
+      test("auth with custom 401 status to OpenAPI") {
+        val endpoint401  = Endpoint(GET / "withAuth401").auth(AuthType.Bearer).unauthorizedStatus(Status.Unauthorized)
+        val generated    = OpenAPIGen.fromEndpoints("Endpoint with Auth 401", "1.0", endpoint401)
+        val json         = toJsonAst(generated)
+        val expectedJson = """{
+                             |  "openapi": "3.1.0",
+                             |  "info": {
+                             |    "title": "Endpoint with Auth 401",
+                             |    "version": "1.0"
+                             |  },
+                             |  "paths": {
+                             |    "/withAuth401": {
+                             |      "get": {
+                             |        "responses": {
+                             |          "401": {
+                             |            "description": "Unauthorized\n\n"
+                             |          }
+                             |        },
+                             |        "security": [
+                             |          {
+                             |            "Bearer": []
+                             |          }
+                             |        ]
+                             |      }
+                             |    }
+                             |  },
+                             |  "components": {
+                             |    "securitySchemes": {
+                             |      "Bearer": {
+                             |        "type": "http",
+                             |        "scheme": "Bearer"
+                             |      }
+                             |    }
+                             |  },
+                             |  "security": [
+                             |    {
+                             |      "Bearer": []
                              |    }
                              |  ]
                              |}""".stripMargin

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
@@ -7,6 +7,12 @@ sealed trait AuthType { self =>
   type ClientRequirement
   def codec: HttpCodec[HttpCodecType.RequestType, ClientRequirement]
 
+  def unauthorizedStatus: Status                       = Status.NotFound
+  def withUnauthorizedStatus(status: Status): AuthType =
+    AuthType
+      .WithStatus(self.asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }], status)
+      .asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }]
+
   def |[ClientReq2, ClientReq](that: AuthType { type ClientRequirement = ClientReq2 })(implicit
     alternator: Alternator.WithOut[ClientRequirement, ClientReq2, ClientReq],
   ): AuthType { type ClientRequirement = ClientReq } =
@@ -59,6 +65,16 @@ object AuthType {
     type ClientRequirement = ClientReq
     override val codec: HttpCodec[HttpCodecType.RequestType, ClientReq] =
       auth1.codec.orElseEither(auth2.codec)(alternator)
+
+    override def unauthorizedStatus: Status = auth1.unauthorizedStatus
+  }
+
+  final case class WithStatus[ClientReq](
+    authType: AuthType { type ClientRequirement = ClientReq },
+    override val unauthorizedStatus: Status,
+  ) extends AuthType {
+    type ClientRequirement = ClientReq
+    override val codec: HttpCodec[HttpCodecType.RequestType, ClientReq] = authType.codec
   }
 
   final case class ScopedAuth[ClientReq](
@@ -67,6 +83,8 @@ object AuthType {
   ) extends AuthType {
     type ClientRequirement = ClientReq
     override val codec: HttpCodec[HttpCodecType.RequestType, ClientReq] = authType.codec
+
+    override def unauthorizedStatus: Status = authType.unauthorizedStatus
 
     def scopes: List[String] = _scopes
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -361,11 +361,12 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
             val wwwAuth = (auth match {
               case AuthType.Basic            => Header.WWWAuthenticate.Basic()
               case AuthType.Bearer           => Header.WWWAuthenticate.Bearer(realm = "")
-              case AuthType.Digest           => Header.WWWAuthenticate.Bearer(realm = "")
+              case AuthType.Digest           => Header.WWWAuthenticate.Digest(realm = Some(""))
               case AuthType.WithStatus(a, _) =>
                 (a: AuthType) match {
                   case AuthType.Basic  => Header.WWWAuthenticate.Basic()
                   case AuthType.Bearer => Header.WWWAuthenticate.Bearer(realm = "")
+                  case AuthType.Digest => Header.WWWAuthenticate.Digest(realm = Some(""))
                   case _               => Header.WWWAuthenticate.Bearer(realm = "")
                 }
               case _                         => Header.WWWAuthenticate.Bearer(realm = "")
@@ -460,9 +461,10 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
               case Some(HttpCodecError.CustomError("SchemaTransformationFailure", message))
                   if maybeUnauthedResponse.isDefined && message.endsWith(" auth required") =>
                 maybeUnauthedResponse.get
-              case Some(_: HttpCodecError.MissingHeader) if maybeUnauthedResponse.isDefined =>
+              case Some(e: HttpCodecError.MissingHeader)
+                  if maybeUnauthedResponse.isDefined && e.headerName.toLowerCase == "authorization" =>
                 maybeUnauthedResponse.get
-              case Some(_)                                                                  =>
+              case Some(_) =>
                 Handler.fromFunctionZIO { (request: zio.http.Request) =>
                   val error    = cause.defects.head.asInstanceOf[HttpCodecError]
                   val response = {
@@ -477,7 +479,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
                   }
                   ZIO.succeed(response)
                 }
-              case None                                                                     =>
+              case None    =>
                 Handler.failCause(cause)
             }
           }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -201,6 +201,9 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
   def auth[Auth0 <: AuthType](auth: Auth0): Endpoint[PathInput, Input, Err, Output, Auth0] =
     copy(authType = auth)
 
+  def unauthorizedStatus(status: Status): Endpoint[PathInput, Input, Err, Output, Auth] =
+    copy(authType = authType.withUnauthorizedStatus(status).asInstanceOf[Auth])
+
   def scopes: List[String] = authScopesRecursive(authType)
 
   private def authScopesRecursive(authType: AuthType): List[String] = authType match {
@@ -352,7 +355,26 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
 
     val maybeUnauthedResponse = authType.asInstanceOf[AuthType] match {
       case AuthType.None => None
-      case _             => Some(Handler.succeed(Response.unauthorized))
+      case auth          =>
+        val resp = auth.unauthorizedStatus match {
+          case Status.Unauthorized =>
+            val wwwAuth = (auth match {
+              case AuthType.Basic            => Header.WWWAuthenticate.Basic()
+              case AuthType.Bearer           => Header.WWWAuthenticate.Bearer(realm = "")
+              case AuthType.Digest           => Header.WWWAuthenticate.Bearer(realm = "")
+              case AuthType.WithStatus(a, _) =>
+                (a: AuthType) match {
+                  case AuthType.Basic  => Header.WWWAuthenticate.Basic()
+                  case AuthType.Bearer => Header.WWWAuthenticate.Bearer(realm = "")
+                  case _               => Header.WWWAuthenticate.Bearer(realm = "")
+                }
+              case _                         => Header.WWWAuthenticate.Bearer(realm = "")
+            }): Header.WWWAuthenticate
+            Response(status = Status.Unauthorized, headers = Headers(wwwAuth))
+          case status              =>
+            Response(status = status)
+        }
+        Some(Handler.succeed(resp))
     }
 
     def handlers(
@@ -438,7 +460,9 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
               case Some(HttpCodecError.CustomError("SchemaTransformationFailure", message))
                   if maybeUnauthedResponse.isDefined && message.endsWith(" auth required") =>
                 maybeUnauthedResponse.get
-              case Some(_) =>
+              case Some(_: HttpCodecError.MissingHeader) if maybeUnauthedResponse.isDefined =>
+                maybeUnauthedResponse.get
+              case Some(_)                                                                  =>
                 Handler.fromFunctionZIO { (request: zio.http.Request) =>
                   val error    = cause.defects.head.asInstanceOf[HttpCodecError]
                   val response = {
@@ -453,7 +477,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
                   }
                   ZIO.succeed(response)
                 }
-              case None    =>
+              case None                                                                     =>
                 Handler.failCause(cause)
             }
           }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -346,6 +346,8 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
         authCodec(auth1).orElseEither(authCodec(auth2))(Alternator.leftRightEqual[Unit])
       case AuthType.ScopedAuth(auth, _) =>
         authCodec(auth)
+      case AuthType.WithStatus(auth, _) =>
+        authCodec(auth)
     }
 
     val maybeUnauthedResponse = authType.asInstanceOf[AuthType] match {

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -764,6 +764,23 @@ object OpenAPIGen {
       loop(endpoint.authType.asInstanceOf[AuthType])
     }
 
+    def authResponse(endpoint: Endpoint[_, _, _, _, _]): OpenAPI.Responses = {
+      val authType = endpoint.authType.asInstanceOf[AuthType]
+      if (authType == AuthType.None) Map.empty
+      else {
+        val status      = authType.unauthorizedStatus
+        val statusKey   = OpenAPI.StatusOrDefault.StatusValue(status)
+        val description = status match {
+          case Status.Unauthorized => "Unauthorized"
+          case Status.NotFound     => "Not Found"
+          case Status.Forbidden    => "Forbidden"
+          case Status.BadRequest   => "Bad Request"
+          case other               => other.text
+        }
+        Map(statusKey -> OpenAPI.ReferenceOr.Or(OpenAPI.Response(description = Some(Doc.p(description)))))
+      }
+    }
+
     def operation(endpoint: Endpoint[_, _, _, _, _]): OpenAPI.Operation = {
       val maybeDoc = Some(endpoint.documentation + pathDoc).filter(!_.isEmpty)
       OpenAPI.Operation(
@@ -774,7 +791,7 @@ object OpenAPIGen {
         operationId = None,
         parameters = parameters,
         requestBody = requestBody,
-        responses = responses,
+        responses = authResponse(endpoint) ++ responses,
         callbacks = Map.empty,
         security = getSecurity(endpoint),
         servers = Nil,

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -767,8 +767,14 @@ object OpenAPIGen {
     }
 
     def authResponse(endpoint: Endpoint[_, _, _, _, _]): OpenAPI.Responses = {
-      val authType = endpoint.authType.asInstanceOf[AuthType]
-      if (authType == AuthType.None) Map.empty
+      val authType                      = endpoint.authType.asInstanceOf[AuthType]
+      def isNone(at: AuthType): Boolean = at match {
+        case AuthType.None             => true
+        case AuthType.WithStatus(a, _) => isNone(a)
+        case AuthType.ScopedAuth(a, _) => isNone(a)
+        case _                         => false
+      }
+      if (isNone(authType)) Map.empty
       else {
         val status      = authType.unauthorizedStatus
         val statusKey   = OpenAPI.StatusOrDefault.StatusValue(status)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -759,6 +759,8 @@ object OpenAPIGen {
           List(SecurityRequirement(schemes.map { case (name, _) => name -> Nil }.toMap))
         case or: AuthType.Or[_, _, _]                           =>
           loop(or.auth1) ++ loop(or.auth2)
+        case AuthType.WithStatus(auth, _)                       =>
+          loop(auth)
         case _                                                  => Nil
       }
       loop(endpoint.authType.asInstanceOf[AuthType])
@@ -1063,6 +1065,8 @@ object OpenAPIGen {
             }: _*)
           case or: AuthType.Or[_, _, _]                           =>
             loop(or.auth1) ++ loop(or.auth2)
+          case AuthType.WithStatus(auth, _)                       =>
+            loop(auth)
           case _                                                  => ListMap.empty
         }
       loop(endpoint.authType.asInstanceOf[AuthType])


### PR DESCRIPTION
## Summary

Fixes #3235 — Missing Authorization header returned 400 (Bad Request) instead of a meaningful auth failure response.
/claim #3235 

**Changes:**
- Default auth failure response is now **404 (Not Found)** — most secure, doesn't reveal whether the resource exists (same approach as GitHub)
- New `.unauthorizedStatus(Status)` builder method on `Endpoint` for customization:
  ```scala
  endpoint.auth(AuthType.Bearer).unauthorizedStatus(Status.Unauthorized) // RFC-compliant 401
  ```
- When status is 401, `WWW-Authenticate` header is automatically included per RFC 7235
- `MissingHeader("authorization")` errors are now correctly routed to the auth failure handler (previously fell through to generic 400)
- OpenAPI spec generation reflects the configured auth failure status
- Closed community PRs #3948, #3614, #3945 with explanation

## Files Changed
- `AuthType.scala` — Added `unauthorizedStatus`, `withUnauthorizedStatus`, `WithStatus` case class
- `Endpoint.scala` — Added builder method, configurable auth failure response, `MissingHeader` catch
- `OpenAPIGen.scala` — Added `authResponse` helper, `WithStatus` handling in security schemes
- `MimaSettings.scala` — Binary compatibility filters for new trait methods
- `AuthSpec.scala` — Updated existing test + 3 new tests for configurable status
- `OpenAPIGenSpec.scala` — Updated 7 existing auth tests + 1 new test for custom 401 status