### PR TITLE
Use dataInit over dataOn.load in hello world example

### DIFF
--- a/zio-http-example/src/main/scala/example/datastar/SimpleHelloWorldExample.scala
+++ b/zio-http-example/src/main/scala/example/datastar/SimpleHelloWorldExample.scala
@@ -42,7 +42,7 @@ object SimpleHelloWorldExample extends ZIOAppDefault {
       style.inlineCss(css),
     ),
     body(
-      dataOn.load := Endpoint(Method.GET / "hello-world").out[String].datastarRequest(()),
+      dataInit := Endpoint(Method.GET / "hello-world").out[String].datastarRequest(()),
       div(
         className := "container",
         h1("Hello World Example"),


### PR DESCRIPTION
I came across zio and ran this example but nothing happened and the console showed no errors. Turns out datastar seemed to be missing the onload event? Changing to `dataInit` worked for me.