### PR TITLE
docs: Add missing concept pages for Server, Client, and Request Handling

### DIFF
--- a/docs/concepts/client.md
+++ b/docs/concepts/client.md
@@ -1,0 +1,72 @@
+# Client
+
+The ZIO HTTP Client allows your application to make outbound HTTP requests to external services. Built on ZIO and Netty, it provides a purely functional, type-safe API for HTTP communication with support for connection pooling, streaming, and middleware.
+
+## Client as a Function
+
+At its core, the client can be thought of as a function from `Request` to `Response`:
+
+```
+Request => ZIO[R, Throwable, Response]
+```
+
+You construct a request, send it through the client, and receive a response wrapped in a ZIO effect. The effect captures potential failures (network errors, timeouts, malformed responses) in a type-safe manner.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+val program =
+  for {
+    response <- Client.batched(Request.get("https://api.example.com/users"))
+    body     <- response.body.asString
+  } yield body
+```
+
+## Batched vs Streaming
+
+The client supports two execution modes:
+
+**Batched mode** buffers the entire response body in memory. Connection lifecycle is managed automatically. Use this for typical API calls where response sizes are reasonable.
+
+**Streaming mode** allows processing large response bodies without loading them entirely into memory. You manage the connection scope explicitly, which is necessary when the response body is a stream. Use this for large file downloads or responses of unknown size.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+import zio.stream._
+
+// Batched - automatic resource management
+val batched = Client.batched(Request.get("https://api.example.com/data"))
+
+// Streaming - explicit scope management  
+val streaming = ZIO.scoped {
+  Client.streaming(Request.get("https://example.com/large-file"))
+    .flatMap(_.body.asStream.runCollect)
+}
+```
+
+## Connection Pooling
+
+The client maintains a pool of connections to hosts, reusing them across requests. This avoids the overhead of establishing new TCP connections for every request. The connection pool is configured automatically but can be tuned:
+
+- Maximum connections per host
+- Idle connection timeout
+- Connection TTL
+
+## SSL/TLS Support
+
+The client supports secure connections out of the box. For most cases, the default SSL configuration works. Custom SSL configurations are available for scenarios like self-signed certificates or client certificate authentication.
+
+## Middleware
+
+Client middleware lets you intercept requests and responses for cross-cutting concerns:
+
+- Logging outgoing requests
+- Adding authentication headers
+- Retrying failed requests
+- Metrics and tracing
+
+Middleware composes, so you can layer multiple concerns without tangling your business logic.
+
+For detailed configuration and examples, see the [Client Reference](./../reference/client.md).

