### PR TITLE
Handle braces in absolute URL queries

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -403,6 +403,15 @@ object URLSpec extends ZIOHttpSpec {
             result.path == Path("/plaintext"),
           )
         },
+        test("absolute URL with braces in query returns non-null URL") {
+          val result = URL.decodeOrNull("https://example.com/t?v={bla}")
+          assertTrue(
+            result ne null,
+            result.kind == URL.Location.Absolute(Scheme.HTTPS, "example.com", None),
+            result.path == Path("/t"),
+            result.queryParams.queryParam("v") == Some("{bla}"),
+          )
+        },
         test("valid path with query params returns non-null URL") {
           val result = URL.decodeOrNull("/api/users?id=1")
           assertTrue(
@@ -493,6 +502,18 @@ object URLSpec extends ZIOHttpSpec {
           assertTrue(
             url.kind.isAbsolute,
             url.path == Path.decode("/users"),
+          )
+        },
+        test("absolute URL with braces in query matches relative decoding") {
+          val relative = URL.decode("/t?v={bla}")
+          val absolute = URL.decode("https://example.com/t?v={bla}")
+
+          assertTrue(
+            relative.isRight,
+            absolute.isRight,
+            relative.toOption.get.path == absolute.toOption.get.path,
+            relative.toOption.get.queryParams == absolute.toOption.get.queryParams,
+            absolute.toOption.get.kind == URL.Location.Absolute(Scheme.HTTPS, "example.com", None),
           )
         },
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -412,6 +412,15 @@ object URLSpec extends ZIOHttpSpec {
             result.queryParams.queryParam("v") == Some("{bla}"),
           )
         },
+        test("relative URL with braces in query returns non-null URL") {
+          val result = URL.decodeOrNull("/t?v={bla}")
+          assertTrue(
+            result ne null,
+            result.kind == URL.Location.Relative,
+            result.path == Path("/t"),
+            result.queryParams.queryParam("v") == Some("{bla}"),
+          )
+        },
         test("valid path with query params returns non-null URL") {
           val result = URL.decodeOrNull("/api/users?id=1")
           assertTrue(
@@ -505,15 +514,17 @@ object URLSpec extends ZIOHttpSpec {
           )
         },
         test("absolute URL with braces in query matches relative decoding") {
-          val relative = URL.decode("/t?v={bla}")
-          val absolute = URL.decode("https://example.com/t?v={bla}")
+          val relative    = URL.decode("/t?v={bla}")
+          val absolute    = URL.decode("https://example.com/t?v={bla}")
+          val relativeUrl = relative.toOption.get
+          val absoluteUrl = absolute.toOption.get
 
           assertTrue(
             relative.isRight,
             absolute.isRight,
-            relative.toOption.get.path == absolute.toOption.get.path,
-            relative.toOption.get.queryParams == absolute.toOption.get.queryParams,
-            absolute.toOption.get.kind == URL.Location.Absolute(Scheme.HTTPS, "example.com", None),
+            relativeUrl.path == absoluteUrl.path,
+            relativeUrl.queryParams == absoluteUrl.queryParams,
+            absoluteUrl.kind == URL.Location.Absolute(Scheme.HTTPS, "example.com", None),
           )
         },
       ),

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -284,6 +284,9 @@ final case class URL(
 object URL {
   val empty: URL = URL(path = Path.empty)
 
+  private val EncodedLeftBrace  = "%7B"
+  private val EncodedRightBrace = "%7D"
+
   /**
    * To better understand this implementation, read discussion:
    * https://github.com/zio/zio-http/pull/3017/files#r1716489733
@@ -319,7 +322,7 @@ object URL {
 
         Right(URL(Path.decodeRaw(rawPath), Location.Relative, QueryParams.decode(rawQuery), fragment))
       } else {
-        val uri = new URI(rawUrl)
+        val uri = new URI(sanitizeAbsoluteUrlQuery(rawUrl))
         val url = if (uri.isAbsolute) fromAbsoluteURI(uri) else fromRelativeURI(uri)
 
         url match {
@@ -355,10 +358,32 @@ object URL {
 
   private[http] def decodeOrNull(rawUrl: String): URL = {
     try {
-      val uri = new URI(rawUrl)
+      val uri = new URI(sanitizeAbsoluteUrlQuery(rawUrl))
       if (uri.isAbsolute) fromAbsoluteURIOrNull(uri) else fromRelativeURIOrNull(uri)
     } catch {
       case NonFatal(_) => null
+    }
+  }
+
+  private def sanitizeAbsoluteUrlQuery(rawUrl: String): String = {
+    if (rawUrl.isEmpty || rawUrl.charAt(0) == '/') rawUrl
+    else {
+      val queryIdx = rawUrl.indexOf('?')
+      if (queryIdx < 0) rawUrl
+      else {
+        val fragmentIdx = rawUrl.indexOf('#', queryIdx + 1)
+        val queryEnd    = if (fragmentIdx >= 0) fragmentIdx else rawUrl.length
+        val rawQuery    = rawUrl.substring(queryIdx + 1, queryEnd)
+        if (rawQuery.indexOf('{') < 0 && rawQuery.indexOf('}') < 0) rawUrl
+        else {
+          val sanitizedQuery = rawQuery
+            .replace("{", EncodedLeftBrace)
+            .replace("}", EncodedRightBrace)
+
+          if (sanitizedQuery eq rawQuery) rawUrl
+          else rawUrl.substring(0, queryIdx + 1) + sanitizedQuery + rawUrl.substring(queryEnd)
+        }
+      }
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -358,8 +358,28 @@ object URL {
 
   private[http] def decodeOrNull(rawUrl: String): URL = {
     try {
-      val uri = new URI(sanitizeAbsoluteUrlQuery(rawUrl))
-      if (uri.isAbsolute) fromAbsoluteURIOrNull(uri) else fromRelativeURIOrNull(uri)
+      if (rawUrl.isEmpty) URL.empty
+      else if (rawUrl.charAt(0) == '/') {
+        val fragmentIdx = rawUrl.indexOf('#')
+        val rawQueryIdx = rawUrl.indexOf('?')
+        val queryIdx    = if (fragmentIdx >= 0 && rawQueryIdx > fragmentIdx) -1 else rawQueryIdx
+
+        val pathEnd  = if (queryIdx >= 0) queryIdx else if (fragmentIdx >= 0) fragmentIdx else rawUrl.length
+        val rawPath  = rawUrl.substring(0, pathEnd)
+        val rawQuery = if (queryIdx >= 0) {
+          val queryEnd = if (fragmentIdx > queryIdx) fragmentIdx else rawUrl.length
+          rawUrl.substring(queryIdx + 1, queryEnd)
+        } else null
+        val fragment = if (fragmentIdx >= 0) {
+          val rawFrag = rawUrl.substring(fragmentIdx + 1)
+          Some(Fragment.fromRaw(rawFrag))
+        } else None
+
+        URL(Path.decodeRaw(rawPath), Location.Relative, QueryParams.decode(rawQuery), fragment)
+      } else {
+        val uri = new URI(sanitizeAbsoluteUrlQuery(rawUrl))
+        if (uri.isAbsolute) fromAbsoluteURIOrNull(uri) else fromRelativeURIOrNull(uri)
+      }
     } catch {
       case NonFatal(_) => null
     }
@@ -379,9 +399,7 @@ object URL {
           val sanitizedQuery = rawQuery
             .replace("{", EncodedLeftBrace)
             .replace("}", EncodedRightBrace)
-
-          if (sanitizedQuery eq rawQuery) rawUrl
-          else rawUrl.substring(0, queryIdx + 1) + sanitizedQuery + rawUrl.substring(queryEnd)
+          rawUrl.substring(0, queryIdx + 1) + sanitizedQuery + rawUrl.substring(queryEnd)
         }
       }
     }


### PR DESCRIPTION
## Summary
- sanitize raw braces in absolute URL query strings before delegating to java.net.URI
- preserve the relative fast path while making absolute and relative query decoding consistent
- add regressions for URL.decode and URL.decodeOrNull with https://example.com/t?v={bla}

## Verification
- sbt fmt
- sbt "zioHttpJVM/testOnly zio.http.URLSpec"
- sbt "zioHttpJVM/test"

Closes #4121