### PR TITLE
Fix route-local HandlerAspect composition with path params (#3141)

### DIFF
--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -426,7 +426,10 @@ We notice in the response that first `basicAuth` handler aspect responded `HTTP/
 We can abort the requests by specific response using `HandlerAspect.fail` and `HandlerAspect.failWith` aspects, so the downstream handlers will not be executed:
 
 ```scala mdoc:invisible
-val myHandler = Handler.identity
+import zio.http._
+
+val myHandler: Handler[Any, Nothing, Request, Response] =
+  Handler.fromFunction[Request](_ => Response.ok)
 ```
 
 ```scala mdoc:compile-only

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -53,6 +53,9 @@ object MimaSettings {
         ProblemFilters.exclude[MissingClassProblem]("zio.http.Header$ContentSecurityPolicy$Combined$"),
         ProblemFilters.exclude[MissingClassProblem]("zio.http.Header$ContentSecurityPolicyReportOnly"),
         ProblemFilters.exclude[MissingClassProblem]("zio.http.Header$ContentSecurityPolicyReportOnly$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("zio.http.Handler.@@"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.Handler#IsRequest.request"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.http.Handler#IsRequest.update"),
       ),
       mimaFailOnProblem := failOnProblem,
     )

--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -391,6 +391,36 @@ object RouteSpec extends ZIOHttpSpec {
           bodyString <- response.body.asString
         } yield assertTrue(bodyString == expected)
       },