--- a/docs/concepts/request-handling.md
+++ b/docs/concepts/request-handling.md
@@ -1,0 +1,108 @@
+# Request Handling
+
+Understanding how requests flow through a ZIO HTTP application helps you structure your code and debug issues. This page explains the request lifecycle from arrival to response.
+
+## The Request-Response Cycle
+
+When an HTTP request arrives at your server:
+
+1. The server receives the raw bytes from the network
+2. ZIO HTTP parses the bytes into a `Request` object
+3. The request is matched against your defined routes
+4. If a route matches, the handler processes the request and produces a `Response`
+5. If no route matches, a 404 response is generated
+6. The response is serialized and sent back to the client
+
+```
+Client → Network → Server → Route Matching → Handler → Response → Network → Client
+```
+
+## Handlers
+
+A `Handler` is a function that takes some input and produces a `Response`. The simplest handler ignores the request:
+
+```scala mdoc:compile-only
+import zio.http._
+
+val simple = handler(Response.text("Hello"))
+```
+
+More typically, handlers inspect the request to produce a response:
+
+```scala mdoc:compile-only
+import zio.http._
+
+val greeting = handler { (req: Request) =>
+  val name = req.queryOrElse[String]("name", "World")
+  Response.text(s"Hello, $name!")
+}
+```
+
+Handlers can be effectful, performing database queries, calling external services, or any other ZIO operation:
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+def getUser(id: String): ZIO[Any, Throwable, String] = ???
+
+val userHandler = handler { (id: String, req: Request) =>
+  getUser(id).map(user => Response.text(user))
+}
+```
+
+## Error Handling
+
+Errors in handlers are categorized as:
+
+**Handled errors** - Errors that have been converted to HTTP responses. These are represented as `Response` values with appropriate status codes.
+
+**Unhandled errors** - Errors that haven't been converted to responses yet. Before serving routes, you must handle all errors using methods like `handleError` or `handleErrorCause`.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+val routes = Routes(
+  Method.GET / "might-fail" -> handler {
+    ZIO.fail(new Exception("oops")).map(_ => Response.ok)
+  }
+).handleError { error =>
+  Response.text(s"Error: ${error.getMessage}").status(Status.InternalServerError)
+}
+```
+
+## Request Context
+
+Handlers can access contextual information through:
+
+- **Path parameters** - Values extracted from the URL path (e.g., `/users/:id`)
+- **Query parameters** - Key-value pairs from the URL query string
+- **Headers** - Request headers for content negotiation, authentication, etc.
+- **Body** - The request body for POST/PUT/PATCH requests
+
+ZIO HTTP provides typed access to all of these, catching parsing errors before your business logic runs.
+
+## The Handler Environment
+
+Handlers can require services from the ZIO environment, allowing dependency injection:
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+trait UserService {
+  def findUser(id: String): Task[Option[String]]
+}
+
+val userHandler = handler { (id: String, req: Request) =>
+  ZIO.serviceWithZIO[UserService](_.findUser(id)).map {
+    case Some(user) => Response.text(user)
+    case None       => Response.notFound
+  }
+}
+```
+
+The required services are tracked in the route's type signature, ensuring all dependencies are provided before the server starts.
+
+For more details on handlers, see the [Handler Reference](./../reference/handler.md).

--- a/docs/concepts/server.md
+++ b/docs/concepts/server.md
@@ -1,0 +1,57 @@
+# Server
+
+The ZIO HTTP Server is the component that listens for incoming HTTP connections, processes requests through your application's routes, and sends back responses. It handles all the low-level networking concerns so you can focus on your application logic.
+
+## Server as a Resource
+
+A ZIO HTTP server is modeled as a ZIO resource with proper lifecycle management. When you start a server, it acquires network resources (ports, threads, connection pools), and when the application terminates, these resources are properly released. This is handled through ZIO's built-in resource management.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+val routes = Routes(
+  Method.GET / "hello" -> handler(Response.text("Hello!"))
+)
+
+// The server starts when the effect runs and stops when it completes
+Server.serve(routes).provide(Server.default)
+```
+
+## Configuring the Server
+
+The server supports extensive configuration for production deployments:
+
+- **Binding address and port** - Where the server listens for connections
+- **SSL/TLS** - Secure communication with clients
+- **Request decompression** - Handle gzip/deflate compressed requests
+- **Response compression** - Compress responses for bandwidth savings
+- **Keep-alive** - Connection reuse settings
+- **Timeouts** - Idle timeout and graceful shutdown duration
+
+The default configuration works for development, but production deployments typically require tuning these settings.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+val prodConfig = Server.Config.default
+  .port(443)
+  .idleTimeout(60.seconds)
+  .responseCompression()
+```
+
+## Installing vs Serving
+
+ZIO HTTP provides two ways to run your routes:
+
+- `Server.serve(routes)` - Starts the server and keeps it running until interrupted
+- `Server.install(routes)` - Installs routes into the server but doesn't block, useful when you need to run other operations alongside the server
+
+Most applications use `serve`, but `install` is helpful for scenarios like running background jobs while serving HTTP requests.
+
+## Netty Backend
+
+Under the hood, ZIO HTTP uses [Netty](https://netty.io/) for high-performance networking. Netty provides event-driven, non-blocking I/O that scales to thousands of concurrent connections. The server automatically configures Netty with sensible defaults, but advanced users can customize the Netty channel pipeline through the server configuration.
+
+For detailed server configuration options and examples, see the [Server Reference](./../reference/server.md).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -183,7 +183,15 @@ const sidebars = {
       type: "category",
       collapsed: false,
       label: "Concepts",
-      items: ["concepts/routing", "concepts/middleware", "concepts/endpoint", "concepts/dev-mode"],
+      items: [
+        "concepts/server",
+        "concepts/client",
+        "concepts/routing",
+        "concepts/request-handling",
+        "concepts/middleware",
+        "concepts/endpoint",
+        "concepts/dev-mode"
+      ],
     },
   ],
 


### PR DESCRIPTION
## Summary

This PR adds three new concept documentation pages that were identified as gaps in the documentation structure outlined in #2198:

- **concepts/server.md**: High-level overview of the ZIO HTTP Server component, covering resource management, configuration options, and the serve vs install distinction
- **concepts/client.md**: Introduction to the HTTP client, explaining batched vs streaming modes, connection pooling, and middleware support  
- **concepts/request-handling.md**: Explanation of the request lifecycle, handlers, error handling patterns, and the ZIO environment integration

Updated sidebars.js to include the new pages in the Concepts section.

## Changes

- Added docs/concepts/server.md - Server architecture and configuration overview
- Added docs/concepts/client.md - HTTP client usage patterns
- Added docs/concepts/request-handling.md - Request lifecycle and handler patterns
- Updated website/sidebars.js to add new concept pages to navigation

## Related

Addresses gaps identified in #2198

## Test Plan

- [ ] Verify documentation renders correctly in Docusaurus
- [ ] Check all mdoc code examples compile
