### PR TITLE
feat(middleware): add tracing middleware for OpenTelemetry integration

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/TracingMiddlewareSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/TracingMiddlewareSpec.scala
@@ -1,0 +1,69 @@
+package zio.http
+
+import zio._
+import zio.test._
+
+object TracingMiddlewareSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("Middleware.tracing")(
+      test("creates span with default name from route pattern") {
+        val routes = Routes(
+          Method.GET / "users" / string("id") ->
+            handler { (_: String, _: Request) =>
+              ZIO.log("handled") *> ZIO.succeed(Response.ok)
+            },
+        ) @@ Middleware.tracing()
+        for {
+          _    <- routes.runZIO(Request.get(url"/users/123"))
+          logs <- ZTestLogger.logOutput
+          logOpt = logs.find(_.message() == "handled")
+        } yield assertTrue(
+          logOpt.exists(_.spans.exists(_.label == "GET /users/{id}")),
+        )
+      },
+      test("adds HTTP annotations") {
+        val routes = Routes(
+          Method.POST / "api" / "items" ->
+            handler { (_: Request) =>
+              ZIO.log("handled") *> ZIO.succeed(Response.status(Status.Created))
+            },
+        ) @@ Middleware.tracing()
+        for {
+          _    <- routes.runZIO(Request.post("/api/items", Body.empty))
+          logs <- ZTestLogger.logOutput
+          logOpt = logs.find(_.message() == "handled")
+        } yield assertTrue(
+          logOpt.exists(_.annotations.get("http.method").contains("POST")),
+          logOpt.exists(_.annotations.get("http.route").contains("/api/items")),
+          logOpt.exists(_.annotations.get("http.target").contains("/api/items")),
+        )
+      },
+      test("supports custom span name") {
+        val routes = Routes
+          .singleton(handler(ZIO.log("handled") *> ZIO.succeed(Response.ok)))
+          .@@(Middleware.tracing(spanName = (_, req) => s"custom-${req.method.render}"))
+        for {
+          _    <- routes.runZIO(Request.get(url"/"))
+          logs <- ZTestLogger.logOutput
+          logOpt = logs.find(_.message() == "handled")
+        } yield assertTrue(
+          logOpt.exists(_.spans.exists(_.label == "custom-GET")),
+        )
+      },
+      test("includes query string in http.target") {
+        val routes = Routes(
+          Method.GET / "search" ->
+            handler { (_: Request) =>
+              ZIO.log("handled") *> ZIO.succeed(Response.ok)
+            },
+        ) @@ Middleware.tracing()
+        for {
+          _    <- routes.runZIO(Request.get(url"/search?q=hello&page=1"))
+          logs <- ZTestLogger.logOutput
+          logOpt = logs.find(_.message() == "handled")
+        } yield assertTrue(
+          logOpt.exists(_.annotations.get("http.target").contains("/search?q=hello&page=1")),
+        )
+      },
+    )
+}

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -563,6 +563,47 @@ object Middleware extends HandlerAspects {
       extraLabels = extraLabels,
     )
 
+  /**
+   * Creates middleware for HTTP request tracing using ZIO's built-in log spans
+   * and annotations. When used with a ZIO OpenTelemetry backend, spans are
+   * automatically exported as OpenTelemetry traces.
+   *
+   * @param spanName
+   *   Derives the span name from the route pattern and request. Defaults to
+   *   "{METHOD} {route}" per OpenTelemetry semantic conventions.
+   * @param additionalAttributes
+   *   Derives additional log annotations from the request.
+   */
+  def tracing(
+    spanName: (RoutePattern[_], Request) => String = (routePattern, request) =>
+      s"${request.method.render} ${routePattern.pathCodec.render}",
+    additionalAttributes: Request => Set[LogAnnotation] = _ => Set.empty,
+  )(implicit trace: Trace): Middleware[Any] =
+    new Middleware[Any] {
+      def apply[Env1 <: Any, Err](routes: Routes[Env1, Err]): Routes[Env1, Err] =
+        Routes.fromIterable(
+          routes.routes.map { route =>
+            val routePattern = route.routePattern
+            route.transform[Env1] { h =>
+              Handler.scoped[Env1](handler { (request: Request) =>
+                val name        = spanName(routePattern, request)
+                val annotations = Set(
+                  LogAnnotation("http.method", request.method.render),
+                  LogAnnotation("http.route", routePattern.pathCodec.render),
+                  LogAnnotation("http.target", request.url.path.encode + request.url.queryParams.encode),
+                ) ++ additionalAttributes(request)
+
+                ZIO.logSpan(name) {
+                  ZIO.logAnnotate(annotations) {
+                    h(request)
+                  }
+                }
+              })
+            }
+          },
+        )
+    }
+
   private sealed trait StaticServe[-R, +E] { self =>
     def run(path: Path, req: Request): Handler[R, E, Request, Response]
 


### PR DESCRIPTION
## Summary

Adds `Middleware.tracing()` that creates HTTP request spans using ZIO's built-in `ZIO.logSpan` and `ZIO.logAnnotate`. When used with a ZIO OpenTelemetry logging backend, these spans are automatically exported as OpenTelemetry traces — **no new external dependencies required**.

Closes #3469

## Design

- **Pattern**: Follows the same `Routes.fromIterable(routes.routes.map { route => ... })` pattern as the existing `Middleware.metrics`
- **Span name**: Defaults to `"{METHOD} {route_pattern}"` per [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
- **Annotations**: Automatically adds `http.method`, `http.route`, and `http.target` as log annotations
- **Customization**: `spanName` and `additionalAttributes` parameters allow full control
- **No external deps**: Uses ZIO's built-in logging infrastructure (`ZIO.logSpan` + `ZIO.logAnnotate`)

## Usage

```scala
val app = Routes(
  Method.GET / "users" / string("id") -> handler { (id: String, req: Request) =>
    ZIO.succeed(Response.text(s"User $id"))
  }
) @@ Middleware.tracing()

// With custom span name:
val app2 = routes @@ Middleware.tracing(
  spanName = (pattern, req) => s"my-service ${req.method.render} ${pattern.pathCodec.render}"
)

// With additional attributes:
val app3 = routes @@ Middleware.tracing(
  additionalAttributes = req => Set(LogAnnotation("tenant", req.header("X-Tenant-Id").getOrElse("unknown")))
)
```

## Changes

- `Middleware.scala` — Added `tracing` method (+41 lines)
- `TracingMiddlewareSpec.scala` — 3 tests covering default span name, annotations, and custom span name
- `StaticFileServerSpec.scala` — Fixed pre-existing deprecated `.request()` → `.batched()` call