### PR TITLE
feat(datastar): add dispatchEvent for firing custom DOM events from backend

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarEvent.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarEvent.scala
@@ -208,6 +208,62 @@ object DatastarEvent {
   ): ExecuteScript =
     executeScript(script0, ExecuteScriptOptions(autoRemove, attributes, eventId, retryDuration))
 
+  def dispatchEvent[T <: Product: Schema](eventName: String, payload: T): ExecuteScript =
+    dispatchEvent(eventName, payload, DispatchEventOptions.default)
+
+  def dispatchEvent[T <: Product: Schema](
+    eventName: String,
+    payload: T,
+    options: DispatchEventOptions,
+  ): ExecuteScript = {
+    val escapedName  = eventName.replace("\\", "\\\\").replace("'", "\\'")
+    val jsonPayload  = zio.schema.codec.JsonCodec.jsonCodec(Schema[T]).encodeJson(payload, None).toString
+    val eventOptions =
+      s"detail:$jsonPayload,bubbles:${options.bubbles},cancelable:${options.cancelable},composed:${options.composed}"
+    val jsCode       = options.source match {
+      case None           =>
+        s"document.dispatchEvent(new CustomEvent('$escapedName',{$eventOptions}))"
+      case Some(selector) =>
+        val sel = selector.render.replace("\\", "\\\\").replace("'", "\\'")
+        s"(function(){var el=document.querySelector('$sel');if(el)el.dispatchEvent(new CustomEvent('$escapedName',{$eventOptions}))})()"
+    }
+    executeScript(
+      jsCode,
+      ExecuteScriptOptions(
+        autoRemove = options.autoRemove,
+        eventId = options.eventId,
+        retryDuration = options.retryDuration,
+      ),
+    )
+  }
+
+  def dispatchEvent[T <: Product: Schema](eventName: String, payload: T, source: Option[CssSelector]): ExecuteScript =
+    dispatchEvent(eventName, payload, DispatchEventOptions(source = source))
+
+  def dispatchEvent(eventName: String, payload: Js): ExecuteScript =
+    dispatchEvent(eventName, payload, DispatchEventOptions.default)
+
+  def dispatchEvent(eventName: String, payload: Js, options: DispatchEventOptions): ExecuteScript = {
+    val escapedName  = eventName.replace("\\", "\\\\").replace("'", "\\'")
+    val eventOptions =
+      s"detail:${payload.value},bubbles:${options.bubbles},cancelable:${options.cancelable},composed:${options.composed}"
+    val jsCode       = options.source match {
+      case None           =>
+        s"document.dispatchEvent(new CustomEvent('$escapedName',{$eventOptions}))"
+      case Some(selector) =>
+        val sel = selector.render.replace("\\", "\\\\").replace("'", "\\'")
+        s"(function(){var el=document.querySelector('$sel');if(el)el.dispatchEvent(new CustomEvent('$escapedName',{$eventOptions}))})()"
+    }
+    executeScript(
+      jsCode,
+      ExecuteScriptOptions(
+        autoRemove = options.autoRemove,
+        eventId = options.eventId,
+        retryDuration = options.retryDuration,
+      ),
+    )
+  }
+
   def patchElements(elements: String): PatchElements =
     patchElements(elements, PatchElementOptions.default)
 

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/ServerSentEventGenerator.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/ServerSentEventGenerator.scala
@@ -113,6 +113,20 @@ object ExecuteScriptOptions {
   val default: ExecuteScriptOptions = ExecuteScriptOptions()
 }
 
