### PR TITLE
Don't log unhandled errors failures of type response

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -88,6 +88,29 @@ object RouteSpec extends ZIOHttpSpec {
           ),
         )
       },
+      test("sandbox does not log requests with failures of type Response") {
+        val route =
+          Method.GET / "foo" -> Handler.fail(Response.badRequest)
+
+        for {
+          _       <- route.sandbox.toRoutes.runZIO(Request.get(url"/foo"))
+          entries <- ZTestLogger.logOutput
+        } yield assertTrue(
+          !entries.exists(e => e.message().contains("Unhandled exception in request handler")),
+        )
+      },
+      test("sandbox does not log requests with middleware failures of type Response") {
+        val route =
+          Method.GET / "foo" -> handler(Response.ok)
+
+        val routes = route.sandbox.toRoutes @@ Middleware.fail(Response.badRequest)
+        for {
+          _       <- routes.runZIO(Request.get(url"/foo"))
+          entries <- ZTestLogger.logOutput
+        } yield assertTrue(
+          !entries.exists(e => e.message().contains("Unhandled exception in request handler")),
+        )
+      },
       test("sandbox does not log for successful requests") {
         val route =
           Method.GET / "foo" -> handler(Response.ok)

--- a/zio-http/jvm/src/test/scala/zio/http/ServerErrorLoggingSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerErrorLoggingSpec.scala
@@ -39,6 +39,16 @@ object ServerErrorLoggingSpec extends ZIOSpecDefault {
     Method.GET / "fail" -> Handler.fail(new RuntimeException("typed failure")),
   ).sandbox
 
+  // Routes that fail with a response, should not produce error logs
+  val routesFailResponse = Routes(
+    Method.GET / "fail-response" -> Handler.fail(Response.fromThrowable(new RuntimeException("typed failure"))),
+  ).sandbox
+
+  // Routes that fail with a response because of Middleware, should not produce error logs
+  val routesFailMiddlewareResponse = (Routes(
+    Method.GET / "fail-middleware-response" -> Handler.ok,
+  ) @@ Middleware.fail(Response.fromThrowable(new RuntimeException("typed failure")))).sandbox
+
   // Routes that succeed - should not produce error logs
   val routesOk = Routes(
     Method.GET / "ok" -> Handler.ok,
@@ -71,6 +81,26 @@ object ServerErrorLoggingSpec extends ZIOSpecDefault {
           errorLog.isDefined,
           errorLog.get.logLevel == LogLevel.Error,
         )
+      },
+      test("sandbox does not log requests with failures of type Response") {
+        for {
+          port    <- Server.installRoutes(routesFailResponse)
+          _       <- ZIO.scoped {
+            Client.streaming(Request.get(s"http://localhost:$port/fail-response")).flatMap(_.ignoreBody)
+          }
+          entries <- ZTestLogger.logOutput
+          errorLog = entries.find(_.message() == "Unhandled exception in request handler")
+        } yield assertTrue(errorLog.isEmpty)
+      },
+      test("sandbox does not log requests with middleware failures of type Response") {
+        for {
+          port    <- Server.installRoutes(routesFailMiddlewareResponse)
+          _       <- ZIO.scoped {
+            Client.streaming(Request.get(s"http://localhost:$port/fail-middleware-response")).flatMap(_.ignoreBody)
+          }
+          entries <- ZTestLogger.logOutput
+          errorLog = entries.find(_.message() == "Unhandled exception in request handler")
+        } yield assertTrue(errorLog.isEmpty)
       },
       test("sandbox does not log for successful requests") {
         for {

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -560,7 +560,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   private def logUnhandledError(cause: Cause[Any]): UIO[Unit] =
     cause.failureOrCause match {
       case Left(_: Response) => ZIO.unit
-      case _ => ZIO.logErrorCause("Unhandled exception in request handler", cause)
+      case _                 => ZIO.logErrorCause("Unhandled exception in request handler", cause)
     }
 
   final def status(implicit ev: Out <:< Response, trace: Trace): Handler[R, Err, In, Status] =

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -550,8 +550,17 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
 
   final def sandbox(implicit trace: Trace): Handler[R, Response, In, Out] =
     self.mapErrorCauseZIO { cause =>
-      ZIO.logErrorCause("Unhandled exception in request handler", cause) *>
+      logUnhandledError(cause) *>
         ErrorResponseConfig.configRef.getWith(cfg => Exit.fail(Response.fromCause(cause, cfg)))
+    }
+
+  /**
+   * Log an unhandled error unless the cause is already a response
+   */
+  private def logUnhandledError(cause: Cause[Any]): UIO[Unit] =
+    cause.failureOrCause match {
+      case Left(_: Response) => ZIO.unit
+      case _ => ZIO.logErrorCause("Unhandled exception in request handler", cause)
     }
 
   final def status(implicit ev: Out <:< Response, trace: Trace): Handler[R, Err, In, Status] =

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -410,8 +410,17 @@ sealed trait Route[-Env, +Err] { self =>
    */
   final def sandbox(implicit trace: Trace): Route[Env, Nothing] =
     handleErrorCauseZIO { cause =>
-      ZIO.logErrorCause("Unhandled exception in request handler", cause) *>
+      logUnhandledError(cause) *>
         ErrorResponseConfig.configRef.getWith(cfg => Exit.succeed(Response.fromCause(cause, cfg)))
+    }
+
+  /**
+   * Log an unhandled error unless the cause is already a response
+   */
+  private def logUnhandledError(cause: Cause[Any]): UIO[Unit] =
+    cause.failureOrCause match {
+      case Left(_: Response) => ZIO.unit
+      case _ => ZIO.logErrorCause("Unhandled exception in request handler", cause)
     }
 
   def toHandler(implicit ev: Err <:< Response, trace: Trace): Handler[Env, Response, Request, Response]

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -420,7 +420,7 @@ sealed trait Route[-Env, +Err] { self =>
   private def logUnhandledError(cause: Cause[Any]): UIO[Unit] =
     cause.failureOrCause match {
       case Left(_: Response) => ZIO.unit
-      case _ => ZIO.logErrorCause("Unhandled exception in request handler", cause)
+      case _                 => ZIO.logErrorCause("Unhandled exception in request handler", cause)
     }
 
   def toHandler(implicit ev: Err <:< Response, trace: Trace): Handler[Env, Response, Request, Response]


### PR DESCRIPTION
When middleware fails with a response, unhandled error should not be logged