### PR TITLE
Update Netty 4.2.15, scalameta parsers 4.17.0, brotli4j 1.23.0, tapir 1.13.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Run Coverage
         id: run_coverage
-        run: sbt coverage; project zioHttpJVM; test; coverageReport
+        run: sbt 'coverage; zioHttpJVM/test; zioHttpJVM/coverageReport'
 
       - name: Push Codecov
         id: push_codecov

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object Dependencies {
   val JwtCoreVersion               = "11.0.4"
-  val NettyVersion                 = "4.2.14.Final"
+  val NettyVersion                 = "4.2.15.Final"
   val ScalaCompatCollectionVersion = "2.14.0"
   val ZioVersion                   = "2.1.26"
   val ZioCliVersion                = "0.8.1"
@@ -30,7 +30,7 @@ object Dependencies {
       "io.netty" % "netty-transport-native-kqueue"   % NettyVersion classifier "osx-aarch_64",
       "io.netty" % "netty-pkitesting"                % NettyVersion,
       "io.netty" % "netty-transport-native-io_uring" % NettyVersion % "provided" classifier "linux-x86_64",
-      "com.aayushatharva.brotli4j" % "brotli4j" % "1.22.0" % "provided",
+      "com.aayushatharva.brotli4j" % "brotli4j" % "1.23.0" % "provided",
     )
 
   val unroll = Seq(

--- a/project/ScoverageWorkFlow.scala
+++ b/project/ScoverageWorkFlow.scala
@@ -31,7 +31,7 @@ object ScoverageWorkFlow {
             name = Some("Update Build Definition"),
           ),
           WorkflowStep.Sbt(
-            commands = List(s"coverage; project zioHttpJVM; test; coverageReport"),
+            commands = List("coverage", "zioHttpJVM/test", "zioHttpJVM/coverageReport"),
             id = Some("run_coverage"),
             name = Some("Run Coverage"),
           ),


### PR DESCRIPTION
## Dependency Updates

| Dependency | Old Version | New Version |
|---|---|---|
| io.netty (all modules) | 4.2.14.Final | 4.2.15.Final |
| org.scalameta :: parsers | 4.14.7 | 4.17.0 |
| com.aayushatharva.brotli4j | 1.22.0 | 1.23.0 |
| com.softwaremill.sttp.tapir :: tapir-http4s-server | 1.13.22 | 1.13.23 |
| com.softwaremill.sttp.tapir :: tapir-json-circe | 1.13.22 | 1.13.23 |

### Files Changed
- `project/Dependencies.scala`: Netty, scalameta parsers, brotli4j version bumps
- `build.sbt`: tapir version bump in benchmarks subproject

### Verification
- `sbt compile` passes on Scala 2.13