### PR TITLE
chore: update zio-schema 1.8.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val ZioVersion                   = "2.1.24"
   val ZioCliVersion                = "0.8.0"
   val ZioJsonVersion               = "0.9.0"
-  val ZioSchemaVersion             = "1.8.2"
+  val ZioSchemaVersion             = "1.8.3"
   val SttpVersion                  = "3.3.18"
   val ZioConfigVersion             = "4.0.6"
 


### PR DESCRIPTION
## Summary
- Update `zio-schema` from 1.8.2 to 1.8.3

## Changes

### Dependency versions
- `ZioSchemaVersion`: 1.8.2 → 1.8.3

### Files modified
- `project/Dependencies.scala` — version update