### PR TITLE
fix: escape </script> in Datastar executeScript SSE rendering

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarEvent.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarEvent.scala
@@ -93,7 +93,7 @@ object DatastarEvent {
       sb.append("selector ").append(body.render).append('\n')
       sb.append("mode append\n")
 
-      val rendered = script.render
+      val rendered = escapeScriptContent(script.render)
       if (rendered.contains('\n'))
         rendered.split('\n').foreach(line => sb.append("elements ").append(line).append('\n'))
       else
@@ -101,6 +101,18 @@ object DatastarEvent {
 
       val retry = if (retryDuration != DefaultRetryDelay) Some(retryDuration) else None
       ServerSentEvent(sb.toString(), Some(eventType.render), eventId, retry)
+    }
+  }
+
+  private val ScriptEndPattern = "(?i)</script".r
+
+  private def escapeScriptContent(rendered: String): String = {
+    val closingTagIdx = rendered.lastIndexOf("</script>")
+    if (closingTagIdx < 0) rendered
+    else {
+      val content    = rendered.substring(0, closingTagIdx)
+      val closingTag = rendered.substring(closingTagIdx)
+      ScriptEndPattern.replaceAllIn(content, "<\\\\/script") + closingTag
     }
   }
 

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarEventSpec.scala
@@ -591,6 +591,13 @@ object DatastarEventSpec extends ZIOSpecDefault {
           sse.data.contains("elements console.log(x + y);</script>\n"),
         )
       },
+      test("executeScript escapes </script> in JS content") {
+        val event = DatastarEvent.executeScript("var x = '</script><div>xss</div>'; alert(x)")
+        val sse   = event.toServerSentEvent
+        assertTrue(
+          sse.data == "selector <body></body>\nmode append\nelements <script data-effect=\"el.remove()\">var x = '<\\/script><div>xss</div>'; alert(x)</script>\n",
+        )
+      },
     ),
     suite("dispatchEvent")(
       test("basic dispatch with default options") {


### PR DESCRIPTION
## Summary

Fixes a potential XSS/injection vulnerability in the Datastar SDK's `executeScript` event rendering.

When JavaScript content passed to `executeScript` contains a literal `</script>` string, the rendered SSE output would include an unescaped `</script>` tag. When morphdom patches this into the DOM via innerHTML, the HTML parser interprets `</script>` as the end of the script element, breaking out of the tag and potentially allowing injection.

## Changes

- Added `escapeScriptContent` method in `DatastarEvent.scala` that replaces `</script` with `<\/script` in the JavaScript content portion (but NOT the real closing tag)
- Uses case-insensitive regex matching to catch all variants (`</SCRIPT>`, `</Script>`, etc.)
- The escape is safe: in JavaScript, `\/` equals `/` (backslash before `/` is a no-op), so `<\/script>` evaluates correctly at runtime
- Added test verifying the escaping behavior with exact matching