### PR TITLE
fix(Route): add @@ operators to apply HandlerAspect after path decoding (#3141)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -439,5 +439,50 @@ object RouteSpec extends ZIOHttpSpec {
 
       assertTrue(Exit.succeed(Response.ok) == ok(request))
     },
+    suite("Route#@@ with path parameters (#3141)")(
+      test("HandlerAspect[Any, Unit] applied via Route#@@ should not ClassCastException") {
+        // Regression test for https://github.com/zio/zio-http/issues/3141
+        // Applying a HandlerAspect via handler @@ when the handler has path
+        // parameters would throw ClassCastException at runtime because the
+        // handler's In type is (String, Request), not Request.
+        // Route#@@ applies the aspect after path decoding so In = Request.
+        val addHeader: HandlerAspect[Any, Unit] =
+          HandlerAspect.interceptIncomingHandler(
+            Handler.fromFunctionZIO[Request](req => ZIO.succeed((req, ()))),
+          )
+
+        val route =
+          (Method.GET / "base" / string("param") -> handler { (param: String, req: Request) =>
+            Response.text(s"param=$param")
+          }) @@ addHeader
+
+        val req = Request.get(URL(Path.root / "base" / "hello"))
+        for {
+          response <- route.toRoutes.runZIO(req)
+          body     <- response.body.asString
+        } yield assertTrue(body == "param=hello", response.status == Status.Ok)
+      },
+      test("context-providing HandlerAspect applied via Route#@@ should not ClassCastException") {
+        // Regression test for https://github.com/zio/zio-http/issues/3141
+        // A HandlerAspect that provides context should also work via Route#@@.
+        case class WebSession(id: Int)
+
+        val maybeSession: HandlerAspect[Any, Option[WebSession]] =
+          HandlerAspect.interceptIncomingHandler(
+            Handler.fromFunctionZIO[Request](req => ZIO.succeed((req, Some(WebSession(42))))),
+          )
+
+        val route =
+          (Method.GET / "base" / string("param") -> handler { (param: String, req: Request) =>
+            withContext((sess: Option[WebSession]) => Response.text(s"param=$param,session=${sess.map(_.id)}"))
+          }) @@ maybeSession
+
+        val req = Request.get(URL(Path.root / "base" / "hello"))
+        for {
+          response <- route.toRoutes.runZIO(req)
+          body     <- response.body.asString
+        } yield assertTrue(body == "param=hello,session=Some(42)", response.status == Status.Ok)
+      },
+    ),
   )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -428,6 +428,30 @@ sealed trait Route[-Env, +Err] { self =>
 
   final def toRoutes: Routes[Env, Err] = Routes(self)
 
+  /**
+   * Applies a [[HandlerAspect]] to this route.
+   *
+   * Unlike applying `@@` directly on a handler created with path parameters,
+   * this operator applies the aspect *after* path parameters have been decoded.
+   * This prevents a `ClassCastException` that occurs when the handler's input
+   * type is a tuple of path parameters rather than a plain [[Request]] (see
+   * issue #3141).
+   */
+  final def @@[Env1 <: Env](aspect: HandlerAspect[Env1, Unit])(implicit trace: Trace): Route[Env1, Err] =
+    self.transform(handler => handler @@ aspect)
+
+  /**
+   * Applies a context-providing [[HandlerAspect]] to this route.
+   *
+   * Applies the aspect after path parameters have been decoded, preventing the
+   * `ClassCastException` described in issue #3141.
+   */
+  final def @@[Env0, Ctx <: Env](aspect: HandlerAspect[Env0, Ctx])(implicit
+    tag: Tag[Ctx],
+    trace: Trace,
+  ): Route[Env0, Err] =
+    self.transform(handler => handler @@ aspect)
+
   def transform[Env1](
     f: Handler[Env, Response, Request, Response] => Handler[Env1, Response, Request, Response],
   ): Route[Env1, Err] =


### PR DESCRIPTION
/claim #3141

## Summary

Fixes `ClassCastException` when applying a `HandlerAspect` to a route
that has path parameters (see #3141).

## Root Cause

The existing `Handler.@@` operators use `asInstanceOf` to cast the
handler to `Handler[Ctx, Response, Request, Response]`:

```scala
// Handler.scala
self.asInstanceOf[Handler[Ctx, Response, Request, Response]](req)
```

When a route is constructed with path parameters, the handler's actual
input type is a tuple — e.g. `(String, Request)` — not `Request`. The
operator precedence of `@@` is higher than `->`, so:

```scala
Method.GET / "base" / string("param") -> handler { (p: String, req: Request) =>
  withContext((sess: Option[WebSession]) => Response.text(p))
} @@ maybeSession
```

parses as applying `@@` to the raw un-decoded handler, whose `In` is
`(String, Request)`. The cast to `Request` then fails at runtime with:

```
class zio.http.Request cannot be cast to class scala.Tuple2
```

## Fix

Add `@@` operators on the `Route` trait that delegate to
`Route#transform`. The `transform` callback receives the handler
**after** path parameters have been decoded, so `In = Request` there
and `Handler.@@` is safe to call.

Two overloads mirror `Handler.@@`:

```scala
// Simple middleware
route @@ HandlerAspect[Env1, Unit]

// Context-providing middleware
route @@ HandlerAspect[Env0, Ctx]
```

Both operators use `self.transform(handler => handler @@ aspect)` —
exactly one line each, no `asInstanceOf`, no `DummyImplicit` hacks.

## Tests

Two regression tests added to `RouteSpec`:

1. **`HandlerAspect[Any, Unit]`** — verifies no `ClassCastException` with a
   simple header-adding middleware applied to a single-path-param route.
2. **Context-providing aspect** — verifies the same with a
   `HandlerAspect[Any, Option[WebSession]]` that injects session context.

Both tests confirm the response body contains the decoded path parameter
value, proving path decoding still works correctly after the aspect is
applied.