### PR TITLE
fix(website): expand hero min-height to fill viewport on mobile

### DIFF
--- a/website/src/components/HomepageHero/styles.module.css
+++ b/website/src/components/HomepageHero/styles.module.css
@@ -221,7 +221,7 @@
 
 @media screen and (max-width: 480px) {
   .leftColumn {
-    min-height: 220px;
+    min-height: calc(100vh - var(--ifm-navbar-height));
   }
 
   .zioTitle {


### PR DESCRIPTION
## Summary
- Mobile hero (`max-width: 480px`) used a fixed `220px` min-height, leaving dead space below the hero on small screens.
- Switch to `calc(100vh - var(--ifm-navbar-height))` so it fills the viewport like the larger breakpoints already do.

## Test plan
- [ ] Load homepage on a mobile viewport (<480px) and confirm the hero fills the screen with no dead space below it.