+      test("single Route aspects should compose with path params and request input (#3141)") {
+        case class WebSession(id: Int)
+
+        val sessionAspect: HandlerAspect[Any, Option[WebSession]] =
+          HandlerAspect.interceptIncomingHandler(
+            Handler.fromFunction[Request] { req =>
+              (req, Some(WebSession(7)))
+            },
+          )
+
+        val baseHandler: Handler[Option[WebSession], Response, (String, Request), Response] =
+          Handler.fromFunctionZIO[(String, Request)] { case (message, request) =>
+            withContext { (session: Option[WebSession]) =>
+              ZIO.succeed(Response.text(s"$message ${session.map(_.id).getOrElse(-1)} ${request.method.render}"))
+            }
+          }
+
+        val route =
+          Method.DELETE / string("message") -> (baseHandler.@@[Any, Option[WebSession], (String, Request)](
+            sessionAspect,
+          ))
+
+        for {
+          response <- Routes(route).runZIO(Request.delete(url"/twenty"))
+          body     <- response.body.asString
+        } yield assertTrue(
+          response.status == Status.Ok,
+          body == "twenty 7 DELETE",
+        )
+      },
       test("handleErrorCause should catch defects after handleErrorZIO (#3432)") {
         val route = Method.GET / "endpoint" -> handler { (_: Request) =>
           ZIO

--- a/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
@@ -3,23 +3,32 @@ package zio.http
 import zio._
 
 trait HandlerVersionSpecific {
-  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](private val self: Handler[Env, Err, In, Out]) {
+  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](
+    private val self: Handler[Env, Err, In, Out],
+  ) {
     def apply[Env1, Ctx: Tag, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
       in: Handler.IsRequest[In1],
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,
       trace: Trace,
-    ): Handler[Env0 with Env1, Response, Request, Response] =
-      aspect.applyHandlerContext {
-        Handler.scoped[Env0] {
-          handler { (ctx: Ctx, req: Request) =>
-            val handler: ZIO[Scope & Env, Response, Response] =
-              self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
-            handler.provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx).asInstanceOf[ZEnvironment[Scope & Env]])
+    ): Handler[Env0 with Env1, Response, In1, Response] =
+      Handler.scoped[Env0 with Env1] {
+        Handler.fromFunctionZIO[In1] { input =>
+          aspect.protocol.incoming(in.request(input)).flatMap { case (state, (request, ctx)) =>
+            self
+              .asInstanceOf[Handler[Env, Response, In1, Response]](in.update(input, request))
+              .provideSomeEnvironment[Scope & Env0 with Env1](
+                _.add[Ctx](ctx).asInstanceOf[ZEnvironment[Scope & Env]],
+              )
+              .either
+              .flatMap { either =>
+                aspect.protocol
+                  .outgoing(state, either.merge)
+                  .flatMap(response => if (either.isLeft) ZIO.fail(response) else ZIO.succeed(response))
+              }
           }
         }
       }
   }
-
 }

--- a/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
@@ -3,19 +3,27 @@ package zio.http
 import zio.*
 
 trait HandlerVersionSpecific {
-  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](self: Handler[Env, Err, In, Out]) {
-    transparent inline def apply[Env1, Ctx, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
+  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](private val self: Handler[Env, Err, In, Out]) {
+    def apply[Env1, Ctx: Tag, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
       in: Handler.IsRequest[In1],
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,
       trace: Trace,
-    ): Handler[Env0 with Env1, Response, Request, Response] =
-      aspect.applyHandlerContext {
-        Handler.scoped[Env0] {
-          handler { (ctx: Ctx, req: Request) =>
-            val handler: ZIO[Scope & Env, Response, Response] = self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
-            handler.provideSomeEnvironment[Scope & Env0](_.add(ctx).asInstanceOf[ZEnvironment[Scope & Env]])
+    ): Handler[Env0 with Env1, Response, In1, Response] =
+      Handler.scoped[Env0 with Env1] {
+        Handler.fromFunctionZIO[In1] { input =>
+          val aspect0 = aspect
+          aspect0.protocol.incoming(in.request(input)).flatMap { case (state, (request, ctx)) =>
+            self
+              .asInstanceOf[Handler[Env, Response, In1, Response]](in.update(input, request))
+              .provideSomeEnvironment[Scope & Env0 with Env1](_.add(ctx).asInstanceOf[ZEnvironment[Scope & Env]])
+              .either
+              .flatMap { either =>
+                aspect0.protocol
+                  .outgoing(state, either.merge)
+                  .flatMap(response => if (either.isLeft) ZIO.fail(response) else ZIO.succeed(response))
+              }
           }
         }
       }

--- a/zio-http/shared/src/main/scala-3/zio/http/RoutesCompanionVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/RoutesCompanionVersionSpecific.scala
@@ -1,8 +1,10 @@
 package zio.http
 
+import zio.Tag
+
 trait RoutesCompanionVersionSpecific {
   private[http] class ApplyContextAspect[-Env, +Err, Env0](private val self: Routes[Env, Err]) {
-    transparent inline def apply[Env1, Env2 <: Env, Ctx](aspect: HandlerAspect[Env1, Ctx])(implicit
+    def apply[Env1, Env2 <: Env, Ctx: Tag](aspect: HandlerAspect[Env1, Ctx])(implicit
       ev: Env0 with Ctx <:< Env,
     ): Routes[Env0 with Env1, Err] = self.transform(_.@@[Env0](aspect))
   }

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -38,12 +38,22 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     in: Handler.IsRequest[In1],
     out: Out <:< Response,
     err: Err <:< Response,
-  ): Handler[Env1, Response, Request, Response] = {
-    def convert(handler: Handler[R, Err, In, Out]): Handler[R, Response, Request, Response] =
-      handler.asInstanceOf[Handler[R, Response, Request, Response]]
-
-    aspect.applyHandler(convert(self))
-  }
+    trace: Trace,
+  ): Handler[Env1, Response, In1, Response] =
+    Handler.scoped[Env1] {
+      Handler.fromFunctionZIO[In1] { input =>
+        aspect.protocol.incoming(in.request(input)).flatMap { case (state, (request, _)) =>
+          self
+            .asInstanceOf[Handler[Env1, Response, In1, Response]](in.update(input, request))
+            .either
+            .flatMap { either =>
+              aspect.protocol
+                .outgoing(state, either.merge)
+                .flatMap(response => if (either.isLeft) ZIO.fail(response) else ZIO.succeed(response))
+            }
+        }
+      }
+    }
 
   def @@[Env0, Ctx <: R, In1 <: In](aspect: HandlerAspect[Env0, Ctx])(implicit
     in: Handler.IsRequest[In1],
@@ -51,14 +61,19 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     err: Err <:< Response,
     trace: Trace,
     tag: Tag[Ctx],
-  ): Handler[Env0, Response, Request, Response] =
-    aspect.applyHandlerContext {
-      Handler.scoped[Env0] {
-        handler { (ctx: Ctx, req: Request) =>
-          val handler: ZIO[Scope & Ctx, Response, Response] =
-            self
-              .asInstanceOf[Handler[Ctx, Response, Request, Response]](req)
-          handler.provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx))
+  ): Handler[Env0, Response, In1, Response] =
+    Handler.scoped[Env0] {
+      Handler.fromFunctionZIO[In1] { input =>
+        aspect.protocol.incoming(in.request(input)).flatMap { case (state, (request, ctx)) =>
+          self
+            .asInstanceOf[Handler[Ctx, Response, In1, Response]](in.update(input, request))
+            .provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx))
+            .either
+            .flatMap { either =>
+              aspect.protocol
+                .outgoing(state, either.merge)
+                .flatMap(response => if (either.isLeft) ZIO.fail(response) else ZIO.succeed(response))
+            }
         }
       }
     }
@@ -703,10 +718,76 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
 
   private val errorMediaTypes = List(MediaType.text.html, MediaType.application.json, MediaType.text.plain)
 
-  sealed trait IsRequest[-A]
+  sealed trait IsRequest[A] {
+    def request(value: A): Request
+    def update(value: A, request: Request): A
+  }
 
-  object IsRequest {
-    implicit val request: IsRequest[Request] = new IsRequest[Request] {}
+  private[http] trait IsRequestLowPriority {
+    implicit def tuple2[A]: IsRequest[(A, Request)] = new IsRequest[(A, Request)] {
+      override def request(value: (A, Request)): Request                       = value._2
+      override def update(value: (A, Request), request: Request): (A, Request) =
+        (value._1, request)
+    }
+
+    implicit def tuple3[A, B]: IsRequest[(A, B, Request)] = new IsRequest[(A, B, Request)] {
+      override def request(value: (A, B, Request)): Request                          = value._3
+      override def update(value: (A, B, Request), request: Request): (A, B, Request) =
+        (value._1, value._2, request)
+    }
+
+    implicit def tuple4[A, B, C]: IsRequest[(A, B, C, Request)] = new IsRequest[(A, B, C, Request)] {
+      override def request(value: (A, B, C, Request)): Request                             = value._4
+      override def update(value: (A, B, C, Request), request: Request): (A, B, C, Request) =
+        (value._1, value._2, value._3, request)
+    }
+
+    implicit def tuple5[A, B, C, D]: IsRequest[(A, B, C, D, Request)] =
+      new IsRequest[(A, B, C, D, Request)] {
+        override def request(value: (A, B, C, D, Request)): Request = value._5
+        override def update(
+          value: (A, B, C, D, Request),
+          request: Request,
+        ): (A, B, C, D, Request) =
+          (value._1, value._2, value._3, value._4, request)
+      }
+
+    implicit def tuple6[A, B, C, D, E]: IsRequest[(A, B, C, D, E, Request)] =
+      new IsRequest[(A, B, C, D, E, Request)] {
+        override def request(value: (A, B, C, D, E, Request)): Request = value._6
+        override def update(
+          value: (A, B, C, D, E, Request),
+          request: Request,
+        ): (A, B, C, D, E, Request) =
+          (value._1, value._2, value._3, value._4, value._5, request)
+      }
+
+    implicit def tuple7[A, B, C, D, E, F]: IsRequest[(A, B, C, D, E, F, Request)] =
+      new IsRequest[(A, B, C, D, E, F, Request)] {
+        override def request(value: (A, B, C, D, E, F, Request)): Request = value._7
+        override def update(
+          value: (A, B, C, D, E, F, Request),
+          request: Request,
+        ): (A, B, C, D, E, F, Request) =
+          (value._1, value._2, value._3, value._4, value._5, value._6, request)
+      }
+
+    implicit def tuple8[A, B, C, D, E, F, G]: IsRequest[(A, B, C, D, E, F, G, Request)] =
+      new IsRequest[(A, B, C, D, E, F, G, Request)] {
+        override def request(value: (A, B, C, D, E, F, G, Request)): Request = value._8
+        override def update(
+          value: (A, B, C, D, E, F, G, Request),
+          request: Request,
+        ): (A, B, C, D, E, F, G, Request) =
+          (value._1, value._2, value._3, value._4, value._5, value._6, value._7, request)
+      }
+  }
+
+  object IsRequest extends IsRequestLowPriority {
+    implicit val request: IsRequest[Request] = new IsRequest[Request] {
+      override def request(value: Request): Request                  = value
+      override def update(value: Request, request: Request): Request = request
+    }
   }
 
   def asChunkBounded(request: Request, limit: Int)(implicit trace: Trace): Handler[Any, Throwable, Any, Chunk[Byte]] =


### PR DESCRIPTION
/claim #3141

## Summary

This patch fixes single-route `HandlerAspect` composition when the handler input includes both decoded path parameters and the `Request`, such as `(String, Request)`.

The failure mode behind `#3141` is that `Handler.@@` treated the input as if it were always just `Request`, which breaks route-local aspects once path decoding has already lifted the input into tuples.

## What changed

- generalized `Handler.IsRequest` so it can extract and reinsert the `Request` from tuple-shaped handler inputs
- updated `Handler.@@` to apply the aspect against the extracted request and then rebuild the original handler input with the possibly transformed request
- updated `ApplyContextAspect` on Scala 2 and Scala 3 to use the same request-extraction/reinsertion path
- added a regression test in `RouteSpec` covering a single-route aspect over a handler with `(String, Request)` input

## Validation

Focused validation:

```text
java -Xmx2G -jar C:\Users\Matteo\.sbt\launchers\1.12.11\sbt-launch.jar ";project zioHttpJVM; testOnly zio.http.RouteSpec"
```

Result:

```text
38 tests passed. 0 tests failed. 0 tests ignored.
```

The new regression test is:
- `single Route aspects should compose with path params and request input (#3141)`

## Scope

This stays local to handler aspect composition and test coverage. It does not change route pattern decoding, path codec semantics, or routes-level aspect behavior.

No documentation update needed.
