### PR TITLE
fix: RFC-compliant header dedup in Netty encoding

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -127,11 +127,10 @@ private[netty] object Conversions {
     val iter         = headers.iterator
     while (iter.hasNext) {
       val header = iter.next()
-      val name   = header.headerName
-      if (singletonHeaders.contains(name.toString.toLowerCase(java.util.Locale.ROOT))) {
-        nettyHeaders.set(name, header.renderedValueAsCharSequence)
+      if (singletonHeaders.contains(header.headerName)) {
+        nettyHeaders.set(header.headerName, header.renderedValueAsCharSequence)
       } else {
-        nettyHeaders.add(name, header.renderedValueAsCharSequence)
+        nettyHeaders.add(header.headerName, header.renderedValueAsCharSequence)
       }
     }
     nettyHeaders

--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -94,12 +94,45 @@ private[netty] object Conversions {
       (headers: HttpHeaders, key: CharSequence) => headers.contains(key),
     )
 
+  private val singletonHeaders: java.util.HashSet[String] = {
+    val set = new java.util.HashSet[String](32)
+    set.add("age")
+    set.add("authorization")
+    set.add("content-length")
+    set.add("content-type")
+    set.add("content-location")
+    set.add("content-range")
+    set.add("date")
+    set.add("etag")
+    set.add("expect")
+    set.add("expires")
+    set.add("from")
+    set.add("host")
+    set.add("if-modified-since")
+    set.add("if-range")
+    set.add("if-unmodified-since")
+    set.add("last-modified")
+    set.add("location")
+    set.add("max-forwards")
+    set.add("proxy-authorization")
+    set.add("referer")
+    set.add("retry-after")
+    set.add("server")
+    set.add("user-agent")
+    set
+  }
+
   private def encodeHeaderListToNetty(headers: Iterable[Header]): HttpHeaders = {
     val nettyHeaders = new DefaultHttpHeaders()
     val iter         = headers.iterator
     while (iter.hasNext) {
       val header = iter.next()
-      nettyHeaders.add(header.headerName, header.renderedValueAsCharSequence)
+      val name   = header.headerName
+      if (singletonHeaders.contains(name.toString.toLowerCase(java.util.Locale.ROOT))) {
+        nettyHeaders.set(name, header.renderedValueAsCharSequence)
+      } else {
+        nettyHeaders.add(name, header.renderedValueAsCharSequence)
+      }
     }
     nettyHeaders
   }

--- a/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HeaderSpec.scala
@@ -382,6 +382,20 @@ object HeaderSpec extends ZIOHttpSpec {
         assert(result)(isLeft)
       },
     ),
+    suite("Headers concatenation")(
+      test("should return second value when both have same key") {
+        val h1     = Headers("key", "old")
+        val h2     = Headers("key", "new")
+        val result = (h1 ++ h2).get("key")
+        assertTrue(result == Some("new"))
+      },
+      test("should return first value when only first has key") {
+        val h1     = Headers("key", "old")
+        val h2     = Headers("other", "val")
+        val result = (h1 ++ h2).get("key")
+        assertTrue(result == Some("old"))
+      },
+    ),
     customHeaderSpec,
   )
 

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -54,6 +54,50 @@ object ConversionsSpec extends ZIOHttpSpec {
           val result  = Conversions.headersToNetty(headers).entries().size()
           assertTrue(result == 2)
         },
