### PR TITLE
fix: fail WebSocket client connection when the server rejects the upgrade

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/WebSocketClientInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/WebSocketClientInboundHandler.scala
@@ -24,7 +24,8 @@ import zio.http.internal.ChannelState
 import zio.http.netty.NettyResponse
 
 import io.netty.channel.{ChannelHandlerContext, SimpleChannelInboundHandler}
-import io.netty.handler.codec.http.FullHttpResponse
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException
+import io.netty.handler.codec.http.{FullHttpResponse, HttpResponseStatus}
 
 private[netty] final class WebSocketClientInboundHandler(
   onResponse: Promise[Throwable, Response],
@@ -36,8 +37,19 @@ private[netty] final class WebSocketClientInboundHandler(
     ctx.fireChannelActive(): Unit
 
   override def channelRead0(ctx: ChannelHandlerContext, msg: FullHttpResponse): Unit = {
-    onResponse.unsafe.done(Exit.succeed(NettyResponse(msg)))
-    ctx.fireChannelRead(msg.retain())
+    msg.status match {
+      case HttpResponseStatus.SWITCHING_PROTOCOLS =>
+        onResponse.unsafe.done(Exit.succeed(NettyResponse(msg)))
+        ctx.fireChannelRead(msg.retain())
+      case status                                 =>
+        val exit = Exit.fail(
+          new WebSocketHandshakeException(
+            s"WebSocket upgrade failed: expected a '101 Switching Protocols' response but got '$status'",
+          ),
+        )
+        onResponse.unsafe.done(exit)
+        onComplete.unsafe.done(exit)
+    }
     ctx.pipeline().remove(ctx.name()): Unit
   }
 

--- a/zio-http/jvm/src/test/scala/zio/http/WebSocketSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/WebSocketSpec.scala
@@ -221,6 +221,21 @@ object WebSocketSpec extends RoutesRunnableSpec {
           assertTrue(result == "immediate")
         }
       },
+      test("client socket fails if the server does not return a 101 Switching Protocols response") {
+        for {
+          url    <- DynamicServer.httpURL
+          id     <- DynamicServer.deploy(Handler.badRequest.toRoutes)
+          result <- ZIO.scoped {
+            Handler
+              .webSocket(_ => ZIO.unit)
+              .connect(url, Headers(DynamicServer.APP_ID, id))
+              .either
+          }
+        } yield assertTrue(
+          result.isLeft,
+          result.swap.toOption.exists(_.getMessage.contains("Switching Protocols")),
+        )
+      },
     )
 
   private val withStreamingEnabled =


### PR DESCRIPTION
### What

`client.url(url).socket(app)` (and `WebSocketApp#connect`) used to return successfully with whatever HTTP response the server sent, even when the server refused the WebSocket upgrade. For example, if the server replied with `400 Bad Request`, the WebSocket app was silently not started and the response was handed back as a success, leaving the caller unaware that the connection never became a WebSocket.

### Fix

`WebSocketClientInboundHandler` now only continues the upgrade when the server responds with `101 Switching Protocols`. For any other status it fails the connection (and the handshake-completion promise) with a `WebSocketHandshakeException` describing the status that was received instead.

### Tests

Added a `WebSocketSpec` test that points the client at a server returning `400 Bad Request` and asserts that `connect` fails rather than returning the response.

Fixes #3464.