+final case class DispatchEventOptions(
+  source: Option[CssSelector] = None,
+  bubbles: Boolean = true,
+  cancelable: Boolean = false,
+  composed: Boolean = false,
+  autoRemove: Boolean = true,
+  eventId: Option[String] = None,
+  retryDuration: Duration = 1000.millis,
+)
+
+object DispatchEventOptions {
+  val default: DispatchEventOptions = DispatchEventOptions()
+}
+
 object ServerSentEventGenerator {
 
   private[datastar] val DefaultRetryDelay: Duration = 1000.millis
@@ -145,6 +159,40 @@ object ServerSentEventGenerator {
         retryDuration = options.retryDuration,
         selector = Some(body),
         mode = ElementPatchMode.Append,
+      ),
+    )
+  }
+
+  def dispatchEvent[T <: Product: Schema](eventName: String, payload: T): ZIO[Datastar, Nothing, Unit] =
+    dispatchEvent(eventName, payload, DispatchEventOptions.default)
+
+  def dispatchEvent[T <: Product: Schema](
+    eventName: String,
+    payload: T,
+    options: DispatchEventOptions,
+  ): ZIO[Datastar, Nothing, Unit] = {
+    val event = DatastarEvent.dispatchEvent(eventName, payload, options)
+    executeScript(
+      event.script,
+      ExecuteScriptOptions(
+        autoRemove = options.autoRemove,
+        eventId = options.eventId,
+        retryDuration = options.retryDuration,
+      ),
+    )
+  }
+
+  def dispatchEvent(eventName: String, payload: Js): ZIO[Datastar, Nothing, Unit] =
+    dispatchEvent(eventName, payload, DispatchEventOptions.default)
+
+  def dispatchEvent(eventName: String, payload: Js, options: DispatchEventOptions): ZIO[Datastar, Nothing, Unit] = {
+    val event = DatastarEvent.dispatchEvent(eventName, payload, options)
+    executeScript(
+      event.script,
+      ExecuteScriptOptions(
+        autoRemove = options.autoRemove,
+        eventId = options.eventId,
+        retryDuration = options.retryDuration,
       ),
     )
   }

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
@@ -598,9 +598,7 @@ object DatastarEventSpec extends ZIOSpecDefault {
         val sse   = event.toServerSentEvent
         assertTrue(
           sse.eventType.contains("datastar-patch-elements"),
-          sse.data.contains(
-            "document.dispatchEvent(new CustomEvent('test-event',{detail:{\"count\":42},bubbles:true,cancelable:false,composed:false}))",
-          ),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('test-event',{detail:{\"count\":42},bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
       test("dispatch with custom selector") {
@@ -611,8 +609,7 @@ object DatastarEventSpec extends ZIOSpecDefault {
         )
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("querySelector('#my-el')"),
-          sse.data.contains("dispatchEvent(new CustomEvent('my-event'"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">(function(){var el=document.querySelector('#my-el');if(el)el.dispatchEvent(new CustomEvent('my-event',{detail:{\"count\":1},bubbles:true,cancelable:false,composed:false}))})()</script>\n",
         )
       },
       test("dispatch with all event options") {
@@ -623,35 +620,35 @@ object DatastarEventSpec extends ZIOSpecDefault {
         )
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("bubbles:false,cancelable:true,composed:true"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('custom',{detail:{\"count\":5},bubbles:false,cancelable:true,composed:true}))</script>\n",
         )
       },
       test("event name escaping") {
         val event = DatastarEvent.dispatchEvent("it's-an-event", CountUpdate(0))
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("CustomEvent('it\\'s-an-event'"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('it\\'s-an-event',{detail:{\"count\":0},bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
       test("complex nested payload") {
         val event = DatastarEvent.dispatchEvent("nested", Outer(Inner(1, "hello"), true))
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("detail:{\"inner\":{\"x\":1,\"y\":\"hello\"},\"flag\":true}"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('nested',{detail:{\"inner\":{\"x\":1,\"y\":\"hello\"},\"flag\":true},bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
       test("raw Js payload") {
         val event = DatastarEvent.dispatchEvent("raw", Js("myExpression"))
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("detail:myExpression,bubbles:true,cancelable:false,composed:false"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('raw',{detail:myExpression,bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
       test("dispatch with source convenience overload") {
         val event = DatastarEvent.dispatchEvent("ev", CountUpdate(7), Some(selector".cls"))
         val sse   = event.toServerSentEvent
         assertTrue(
-          sse.data.contains("querySelector('.cls')"),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">(function(){var el=document.querySelector('.cls');if(el)el.dispatchEvent(new CustomEvent('ev',{detail:{\"count\":7},bubbles:true,cancelable:false,composed:false}))})()</script>\n",
         )
       },
       test("SSE format verification") {
@@ -659,9 +656,7 @@ object DatastarEventSpec extends ZIOSpecDefault {
         val sse   = event.toServerSentEvent
         assertTrue(
           sse.eventType.contains("datastar-patch-elements"),
-          sse.data.contains("selector <body></body>"),
-          sse.data.contains("mode append"),
-          sse.data.contains("data-effect=\"el.remove()\""),
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('fmt-test',{detail:{\"count\":99},bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
     ),

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
@@ -14,6 +14,10 @@ import zio.http.template2._
 object DatastarEventSpec extends ZIOSpecDefault {
   case class CountUpdate(count: Int)
   implicit val schema: Schema[CountUpdate] = DeriveSchema.gen[CountUpdate]
+  case class Inner(x: Int, y: String)
+  implicit val innerSchema: Schema[Inner]  = DeriveSchema.gen[Inner]
+  case class Outer(inner: Inner, flag: Boolean)
+  implicit val outerSchema: Schema[Outer]  = DeriveSchema.gen[Outer]
   override def spec                        = suite("DatastarEventSpec")(
     suite("events from ZStream[DatastarEvent]")(
       test("should convert ZStream of PatchElements events to SSE stream") {
@@ -585,6 +589,79 @@ object DatastarEventSpec extends ZIOSpecDefault {
           sse.data.contains("elements <script data-effect=\"el.remove()\">const x = 1;\n"),
           sse.data.contains("elements const y = 2;\n"),
           sse.data.contains("elements console.log(x + y);</script>\n"),
+        )
+      },
+    ),
+    suite("dispatchEvent")(
+      test("basic dispatch with default options") {
+        val event = DatastarEvent.dispatchEvent("test-event", CountUpdate(42))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.eventType.contains("datastar-patch-elements"),
+          sse.data.contains(
+            "document.dispatchEvent(new CustomEvent('test-event',{detail:{\"count\":42},bubbles:true,cancelable:false,composed:false}))",
+          ),
+        )
+      },
+      test("dispatch with custom selector") {
+        val event = DatastarEvent.dispatchEvent(
+          "my-event",
+          CountUpdate(1),
+          DispatchEventOptions(source = Some(selector"#my-el")),
+        )
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("querySelector('#my-el')"),
+          sse.data.contains("dispatchEvent(new CustomEvent('my-event'"),
+        )
+      },
+      test("dispatch with all event options") {
+        val event = DatastarEvent.dispatchEvent(
+          "custom",
+          CountUpdate(5),
+          DispatchEventOptions(bubbles = false, cancelable = true, composed = true),
+        )
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("bubbles:false,cancelable:true,composed:true"),
+        )
+      },
+      test("event name escaping") {
+        val event = DatastarEvent.dispatchEvent("it's-an-event", CountUpdate(0))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("CustomEvent('it\\'s-an-event'"),
+        )
+      },
+      test("complex nested payload") {
+        val event = DatastarEvent.dispatchEvent("nested", Outer(Inner(1, "hello"), true))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("detail:{\"inner\":{\"x\":1,\"y\":\"hello\"},\"flag\":true}"),
+        )
+      },
+      test("raw Js payload") {
+        val event = DatastarEvent.dispatchEvent("raw", Js("myExpression"))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("detail:myExpression,bubbles:true,cancelable:false,composed:false"),
+        )
+      },
+      test("dispatch with source convenience overload") {
+        val event = DatastarEvent.dispatchEvent("ev", CountUpdate(7), Some(selector".cls"))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data.contains("querySelector('.cls')"),
+        )
+      },
+      test("SSE format verification") {
+        val event = DatastarEvent.dispatchEvent("fmt-test", CountUpdate(99))
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.eventType.contains("datastar-patch-elements"),
+          sse.data.contains("selector <body></body>"),
+          sse.data.contains("mode append"),
+          sse.data.contains("data-effect=\"el.remove()\""),
         )
       },
     ),

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ServerSentEventGeneratorSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ServerSentEventGeneratorSpec.scala
@@ -3,9 +3,15 @@ package zio.http.datastar
 import zio._
 import zio.test._
 
+import zio.schema.{DeriveSchema, Schema}
+
 import zio.http.template2._
 
 object ServerSentEventGeneratorSpec extends ZIOSpecDefault {
+  case class Payload(name: String, value: Int)
+  implicit val payloadSchema: Schema[Payload] = DeriveSchema.gen[Payload]
+  case class Info(msg: String)
+  implicit val infoSchema: Schema[Info]       = DeriveSchema.gen[Info]
 
   override def spec = suite("ServerSentEventGeneratorSpec")(
     suite("EventType")(
@@ -589,6 +595,35 @@ object ServerSentEventGeneratorSpec extends ZIOSpecDefault {
             event.data.contains("Line 2"),
           )
         }
+      },
+    ),
+    suite("dispatchEvent")(
+      test("should send dispatchEvent with typed payload") {
+        for {
+          datastar <- Datastar.make
+          queue = datastar.queue
+          _     <- ServerSentEventGenerator
+            .dispatchEvent("test-event", Payload("foo", 42))
+            .provide(ZLayer.succeed(datastar))
+          event <- queue.take
+        } yield assertTrue(
+          event.eventType.contains("datastar-patch-elements"),
+          event.data.contains("CustomEvent('test-event'"),
+          event.data.contains("detail:{\"name\":\"foo\",\"value\":42}"),
+          event.data.contains("bubbles:true,cancelable:false,composed:false"),
+        )
+      },
+      test("should send dispatchEvent with options") {
+        for {
+          datastar <- Datastar.make
+          queue   = datastar.queue
+          options = DispatchEventOptions(source = Some(selector"#target"), bubbles = false, cancelable = true)
+          _ <- ServerSentEventGenerator.dispatchEvent("custom", Info("hi"), options).provide(ZLayer.succeed(datastar))
+          event <- queue.take
+        } yield assertTrue(
+          event.data.contains("querySelector('#target')"),
+          event.data.contains("bubbles:false,cancelable:true,composed:false"),
+        )
       },
     ),
   )

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ServerSentEventGeneratorSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ServerSentEventGeneratorSpec.scala
@@ -608,9 +608,7 @@ object ServerSentEventGeneratorSpec extends ZIOSpecDefault {
           event <- queue.take
         } yield assertTrue(
           event.eventType.contains("datastar-patch-elements"),
-          event.data.contains("CustomEvent('test-event'"),
-          event.data.contains("detail:{\"name\":\"foo\",\"value\":42}"),
-          event.data.contains("bubbles:true,cancelable:false,composed:false"),
+          event.data == "selector body\nmode append\nelements <script data-effect=\"el.remove()\">document.dispatchEvent(new CustomEvent('test-event',{detail:{\"name\":\"foo\",\"value\":42},bubbles:true,cancelable:false,composed:false}))</script>\n",
         )
       },
       test("should send dispatchEvent with options") {
@@ -621,8 +619,7 @@ object ServerSentEventGeneratorSpec extends ZIOSpecDefault {
           _ <- ServerSentEventGenerator.dispatchEvent("custom", Info("hi"), options).provide(ZLayer.succeed(datastar))
           event <- queue.take
         } yield assertTrue(
-          event.data.contains("querySelector('#target')"),
-          event.data.contains("bubbles:false,cancelable:true,composed:false"),
+          event.data == "selector body\nmode append\nelements <script data-effect=\"el.remove()\">(function(){var el=document.querySelector('#target');if(el)el.dispatchEvent(new CustomEvent('custom',{detail:{\"msg\":\"hi\"},bubbles:false,cancelable:true,composed:false}))})()</script>\n",
         )
       },
     ),


### PR DESCRIPTION
## Summary

Closes #3846

Adds `dispatchEvent` convenience methods to `DatastarEvent` and `ServerSentEventGenerator` that generate JavaScript to dispatch `CustomEvent` instances in the browser, with type-safe payloads via ZIO Schema.

### Changes

- **`DispatchEventOptions`** case class with source element (`Option[CssSelector]`), `bubbles` (default `true`), `cancelable` (default `false`), `composed` (default `false`), `autoRemove`, `eventId`, and `retryDuration`
- **`DatastarEvent.dispatchEvent`** — 5 overloads supporting typed payloads (`T <: Product: Schema`), raw `Js` payloads, optional CSS selector for target element, and full options
- **`ServerSentEventGenerator.dispatchEvent`** — 4 overloads wrapping `DatastarEvent.dispatchEvent` into `ZIO[Datastar, Nothing, Unit]`
- **10 new tests** — 8 in `DatastarEventSpec` (basic usage, custom selector, all options, escaping, nested payload, raw Js, source overload, SSE format) and 2 in `ServerSentEventGeneratorSpec`

### Generated JavaScript

```javascript
// Default (document target):
document.dispatchEvent(new CustomEvent('event-name', {detail:{...}, bubbles:true, cancelable:false, composed:false}))

// With CSS selector target:
(function(){var el=document.querySelector('#my-el');if(el)el.dispatchEvent(new CustomEvent('event-name', {detail:{...}, bubbles:true, cancelable:false, composed:false}))})()
```