### PR TITLE
call remove element function in SSE `executeScript`

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/ServerSentEventGenerator.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/ServerSentEventGenerator.scala
@@ -136,7 +136,7 @@ object ServerSentEventGenerator {
     options: ExecuteScriptOptions,
   ): ZIO[Datastar, Nothing, Unit] = {
     val removeAttr =
-      if (options.autoRemove) Dom.attr("data-effect", AttributeValue.StringValue("el.remove")) else Dom.empty
+      if (options.autoRemove) Dom.attr("data-effect", AttributeValue.StringValue("el.remove()")) else Dom.empty
     patchElements(
       script0(removeAttr)(options.attributes.map(a => Dom.attr(a._1, AttributeValue.StringValue(a._2)))),
       PatchElementOptions(


### PR DESCRIPTION
As it stands the function is not actually called (at least for me?) and the [demo](https://ziohttp.com/reference/datastar-sdk/) populates a ton of noisy script tags.