+        test("should deduplicate singleton Content-Type header (last wins)") {
+          val headers = Headers("content-type", "text/plain") ++ Headers("content-type", "application/json")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("content-type") == "application/json",
+          )
+        },
+        test("should preserve duplicate list-based Accept headers") {
+          val headers = Headers("accept", "text/html") ++ Headers("accept", "application/json")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(result.entries().size() == 2)
+        },
+        test("should preserve duplicate Set-Cookie headers") {
+          val headers = Headers("set-cookie", "a=1") ++ Headers("set-cookie", "b=2")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(result.entries().size() == 2)
+        },
+        test("should preserve duplicate WWW-Authenticate headers") {
+          val headers = Headers("www-authenticate", "Bearer") ++ Headers("www-authenticate", "Basic")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(result.entries().size() == 2)
+        },
+        test("should deduplicate singleton Host header (last wins)") {
+          val headers = Headers("host", "example.com") ++ Headers("host", "other.com")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("host") == "other.com",
+          )
+        },
+        test("should deduplicate singleton Authorization header (last wins)") {
+          val headers = Headers("authorization", "Bearer token1") ++ Headers("authorization", "Bearer token2")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("authorization") == "Bearer token2",
+          )
+        },
+        test("should preserve duplicate unknown custom headers") {
+          val headers = Headers("x-custom", "value1") ++ Headers("x-custom", "value2")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(result.entries().size() == 2)
+        },
       ),
       suite("scheme")(
         test("java http scheme") {

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -62,6 +62,14 @@ object ConversionsSpec extends ZIOHttpSpec {
             result.get("content-type") == "application/json",
           )
         },
+        test("should deduplicate mixed-case singleton Content-Type header (last wins)") {
+          val headers = Headers("Content-Type", "text/plain") ++ Headers("content-type", "application/json")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("content-type") == "application/json",
+          )
+        },
         test("should preserve duplicate list-based Accept headers") {
           val headers = Headers("accept", "text/html") ++ Headers("accept", "application/json")
           val result  = Conversions.headersToNetty(headers)

--- a/zio-http/shared/src/main/scala/zio/http/Headers.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Headers.scala
@@ -122,8 +122,8 @@ object Headers {
       first.iterator ++ second.iterator
 
     private[http] override def getUnsafe(key: CharSequence): String = {
-      val fromFirst = first.getUnsafe(key)
-      if (fromFirst ne null) fromFirst else second.getUnsafe(key)
+      val fromSecond = second.getUnsafe(key)
+      if (fromSecond ne null) fromSecond else first.getUnsafe(key)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the header duplication regression introduced by #3954. That PR changed `encodeHeaderListToNetty` from `.set()` to `.add()` for all headers, which fixed multi-value headers like `WWW-Authenticate` (#3590) but caused singleton headers (`Content-Type`, `Host`, `Authorization`, etc.) to be duplicated on the wire — breaking receivers that expect single values.

### Changes

**1. RFC-compliant header encoding (`Conversions.scala`)**

Classifies headers per RFC 9110 into three categories:

| Category | Encoding | Examples |
|---|---|---|
| **Singleton** | `set()` — last-wins, one on wire | `Content-Type`, `Host`, `Authorization`, `Content-Length`, `Date`, `ETag`, etc. (23 headers) |
| **List-based** | `add()` — preserve all | `Accept`, `WWW-Authenticate`, `Cache-Control`, `Vary`, etc. |
| **Special** | `add()` — preserve all | `Set-Cookie` (cannot comma-fold per RFC 6265) |
| **Unknown/custom** | `add()` — preserve all | Any header not in the singleton set |

The singleton set uses `java.util.HashSet` for O(1) lookup in the hot path, matching Node.js's battle-tested singleton list.

**2. Fix `Headers.Concat.getUnsafe` semantics (`Headers.scala`)**

Previously `(headers ++ override).get(key)` returned the **first** (left-side) value, contradicting the expectation that `++` means "right side overrides left". Now `getUnsafe` checks `second` before `first`, so the override's value wins.

### Why this is needed

- **RFC 9110 §5.5**: Singleton headers MUST NOT appear more than once
- **RFC 9112 §3.2**: Duplicate `Host` → server MUST reject with 400
- **AWS S3**: Hard rejects `DuplicateHeaderName`
- **Envoy CVE-2020-25017** (CVSS 8.3): Security bypass via duplicate headers
- **Spring/Tomcat `getHeader()`**: Returns first value — sender's "update" (last added) is silently ignored

### Tests added

- 7 new tests in `ConversionsSpec`: singleton dedup (Content-Type, Host, Authorization), list-based preservation (Accept, WWW-Authenticate, Set-Cookie), unknown custom header preservation
- 2 new tests in `HeaderSpec`: `Headers.Concat` override semantics