### PR TITLE
ci: fix auto-approve/merge for bot dependency PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.user.login == 'app/dependabot' ||
-      github.event.pull_request.user.login == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
     steps:
       - name: Approve PR
         if: github.event_name == 'pull_request_target'
@@ -27,7 +27,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "app/zio-scala-steward" "app/dependabot"; do
+          for actor in "zio-scala-steward[bot]" "dependabot[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.user.login == 'app/dependabot' ||
-      github.event.pull_request.user.login == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
     steps:
       - name: Enable auto-merge for bot PR
         if: github.event_name == 'pull_request_target'
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "app/zio-scala-steward" "app/dependabot"; do
+          for actor in "zio-scala-steward[bot]" "dependabot[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \


### PR DESCRIPTION
## Summary

Use REST API bot login format (`zio-scala-steward[bot]`, `dependabot[bot]`) instead of GraphQL format (`app/zio-scala-steward`, `app/dependabot`).

GitHub Actions `pull_request_target` event payloads use REST API format for bot login names. The workflows were checking the wrong format, preventing auto-approve/merge from triggering on bot PRs.

## Test plan

- [x] Manual backfill trigger should now find and auto-approve/merge bot PRs when run via `workflow_dispatch`
- [x] New bot PRs should trigger auto-approve/merge workflow on event