### PR TITLE
fix: use batched instead of deprecated request in StaticFileServerSpec

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -405,7 +405,7 @@ object StaticFileServerSpec extends RoutesRunnableSpec {
           results <- ZIO
             .foreach(0 to 2) { _ =>
               ZIO.foreachPar(urls) { url =>
-                ZIO.serviceWithZIO[Client](_.request(Request.get(url)))
+                ZIO.serviceWithZIO[Client](_.batched(Request.get(url)))
               }
             }
             .map(_.flatten)


### PR DESCRIPTION
## Summary

Fixes the CI build failure on `main` introduced by #3931.

The commit `c257ecec5` (fix: Flag ZClient.request as deprecated) missed adding a `@nowarn` annotation or migrating the call in `StaticFileServerSpec.scala:408`. The test still calls the now-deprecated `_.request(...)` method, which triggers a compile error under `-Werror` / `-Xfatal-warnings`.

### Fix

Changed `_.request(Request.get(url))` → `_.batched(Request.get(url))` — using the non-deprecated replacement API as recommended by the deprecation message.

### Affected CI jobs
- `Build and Test (ubuntu-latest, 3.3.7, graal_graalvm@21)` — Scala 3 compile error
- `Unsafe Scoverage (ubuntu-latest, 2.13.18, temurin@17)` — Scala 2.13 `-Werror`