### PR TITLE
Remove `unroll-plugin` from runtime classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val zioHttp = crossProject(JSPlatform, JVMPlatform)
   .settings(Shading.shadingSettings())
   .settings(
     autoCompilerPlugins := true,
-    libraryDependencies ++= unroll,
+    libraryDependencies += unroll,
     addCompilerPlugin("com.lihaoyi" %% "unroll-plugin" % "0.1.12"),
   )
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,10 +33,7 @@ object Dependencies {
       "com.aayushatharva.brotli4j" % "brotli4j" % "1.23.0" % "provided",
     )
 
-  val unroll = Seq(
-    "com.lihaoyi" %% "unroll-annotation" % "0.1.12",
-    "com.lihaoyi" %% "unroll-plugin"     % "0.1.12",
-  )
+  val unroll = "com.lihaoyi" %% "unroll-annotation" % "0.1.12"
 
   val zio                   = "dev.zio" %% "zio"                 % ZioVersion
   val `zio-cli`             = "dev.zio" %% "zio-cli"             % ZioCliVersion


### PR DESCRIPTION
This PR removes `unroll-plugin` from the runtime classpath and prevents it from pulling the scala3-compiler as well.