### PR TITLE
perf: use Scheme.unsafe.decode in URL parsing hot path

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -20,7 +20,7 @@ import java.net.{MalformedURLException, URI}
 
 import scala.util.control.NonFatal
 
-import zio.{Config, ZIO, durationInt}
+import zio.{Config, Unsafe, ZIO, durationInt}
 
 import zio.http.URL.Location.Relative
 import zio.http.URL.{Fragment, Location}
@@ -310,7 +310,7 @@ object URL {
   }
 
   private[http] def fromAbsoluteURIOrNull(uri: URI): URL = {
-    val scheme     = Scheme.decode(uri.getScheme).orNull
+    val scheme     = Scheme.unsafe.decode(uri.getScheme)(Unsafe.unsafe)
     if (scheme eq null) return null
     val host       = uri.getHost
     if (host eq null) return null


### PR DESCRIPTION
## Summary

Follow-up to #3997 — eliminates one `Option` allocation in the URL parsing hot path.

### Changes

**Use `Scheme.unsafe.decode` directly in `fromAbsoluteURIOrNull`**
- `Scheme.decode(uri.getScheme).orNull` wraps in `Some(scheme)` then unwraps with `.orNull`
- `Scheme.unsafe.decode` returns the value directly — same behavior, no `Option` allocation
- Saves 1 `Some(Scheme)` allocation per request with absolute URLs